### PR TITLE
Fix mempool backend OOM crashloop + Service Data Storage panel (v0.3.1-dev.14)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,10 +195,12 @@ fi
 # --- Step 2: Directory layout -------------------------------------------------
 log "Creating directory layout..."
 mkdir -p "$TRUFFELS_BASE"/{compose,config,data,logs,backups,secrets,tmp}
-mkdir -p "$DATA_DIR"/{bitcoin/blockchain,ckpool/logs,electrs/db,mempool/mysql,ckstats/postgres,truffels}
+mkdir -p "$DATA_DIR"/{bitcoin/blockchain,ckpool/logs,electrs/db,mempool/mysql,mempool/cache,ckstats/postgres,truffels}
 # Pre-create ckpool log subdirs with world-readable perms so caps-dropped ckstats-cron can read them
 mkdir -p "$DATA_DIR"/ckpool/logs/{pool,users}
 chmod 0755 "$DATA_DIR"/ckpool/logs/{pool,users}
+# Mempool backend writes RBF/mempool cache here as uid 1000 (image user)
+chown 1000:1000 "$DATA_DIR"/mempool/cache
 mkdir -p "$CONFIG_DIR"/{bitcoin,electrs,ckpool,ckstats,proxy,nftables}
 mkdir -p "$COMPOSE_DIR"/{bitcoin,electrs,ckpool,mempool,ckstats,proxy,truffels}
 chmod 0755 "$TRUFFELS_BASE"
@@ -534,7 +536,7 @@ services:
     env_file:
       - /srv/truffels/secrets/mempool-backend.env
     environment:
-      NODE_OPTIONS: "--max-old-space-size=1280"
+      NODE_OPTIONS: "--max-old-space-size=1792"
       MEMPOOL_BACKEND: "electrum"
       ELECTRUM_HOST: "truffels-electrs"
       ELECTRUM_PORT: "50001"
@@ -546,13 +548,21 @@ services:
       DATABASE_PORT: "3306"
       DATABASE_DATABASE: "mempool"
       STATISTICS_ENABLED: "true"
+    volumes:
+      - /srv/truffels/data/mempool/cache:/backend/cache
     depends_on:
       mempool-db:
         condition: service_healthy
     deploy:
       resources:
         limits:
-          memory: 1536M
+          memory: 2048M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 300s
 
   mempool-frontend:
     image: $MEMPOOL_FRONTEND_IMAGE
@@ -573,6 +583,12 @@ services:
       resources:
         limits:
           memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   mempool-db:
     image: $MARIADB_IMAGE
@@ -874,7 +890,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.13}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.14}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"
@@ -902,9 +918,11 @@ services:
       - /srv/truffels/compose:/srv/truffels/compose:rw
       - /srv/truffels/config:/srv/truffels/config:ro
       - /srv/truffels/secrets:/srv/truffels/secrets:ro
+      - /srv/truffels/data:/srv/truffels/data:rw
       - $TRUFFELS_REPO_SRC:/repo:rw
     environment:
       TRUFFELS_COMPOSE_ROOT: "/srv/truffels/compose"
+      TRUFFELS_DATA_ROOT: "/srv/truffels/data"
       TRUFFELS_AGENT_LISTEN: ":9090"
     deploy:
       resources:

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -52,6 +52,7 @@ var allowedContainers = map[string]bool{
 }
 
 var composeRoot string
+var dataRoot string
 
 var version = "dev" // overridden via -ldflags "-X main.version=v0.2.0"
 
@@ -69,6 +70,7 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	composeRoot = envOr("TRUFFELS_COMPOSE_ROOT", "/srv/truffels/compose")
+	dataRoot = envOr("TRUFFELS_DATA_ROOT", "/srv/truffels/data")
 	listen := envOr("TRUFFELS_AGENT_LISTEN", ":9090")
 
 	mux := http.NewServeMux()
@@ -95,6 +97,8 @@ func main() {
 	mux.HandleFunc("POST /v1/compose/read", handleComposeRead)
 	mux.HandleFunc("POST /v1/compose/reconcile", handleComposeReconcile)
 	mux.HandleFunc("POST /v1/file/reconcile", handleFileReconcile)
+	mux.HandleFunc("POST /v1/fs/ensure-dir", handleEnsureDir)
+	mux.HandleFunc("POST /v1/fs/clear-dir", handleClearDir)
 	mux.HandleFunc("POST /v1/image/remove", handleImageRemove)
 	mux.HandleFunc("POST /v1/docker/prune", handleDockerPrune)
 	mux.HandleFunc("POST /v1/docker/prune-buildcache", handleDockerPruneBuildCache)
@@ -807,6 +811,13 @@ type systemInfoResponse struct {
 	Networks      []networkIfInfo     `json:"networks"`
 	Storage       []storageInfo       `json:"storage"`
 	DockerStorage []dockerStorageItem `json:"docker_storage,omitempty"`
+	ServiceData   []serviceDataItem   `json:"service_data,omitempty"`
+}
+
+type serviceDataItem struct {
+	Path    string `json:"path"`
+	Size    string `json:"size"`
+	SizeRaw int64  `json:"size_raw"` // bytes — for client-side sorting/thresholds
 }
 
 type networkIfInfo struct {
@@ -967,6 +978,46 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Service data: enumerate /srv/truffels/data/* leaf paths and du each.
+	// Walking down one level past dataRoot gives us per-service entries like
+	// mempool/cache, mempool/mysql, ckpool/logs, etc. — granularity matches
+	// what the service templates declare as DataDirs in the API.
+	var serviceData []serviceDataItem
+	if entries, err := os.ReadDir(dataRoot); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			servicePath := filepath.Join(dataRoot, e.Name())
+			children, err := os.ReadDir(servicePath)
+			if err != nil {
+				continue
+			}
+			for _, c := range children {
+				if !c.IsDir() {
+					continue
+				}
+				full := filepath.Join(servicePath, c.Name())
+				size := dirSizeBytes(full)
+				serviceData = append(serviceData, serviceDataItem{
+					Path:    full,
+					Size:    formatBytes(size),
+					SizeRaw: size,
+				})
+			}
+			// Also include the bare top-level dir (e.g. /srv/truffels/data/truffels)
+			// if it has files but no leaf subdirs the template references.
+			if len(children) == 0 {
+				size := dirSizeBytes(servicePath)
+				serviceData = append(serviceData, serviceDataItem{
+					Path:    servicePath,
+					Size:    formatBytes(size),
+					SizeRaw: size,
+				})
+			}
+		}
+	}
+
 	writeJSON(w, 200, systemInfoResponse{
 		Hostname:      hostname,
 		OS:            osRelease,
@@ -979,7 +1030,39 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		Networks:      networks,
 		Storage:       storage,
 		DockerStorage: dockerStorage,
+		ServiceData:   serviceData,
 	})
+}
+
+// dirSizeBytes walks `path` and returns total size in bytes. Returns 0 on any
+// error to keep the system-info endpoint robust against permission-denied
+// nested files (e.g. inside container-managed dirs).
+func dirSizeBytes(path string) int64 {
+	var total int64
+	_ = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// formatBytes renders bytes as a human-friendly size (matches Docker's df output).
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
 // --- System Journal & Tuning ---
@@ -1486,10 +1569,12 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Security: resolve path and ensure it stays under composeRoot
+	// Security: resolve path and ensure it stays under composeRoot.
+	// validateUnderRoot also walks the parent chain via EvalSymlinks so a
+	// symlink at /srv/truffels/compose/foo → /etc cannot be used as a write target.
 	fullPath := filepath.Join(composeRoot, filepath.Clean(req.Path))
-	if !strings.HasPrefix(fullPath, composeRoot+"/") {
-		writeJSON(w, 403, map[string]string{"error": "path outside compose root"})
+	if _, err := validateUnderRoot(fullPath, composeRoot); err != nil {
+		writeJSON(w, 403, map[string]string{"error": "path outside compose root: " + err.Error()})
 		return
 	}
 
@@ -1519,6 +1604,167 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("file reconciled", "path", fullPath)
 	writeJSON(w, 200, map[string]interface{}{"status": "ok", "changed": true})
+}
+
+// validateUnderRoot returns the cleaned absolute path if it lies under `root`,
+// is not a symlink redirecting outside `root`, and contains no relative-path
+// escapes. Returns ("", error) otherwise. The path's parent must exist for
+// EvalSymlinks to resolve cleanly; if the parent doesn't exist yet, the check
+// walks upward until it finds an existing ancestor and validates that one.
+func validateUnderRoot(p, root string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	cleaned := filepath.Clean(p)
+	if !strings.HasPrefix(cleaned, root+"/") {
+		return "", fmt.Errorf("path outside root")
+	}
+	// Walk up to the nearest existing ancestor and EvalSymlinks it. This catches
+	// symlink redirects (e.g. /srv/truffels/data/x is a symlink to /etc).
+	probe := cleaned
+	for {
+		if _, err := os.Stat(probe); err == nil {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe || parent == "/" {
+			break
+		}
+		probe = parent
+	}
+	resolved, err := filepath.EvalSymlinks(probe)
+	if err == nil && !strings.HasPrefix(resolved+"/", root+"/") && resolved != root {
+		return "", fmt.Errorf("symlink redirects outside root")
+	}
+	return cleaned, nil
+}
+
+// handleEnsureDir creates a directory under dataRoot with the requested
+// ownership and mode. Idempotent. Used by the compose reconciler to guarantee
+// bind-mount source paths exist with correct uid:gid before `docker compose up`.
+func handleEnsureDir(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path string `json:"path"`
+		UID  int    `json:"uid"`
+		GID  int    `json:"gid"`
+		Mode string `json:"mode"` // octal string, e.g. "0755"
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.Mode == "" {
+		req.Mode = "0755"
+	}
+	mode64, err := strconv.ParseUint(req.Mode, 8, 32)
+	if err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid mode: " + err.Error()})
+		return
+	}
+	mode := os.FileMode(uint32(mode64))
+
+	cleaned, err := validateUnderRoot(req.Path, dataRoot)
+	if err != nil {
+		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+
+	existed := true
+	if _, err := os.Stat(cleaned); os.IsNotExist(err) {
+		existed = false
+	}
+
+	if err := os.MkdirAll(cleaned, mode); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "mkdir: " + err.Error()})
+		return
+	}
+	if err := os.Chown(cleaned, req.UID, req.GID); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "chown: " + err.Error()})
+		return
+	}
+	if err := os.Chmod(cleaned, mode); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "chmod: " + err.Error()})
+		return
+	}
+
+	slog.Info("ensure-dir", "path", cleaned, "uid", req.UID, "gid", req.GID, "created", !existed)
+	writeJSON(w, 200, map[string]interface{}{"status": "ok", "created": !existed})
+}
+
+// clearDirBasenameAllowlist limits clear-dir to known-safe directory names.
+// Adding to this set requires explicit review.
+var clearDirBasenameAllowlist = map[string]bool{
+	"cache": true,
+	"logs":  true,
+}
+
+// handleClearDir empties a directory under dataRoot, then recreates it with
+// the requested ownership/mode. Double-locked: basename must be in allowlist
+// AND path must be exactly two levels under dataRoot (i.e. dataRoot/<service>/<basename>).
+// This rejects paths like /srv/truffels/data/bitcoin/blockchain/cache.
+func handleClearDir(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path string `json:"path"`
+		UID  int    `json:"uid"`
+		GID  int    `json:"gid"`
+		Mode string `json:"mode"` // octal string, e.g. "0755"
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.Mode == "" {
+		req.Mode = "0755"
+	}
+	mode64, err := strconv.ParseUint(req.Mode, 8, 32)
+	if err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid mode: " + err.Error()})
+		return
+	}
+	mode := os.FileMode(uint32(mode64))
+
+	cleaned, err := validateUnderRoot(req.Path, dataRoot)
+	if err != nil {
+		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Basename allowlist
+	base := filepath.Base(cleaned)
+	if !clearDirBasenameAllowlist[base] {
+		writeJSON(w, 403, map[string]string{"error": "basename not in clear allowlist: " + base})
+		return
+	}
+
+	// Exact depth check: path must be dataRoot/<service>/<basename> — exactly two levels deep.
+	// This rejects e.g. /srv/truffels/data/bitcoin/blockchain/cache.
+	rel := strings.TrimPrefix(cleaned, dataRoot+"/")
+	parts := strings.Split(rel, "/")
+	if len(parts) != 2 {
+		writeJSON(w, 403, map[string]string{"error": "clear-dir path must be exactly dataRoot/<service>/<dir>"})
+		return
+	}
+
+	slog.Info("clear-dir", "path", cleaned, "uid", req.UID, "gid", req.GID)
+
+	if err := os.RemoveAll(cleaned); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "remove: " + err.Error()})
+		return
+	}
+	if err := os.MkdirAll(cleaned, mode); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "mkdir: " + err.Error()})
+		return
+	}
+	if err := os.Chown(cleaned, req.UID, req.GID); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "chown: " + err.Error()})
+		return
+	}
+	if err := os.Chmod(cleaned, mode); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "chmod: " + err.Error()})
+		return
+	}
+
+	writeJSON(w, 200, map[string]interface{}{"status": "ok"})
 }
 
 // serviceContainers maps service IDs to their container names for fallback log retrieval.

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1725,3 +1725,168 @@ func TestHandleFileReconcile_CreatesNewFile(t *testing.T) {
 		t.Fatalf("expected content written, got: %s", string(data))
 	}
 }
+
+// --- fs/ensure-dir ---
+
+func postEnsureDir(t *testing.T, path string, uid, gid int, mode string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/fs/ensure-dir", bytes.NewReader(body))
+	handleEnsureDir(w, r)
+	return w
+}
+
+func TestHandleEnsureDir_CreatesIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+
+	// Use the test runner's own uid/gid so chown is a no-op — production
+	// agent runs as root and can chown to 1000:1000, but CI runners can't.
+	// We're exercising the path validation + mkdir paths, not privilege.
+	uid, gid := os.Getuid(), os.Getgid()
+
+	target := dir + "/mempool/cache"
+	w := postEnsureDir(t, target, uid, gid, "0755")
+	if w.Code != 200 {
+		t.Fatalf("first call: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if fi, err := os.Stat(target); err != nil || !fi.IsDir() {
+		t.Fatalf("dir not created: %v", err)
+	}
+	// Idempotent: second call also OK.
+	w = postEnsureDir(t, target, uid, gid, "0755")
+	if w.Code != 200 {
+		t.Fatalf("second call: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleEnsureDir_RejectsOutsideDataRoot(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+
+	// Absolute escape
+	w := postEnsureDir(t, "/etc/eviltest", 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("absolute escape: expected 403, got %d", w.Code)
+	}
+	// Relative escape via ..
+	w = postEnsureDir(t, dir+"/foo/../../etcbad", 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("..-escape: expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleEnsureDir_RejectsEmptyPath(t *testing.T) {
+	dataRoot = t.TempDir()
+	w := postEnsureDir(t, "", 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for empty path, got %d", w.Code)
+	}
+}
+
+func TestHandleEnsureDir_RejectsSymlinkRedirect(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+	// Create a symlink at dataRoot/evil pointing to /tmp (outside dataRoot).
+	outside := t.TempDir() // real path outside dataRoot
+	if err := os.Symlink(outside, dir+"/evil"); err != nil {
+		t.Skip("symlink not supported: ", err)
+	}
+	// Now try to ensure-dir at dataRoot/evil/foo — parent (evil) resolves outside dataRoot.
+	w := postEnsureDir(t, dir+"/evil/foo", 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for symlink redirect, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- fs/clear-dir ---
+
+func postClearDir(t *testing.T, path string, uid, gid int, mode string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/fs/clear-dir", bytes.NewReader(body))
+	handleClearDir(w, r)
+	return w
+}
+
+func TestHandleClearDir_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+	target := dir + "/mempool/cache"
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// drop a file inside
+	if err := os.WriteFile(target+"/rbfcache.json", []byte("xx"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Use the test runner's own uid/gid (see TestHandleEnsureDir_CreatesIdempotent).
+	uid, gid := os.Getuid(), os.Getgid()
+	w := postClearDir(t, target, uid, gid, "0755")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(target + "/rbfcache.json"); !os.IsNotExist(err) {
+		t.Error("expected rbfcache.json removed")
+	}
+	if fi, err := os.Stat(target); err != nil || !fi.IsDir() {
+		t.Errorf("expected dir to be recreated: %v", err)
+	}
+}
+
+func TestHandleClearDir_RejectsBasenameNotInAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+	target := dir + "/bitcoin/blockchain"
+	_ = os.MkdirAll(target, 0755)
+	w := postClearDir(t, target, 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for blockchain basename, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Error("dir must NOT have been removed")
+	}
+}
+
+// The "blockchain-suffix-trick": even if basename matches "cache", the path is
+// rejected if not exactly two levels under dataRoot. This guards against
+// requests like /srv/truffels/data/bitcoin/blockchain/cache.
+func TestHandleClearDir_RejectsThreeLevelDeep(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+	target := dir + "/bitcoin/blockchain/cache"
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	w := postClearDir(t, target, 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for three-level-deep path, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Error("dir must NOT have been removed")
+	}
+}
+
+func TestHandleClearDir_RejectsAbsoluteEscape(t *testing.T) {
+	dataRoot = t.TempDir()
+	w := postClearDir(t, "/etc/cache", 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for absolute escape, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleClearDir_RejectsRelativeEscape(t *testing.T) {
+	dir := t.TempDir()
+	dataRoot = dir
+	target := dir + "/foo/../../etc/cache"
+	w := postClearDir(t, target, 1000, 1000, "0755")
+	if w.Code != 403 {
+		t.Errorf("expected 403 for relative escape, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -216,7 +216,7 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 	}
 	threshold := e.getSettingInt("restart_loop_count", 5)
 	windowMin := e.getSettingInt("restart_loop_window_min", 10)
-	maxRetries := e.getSettingInt("restart_loop_max_retries", 0)
+	maxRetries := e.getSettingInt("restart_loop_max_retries", 10)
 
 	for _, name := range tmpl.ContainerNames {
 		cs, err := docker.InspectContainer(name)

--- a/truffels-api/internal/api/handlers_test.go
+++ b/truffels-api/internal/api/handlers_test.go
@@ -757,3 +757,114 @@ func TestBackupDownload_PathTraversal(t *testing.T) {
 		}
 	}
 }
+
+// --- Clear Service Data ---
+
+func TestClearServiceData_WrongPassword(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, _, _ := newTestServerWithAgent(t, agentState)
+
+	body := `{"password":"wrong","service_id":"mempool","path":"/srv/truffels/data/mempool/cache"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 401 {
+		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if agentState.clearDirCalls != 0 {
+		t.Errorf("agent clear-dir must not be called on auth failure")
+	}
+}
+
+func TestClearServiceData_HappyPath_Mempool(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, _, _ := newTestServerWithAgent(t, agentState)
+
+	body := `{"password":"testpassword","service_id":"mempool","path":"/srv/truffels/data/mempool/cache"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if agentState.clearDirCalls != 1 {
+		t.Errorf("expected clear-dir called once, got %d", agentState.clearDirCalls)
+	}
+}
+
+func TestClearServiceData_RejectsNonClearablePath(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, _, _ := newTestServerWithAgent(t, agentState)
+
+	// /srv/truffels/data/mempool/mysql is declared but Clearable=false
+	body := `{"password":"testpassword","service_id":"mempool","path":"/srv/truffels/data/mempool/mysql"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for non-clearable path, got %d body=%s", w.Code, w.Body.String())
+	}
+	if agentState.clearDirCalls != 0 {
+		t.Errorf("agent must not be called for non-clearable path")
+	}
+}
+
+func TestClearServiceData_RejectsUnregisteredPath(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, _, _ := newTestServerWithAgent(t, agentState)
+
+	body := `{"password":"testpassword","service_id":"mempool","path":"/srv/truffels/data/mempool/random"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestClearServiceData_RejectsUnknownService(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, _, _ := newTestServerWithAgent(t, agentState)
+
+	body := `{"password":"testpassword","service_id":"madeup","path":"/srv/truffels/data/madeup/cache"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for unknown service, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestClearServiceData_AuditLog(t *testing.T) {
+	agentState := &mockAgentState{}
+	srv, st, _ := newTestServerWithAgent(t, agentState)
+
+	body := `{"password":"testpassword","service_id":"mempool","path":"/srv/truffels/data/mempool/cache"}`
+	req := authedReq(t, srv, "POST", "/api/truffels/system/service-data/clear", body)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	entries, err := st.GetAuditLog(50)
+	if err != nil {
+		t.Fatalf("get audit log: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Action == "service_data_clear" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected service_data_clear audit entry")
+	}
+}

--- a/truffels-api/internal/api/router.go
+++ b/truffels-api/internal/api/router.go
@@ -94,6 +94,7 @@ func (s *Server) Router() http.Handler {
 			r.Post("/system/tuning", s.handleSystemTuningSet)
 			r.Post("/system/docker-prune", s.handleDockerPrune)
 			r.Post("/system/docker-prune-buildcache", s.handleDockerPruneBuildCache)
+			r.Post("/system/service-data/clear", s.handleClearServiceData)
 
 			r.Get("/updates", s.handleGetUpdates)
 			r.Post("/updates/check", s.handleCheckUpdates)

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -30,6 +30,7 @@ type mockAgentState struct {
 	lastAction      string
 	lastServiceID   string
 	lastContainer   string
+	clearDirCalls   int
 }
 
 func newMockAgent(t *testing.T, state *mockAgentState) *httptest.Server {
@@ -113,6 +114,13 @@ func newMockAgent(t *testing.T, state *mockAgentState) *httptest.Server {
 
 		case r.URL.Path == "/v1/docker/prune-buildcache" && r.Method == "POST":
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "reclaimed": "Total reclaimed space: 50MB"})
+
+		case r.URL.Path == "/v1/fs/ensure-dir" && r.Method == "POST":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok", "created": false})
+
+		case r.URL.Path == "/v1/fs/clear-dir" && r.Method == "POST":
+			state.clearDirCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 		}
 	}))
 }
@@ -983,8 +991,8 @@ func TestGetSettings_Defaults(t *testing.T) {
 	if resp["restart_loop_window_min"] != float64(10) {
 		t.Fatalf("expected restart_loop_window_min=10, got %v", resp["restart_loop_window_min"])
 	}
-	if resp["restart_loop_max_retries"] != float64(0) {
-		t.Fatalf("expected restart_loop_max_retries=0, got %v", resp["restart_loop_max_retries"])
+	if resp["restart_loop_max_retries"] != float64(10) {
+		t.Fatalf("expected restart_loop_max_retries=10, got %v", resp["restart_loop_max_retries"])
 	}
 	if resp["dep_handling_mode"] != "flag_only" {
 		t.Fatalf("expected dep_handling_mode=flag_only, got %v", resp["dep_handling_mode"])

--- a/truffels-api/internal/api/settings.go
+++ b/truffels-api/internal/api/settings.go
@@ -2,15 +2,18 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"truffels-api/internal/model"
 )
 
 // settingsDefaults are the default values for all configurable settings.
 var settingsDefaults = map[string]string{
 	"restart_loop_count":      "5",
 	"restart_loop_window_min": "10",
-	"restart_loop_max_retries": "0",
+	"restart_loop_max_retries": "10",
 	"dep_handling_mode":       "flag_only",
 	"temp_warning":            "75",
 	"temp_critical":           "80",
@@ -53,7 +56,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	resp := settingsResponse{
 		RestartLoopCount:      s.getSettingInt("restart_loop_count", 5),
 		RestartLoopWindowMin:  s.getSettingInt("restart_loop_window_min", 10),
-		RestartLoopMaxRetries: s.getSettingInt("restart_loop_max_retries", 0),
+		RestartLoopMaxRetries: s.getSettingInt("restart_loop_max_retries", 10),
 		DepHandlingMode:       s.getSettingStr("dep_handling_mode", "flag_only"),
 		TempWarning:           s.getSettingFloat("temp_warning", 75),
 		TempCritical:          s.getSettingFloat("temp_critical", 80),
@@ -216,6 +219,89 @@ func (s *Server) handleDockerPruneBuildCache(w http.ResponseWriter, r *http.Requ
 
 	_ = s.store.LogAudit("docker_prune_buildcache", "", "Build cache prune: "+reclaimed, r.RemoteAddr)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "reclaimed": reclaimed})
+}
+
+// --- Clear Service Data ---
+
+// handleClearServiceData empties a host data directory belonging to a managed
+// service. The path must be declared in the service template's DataDirs with
+// Clearable=true (e.g. mempool/cache). If RequiresStop, the service is stopped
+// before the clear and started again after. Roll-forward on failure: if the
+// clear step fails after stop, we still try to bring the service back up.
+func (s *Server) handleClearServiceData(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Password  string `json:"password"`
+		ServiceID string `json:"service_id"`
+		Path      string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	ok, err := s.auth.CheckPassword(body.Password)
+	if err != nil || !ok {
+		writeError(w, http.StatusUnauthorized, "invalid password")
+		return
+	}
+	if body.ServiceID == "" || body.Path == "" {
+		writeError(w, http.StatusBadRequest, "service_id and path are required")
+		return
+	}
+
+	// Look up the template and verify the path is declared clearable.
+	tmpl, exists := s.registry.Get(body.ServiceID)
+	if !exists {
+		writeError(w, http.StatusBadRequest, "unknown service: "+body.ServiceID)
+		return
+	}
+	var dd *model.DataDir
+	for i := range tmpl.DataDirs {
+		if tmpl.DataDirs[i].Path == body.Path {
+			dd = &tmpl.DataDirs[i]
+			break
+		}
+	}
+	if dd == nil {
+		writeError(w, http.StatusBadRequest, "path not registered for this service")
+		return
+	}
+	if !dd.Clearable {
+		writeError(w, http.StatusBadRequest, "path is not clearable")
+		return
+	}
+
+	_ = s.store.LogAudit("service_data_clear", body.ServiceID, "Clear data dir: "+body.Path, r.RemoteAddr)
+
+	// Stop first if required. If stop fails, abort entirely — don't try to
+	// clear data of a still-running service.
+	if dd.RequiresStop {
+		if err := s.compose.Stop(body.ServiceID); err != nil {
+			writeError(w, http.StatusInternalServerError, "stop failed: "+err.Error())
+			return
+		}
+	}
+
+	clearErr := s.compose.FsClearDir(body.Path, 1000, 1000, "0755")
+
+	// Always try to bring service back up if we stopped it — even if clear failed.
+	if dd.RequiresStop {
+		if err := s.compose.Up(body.ServiceID); err != nil {
+			if clearErr != nil {
+				writeError(w, http.StatusInternalServerError,
+					fmt.Sprintf("clear failed (%v) AND service restart failed (%v)", clearErr, err))
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "clear succeeded but service restart failed: "+err.Error())
+			return
+		}
+	}
+
+	if clearErr != nil {
+		writeError(w, http.StatusInternalServerError, "clear failed: "+clearErr.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "path": body.Path})
 }
 
 // --- System Info ---

--- a/truffels-api/internal/compose/params_test.go
+++ b/truffels-api/internal/compose/params_test.go
@@ -100,3 +100,78 @@ func TestExtractParams_MissingTag(t *testing.T) {
 		t.Fatal("expected error for missing tag")
 	}
 }
+
+// TestExtractParams_Mempool_OldShape exercises ExtractParams against a verbatim
+// v0.3.1-dev.13 mempool compose file (no volumes/healthcheck on backend, no
+// healthcheck on frontend, NODE_OPTIONS=1280, mem 1536M). The reconciler reads
+// the live compose to extract image tags, then renders the new template — this
+// test confirms a user upgrading from dev.13 doesn't get an extract error.
+func TestExtractParams_Mempool_OldShape(t *testing.T) {
+	dev13Compose := `# Project Truffels — mempool.space (Block Explorer)
+# Managed by truffels. Do not edit manually.
+
+services:
+  mempool-backend:
+    image: mempool/backend:v3.3.1
+    container_name: truffels-mempool-backend
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      bitcoin-backend:
+    env_file:
+      - /srv/truffels/secrets/mempool-backend.env
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=1280"
+      MEMPOOL_BACKEND: "electrum"
+    depends_on:
+      mempool-db:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
+
+  mempool-frontend:
+    image: mempool/frontend:v3.3.1
+    container_name: truffels-mempool-frontend
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  mempool-db:
+    image: mariadb:lts@sha256:78a5047d3ba33975f183f183c2464cc7f1eab13ec8667e57cc9a5821d6da7577
+    container_name: truffels-mempool-db
+
+networks:
+  bitcoin-backend:
+    external: true
+`
+	p, err := ExtractParams("mempool", dev13Compose)
+	if err != nil {
+		t.Fatalf("ExtractParams should succeed on dev.13-shape compose: %v", err)
+	}
+	mp := p.(MempoolParams)
+	if mp.BackendImageTag != "mempool/backend:v3.3.1" {
+		t.Errorf("backend: %q", mp.BackendImageTag)
+	}
+	if mp.FrontendImageTag != "mempool/frontend:v3.3.1" {
+		t.Errorf("frontend: %q", mp.FrontendImageTag)
+	}
+	if !contains(mp.DBImageTag, "mariadb:lts") {
+		t.Errorf("db: %q", mp.DBImageTag)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/truffels-api/internal/compose/reconciler.go
+++ b/truffels-api/internal/compose/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"truffels-api/internal/docker"
+	"truffels-api/internal/model"
 	"truffels-api/internal/service"
 )
 
@@ -19,15 +20,24 @@ var dockerfileMapping = map[string]string{
 // serviceIDs that have compose templates (skip truffels — self-managed).
 var reconciledServices = []string{"bitcoind", "electrs", "ckpool", "mempool", "ckstats", "proxy"}
 
-type Reconciler struct {
-	registry *service.Registry
-	compose  *docker.ComposeClient
+// AlertStore is the subset of the store interface the reconciler needs to
+// surface reconciliation failures as alerts. Defined here (not imported) to
+// avoid an import cycle with internal/store.
+type AlertStore interface {
+	UpsertAlert(*model.Alert) error
 }
 
-func NewReconciler(registry *service.Registry, compose *docker.ComposeClient) *Reconciler {
+type Reconciler struct {
+	registry   *service.Registry
+	compose    *docker.ComposeClient
+	alertStore AlertStore // optional — if nil, failures are slog-only
+}
+
+func NewReconciler(registry *service.Registry, compose *docker.ComposeClient, alertStore AlertStore) *Reconciler {
 	return &Reconciler{
-		registry: registry,
-		compose:  compose,
+		registry:   registry,
+		compose:    compose,
+		alertStore: alertStore,
 	}
 }
 
@@ -80,6 +90,16 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 		return fmt.Errorf("render: %w", err)
 	}
 
+	// Ensure any declared bind-mount host directories exist with correct
+	// ownership before we hand the new compose to `docker compose up`.
+	tmpl, _ := r.registry.Get(serviceID)
+	for _, d := range tmpl.EnsureDirs {
+		if err := r.compose.FsEnsureDir(d.Path, d.UID, d.GID, d.Mode); err != nil {
+			return fmt.Errorf("ensure-dir %s: %w", d.Path, err)
+		}
+		slog.Info("ensure-dir ok", "service", serviceID, "path", d.Path)
+	}
+
 	// Compare and write if different
 	changed, err := r.reconcileWithRetry(serviceID, expected)
 	if err != nil {
@@ -91,6 +111,9 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 	} else {
 		slog.Info("compose reconciled, restarting", "service", serviceID)
 		if err := r.compose.Up(serviceID); err != nil {
+			// Fail loud — without this, a typo in the new compose template
+			// silently breaks the service while self-update reports success.
+			r.raiseAlert(serviceID, fmt.Sprintf("compose reconcile restart failed: %v", err))
 			return fmt.Errorf("restart after reconcile: %w", err)
 		}
 	}
@@ -101,6 +124,22 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 	}
 
 	return nil
+}
+
+// raiseAlert surfaces a reconciliation failure as a critical alert. If no
+// alertStore is configured (e.g. in tests), falls back to slog.
+func (r *Reconciler) raiseAlert(serviceID, msg string) {
+	if r.alertStore == nil {
+		return
+	}
+	if err := r.alertStore.UpsertAlert(&model.Alert{
+		Type:      "compose_reconcile_failed",
+		Severity:  model.SeverityCritical,
+		ServiceID: serviceID,
+		Message:   msg,
+	}); err != nil {
+		slog.Error("failed to upsert reconcile alert", "service", serviceID, "err", err)
+	}
 }
 
 func (r *Reconciler) reconcileDockerfile(serviceID, repoPath string) {

--- a/truffels-api/internal/compose/reconciler_test.go
+++ b/truffels-api/internal/compose/reconciler_test.go
@@ -29,7 +29,7 @@ func TestReconciler_NoChange(t *testing.T) {
 		{ID: "ckpool", ComposeDir: "/srv/truffels/compose/ckpool"},
 	})
 
-	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL))
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
 	if err := reconciler.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -72,7 +72,7 @@ networks:
 		{ID: "ckpool", ComposeDir: "/srv/truffels/compose/ckpool"},
 	})
 
-	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL))
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
 	if err := reconciler.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestReconciler_ReadError(t *testing.T) {
 		{ID: "ckpool", ComposeDir: "/srv/truffels/compose/ckpool"},
 	})
 
-	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL))
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
 	err := reconciler.Run()
 	if err == nil {
 		t.Fatal("expected error")
@@ -169,11 +169,67 @@ func newMockAgentFull(t *testing.T, contents map[string]string,
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
+		case "/v1/fs/ensure-dir":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":  "ok",
+				"created": false,
+			})
+
 		default:
 			w.WriteHeader(404)
 			fmt.Fprintf(w, `{"error":"not found: %s"}`, r.URL.Path)
 		}
 	}))
+}
+
+// captureAlertStore records UpsertAlert calls in memory for testing.
+type captureAlertStore struct {
+	alerts []*model.Alert
+}
+
+func (c *captureAlertStore) UpsertAlert(a *model.Alert) error {
+	c.alerts = append(c.alerts, a)
+	return nil
+}
+
+func TestReconciler_FailedUpEmitsAlert(t *testing.T) {
+	// Render expected (so reconcile reports "changed") but make `compose up`
+	// fail — reconciler must raise a critical Alert via the alertStore.
+	oldContent := `services:
+  ckpool:
+    image: truffels/ckpool:v1.0.0
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+`
+	srv := newMockAgentFull(t, map[string]string{"ckpool": oldContent},
+		func(serviceID, content string) (bool, error) { return true, nil },
+		func(serviceID string) error { return fmt.Errorf("compose up exit 1") },
+	)
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{ID: "ckpool", ComposeDir: "/srv/truffels/compose/ckpool"},
+	})
+	store := &captureAlertStore{}
+
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), store)
+	_ = reconciler.Run() // expected to return error
+
+	if len(store.alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(store.alerts))
+	}
+	got := store.alerts[0]
+	if got.Type != "compose_reconcile_failed" {
+		t.Errorf("type: %q", got.Type)
+	}
+	if got.Severity != model.SeverityCritical {
+		t.Errorf("severity: %q", got.Severity)
+	}
+	if got.ServiceID != "ckpool" {
+		t.Errorf("service: %q", got.ServiceID)
+	}
 }
 
 func newMockAgentError(t *testing.T) *httptest.Server {

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -173,7 +173,7 @@ services:
     env_file:
       - /srv/truffels/secrets/mempool-backend.env
     environment:
-      NODE_OPTIONS: "--max-old-space-size=1280"
+      NODE_OPTIONS: "--max-old-space-size=1792"
       MEMPOOL_BACKEND: "electrum"
       ELECTRUM_HOST: "truffels-electrs"
       ELECTRUM_PORT: "50001"
@@ -185,13 +185,21 @@ services:
       DATABASE_PORT: "3306"
       DATABASE_DATABASE: "mempool"
       STATISTICS_ENABLED: "true"
+    volumes:
+      - /srv/truffels/data/mempool/cache:/backend/cache
     depends_on:
       mempool-db:
         condition: service_healthy
     deploy:
       resources:
         limits:
-          memory: 1536M
+          memory: 2048M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 300s
 
   mempool-frontend:
     image: {{.FrontendImageTag}}
@@ -212,6 +220,12 @@ services:
       resources:
         limits:
           memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   mempool-db:
     image: {{.DBImageTag}}

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -37,17 +37,24 @@ func TestRender_Ckpool(t *testing.T) {
 
 func TestRender_Mempool(t *testing.T) {
 	got, err := Render("mempool", MempoolParams{
-		BackendImageTag:  "mempool/backend:v3.2.1",
-		FrontendImageTag: "mempool/frontend:v3.2.1",
+		BackendImageTag:  "mempool/backend:v3.3.1",
+		FrontendImageTag: "mempool/frontend:v3.3.1",
 		DBImageTag:       "mariadb:lts@sha256:abc123",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertContains(t, got, "image: mempool/backend:v3.2.1")
-	assertContains(t, got, "image: mempool/frontend:v3.2.1")
+	assertContains(t, got, "image: mempool/backend:v3.3.1")
+	assertContains(t, got, "image: mempool/frontend:v3.3.1")
 	assertContains(t, got, "image: mariadb:lts@sha256:abc123")
 	assertContains(t, got, "container_name: truffels-mempool-backend")
+	// Backend OOM-fix shape: bind-mounted cache, bumped heap, healthcheck.
+	assertContains(t, got, "/srv/truffels/data/mempool/cache:/backend/cache")
+	assertContains(t, got, "--max-old-space-size=1792")
+	assertContains(t, got, "memory: 2048M")
+	assertContains(t, got, "start_period: 300s")
+	// Frontend healthcheck.
+	assertContains(t, got, "http://127.0.0.1:8080/")
 }
 
 func TestRender_Ckstats(t *testing.T) {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -201,6 +201,14 @@ type DockerStorageItem struct {
 	Reclaimable string `json:"reclaimable"`
 }
 
+// ServiceDataItem represents a host data directory size — populated for paths
+// under /srv/truffels/data/* by the agent.
+type ServiceDataItem struct {
+	Path    string `json:"path"`
+	Size    string `json:"size"`
+	SizeRaw int64  `json:"size_raw"`
+}
+
 // SystemInfo represents host system information.
 type SystemInfo struct {
 	Hostname      string              `json:"hostname"`
@@ -214,6 +222,7 @@ type SystemInfo struct {
 	Networks      []NetworkIfInfo     `json:"networks"`
 	Storage       []StorageInfo       `json:"storage"`
 	DockerStorage []DockerStorageItem `json:"docker_storage,omitempty"`
+	ServiceData   []ServiceDataItem   `json:"service_data,omitempty"`
 }
 
 // SystemInfoGet fetches host system info via the agent.
@@ -405,6 +414,46 @@ func (c *ComposeClient) RemoveImage(image string) error {
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("agent remove image: %s", ar.Error)
+	}
+	return nil
+}
+
+// FsEnsureDir creates a directory under the agent's dataRoot with the requested
+// ownership and mode. Idempotent. Used by the compose reconciler to guarantee
+// bind-mount source paths exist before bringing a service up.
+func (c *ComposeClient) FsEnsureDir(path string, uid, gid int, mode string) error {
+	body, _ := json.Marshal(map[string]interface{}{
+		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	})
+	resp, err := c.httpClient.Post(c.agentURL+"/v1/fs/ensure-dir", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("agent ensure-dir: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var ar agentResponse
+	_ = json.NewDecoder(resp.Body).Decode(&ar)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("agent ensure-dir: %s", ar.Error)
+	}
+	return nil
+}
+
+// FsClearDir empties a directory under the agent's dataRoot and recreates it
+// with the requested ownership/mode. The agent enforces a basename+depth
+// allowlist; callers must ensure the path is one we want to expose.
+func (c *ComposeClient) FsClearDir(path string, uid, gid int, mode string) error {
+	body, _ := json.Marshal(map[string]interface{}{
+		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	})
+	resp, err := c.httpClient.Post(c.agentURL+"/v1/fs/clear-dir", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("agent clear-dir: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var ar agentResponse
+	_ = json.NewDecoder(resp.Body).Decode(&ar)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("agent clear-dir: %s", ar.Error)
 	}
 	return nil
 }

--- a/truffels-api/internal/model/service.go
+++ b/truffels-api/internal/model/service.go
@@ -28,6 +28,35 @@ type ServiceTemplate struct {
 	RequiresSynced   bool          `json:"requires_synced,omitempty"`
 	UpdateSource     *UpdateSource `json:"update_source,omitempty"`
 	StackContainers  []string      `json:"stack_containers,omitempty"`
+
+	// EnsureDirs are host directories the compose reconciler creates with
+	// the specified ownership before running `docker compose up` — used for
+	// bind-mount sources that need a specific uid:gid.
+	EnsureDirs []EnsureDir `json:"-"`
+
+	// DataDirs are host directories where this service stores persistent state.
+	// Surfaced in the Service Data Storage panel. Clearable entries get a Clear
+	// button in the UI; non-clearable ones are view-only.
+	DataDirs []DataDir `json:"data_dirs,omitempty"`
+}
+
+// EnsureDir describes a directory the reconciler must create before bringing
+// the service up. The reconciler calls the agent's POST /v1/fs/ensure-dir
+// with these parameters.
+type EnsureDir struct {
+	Path string `json:"path"`
+	UID  int    `json:"uid"`
+	GID  int    `json:"gid"`
+	Mode string `json:"mode"` // octal string, e.g. "0755"
+}
+
+// DataDir describes a service's persistent host directory for the UI.
+type DataDir struct {
+	Path         string `json:"path"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`            // shown as warning text in Clear confirmation
+	Clearable    bool   `json:"clearable"`
+	RequiresStop bool   `json:"requires_stop,omitempty"` // service must be stopped before clear
 }
 
 type ContainerState struct {

--- a/truffels-api/internal/service/templates/bitcoind.go
+++ b/truffels-api/internal/service/templates/bitcoind.go
@@ -16,4 +16,12 @@ var Bitcoind = model.ServiceTemplate{
 		Type:   model.SourceDockerHub,
 		Images: []string{"btcpayserver/bitcoin"},
 	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/bitcoin/blockchain",
+			Label:       "Blockchain data",
+			Description: "Full Bitcoin blockchain (~650 GB). Not clearable — would force ~7 day IBD over the network.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/internal/service/templates/ckpool.go
+++ b/truffels-api/internal/service/templates/ckpool.go
@@ -18,4 +18,12 @@ var Ckpool = model.ServiceTemplate{
 		Branch:     "master",
 		NeedsBuild: true,
 	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/ckpool",
+			Label:       "Ckpool state + logs",
+			Description: "Pool state, share data, and per-miner logs. Clearing logs separately is a future feature; today the whole dir is view-only.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/internal/service/templates/ckstats.go
+++ b/truffels-api/internal/service/templates/ckstats.go
@@ -18,4 +18,12 @@ var Ckstats = model.ServiceTemplate{
 		Branch:     "main",
 		NeedsBuild: true,
 	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/ckstats/postgres",
+			Label:       "Mining stats DB",
+			Description: "PostgreSQL — persistent mining stats history. Not clearable.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/internal/service/templates/electrs.go
+++ b/truffels-api/internal/service/templates/electrs.go
@@ -16,4 +16,12 @@ var Electrs = model.ServiceTemplate{
 		Type:   model.SourceDockerHub,
 		Images: []string{"getumbrel/electrs"},
 	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/electrs/db",
+			Label:       "Address index",
+			Description: "RocksDB address index. Not clearable — would force ~6 h reindex.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/internal/service/templates/infra.go
+++ b/truffels-api/internal/service/templates/infra.go
@@ -67,4 +67,12 @@ var Truffels = model.ServiceTemplate{
 		Images:     []string{"truffels/agent", "truffels/api", "truffels/web"},
 		NeedsBuild: true,
 	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/truffels",
+			Label:       "Admin DB",
+			Description: "SQLite store: settings, alerts, update history, audit log. Not clearable — losing this wipes session keys and audit trail.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/internal/service/templates/mempool.go
+++ b/truffels-api/internal/service/templates/mempool.go
@@ -16,4 +16,25 @@ var Mempool = model.ServiceTemplate{
 		Type:   model.SourceDockerHub,
 		Images: []string{"mempool/backend", "mempool/frontend"},
 	},
+	EnsureDirs: []model.EnsureDir{
+		// Bind-mount source for the backend's RBF/mempool cache. Created by
+		// the agent before `compose up` so the in-container uid 1000 process
+		// can write to it. See v0.3.1-dev.14 OOM fix.
+		{Path: "/srv/truffels/data/mempool/cache", UID: 1000, GID: 1000, Mode: "0755"},
+	},
+	DataDirs: []model.DataDir{
+		{
+			Path:        "/srv/truffels/data/mempool/cache",
+			Label:       "Mempool cache",
+			Description: "RBF + mempool state cache. Safe to clear — rebuilt from electrs on next start. The mempool backend will be briefly stopped during clear.",
+			Clearable:   true,
+			RequiresStop: true,
+		},
+		{
+			Path:        "/srv/truffels/data/mempool/mysql",
+			Label:       "Mempool DB",
+			Description: "Historical statistics (mariadb). Not safe to clear — loses chart history.",
+			Clearable:   false,
+		},
+	},
 }

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -54,9 +54,11 @@ func main() {
 	// Host metrics collector
 	collector := metrics.NewCollector(cfg.HostProc, cfg.HostSys, cfg.DataRoot)
 
-	// Alert engine
+	// Alert engine (constructed early so we can pass it to the reconciler).
+	// IMPORTANT: Start() is deferred until after Compose reconciliation so
+	// the alert evaluator doesn't fire spurious warnings against services
+	// that are still being reconciled. See v0.3.1-dev.14 startup-ordering fix.
 	alertEngine := alerts.NewEngine(st, registry, collector, compose)
-	alertEngine.Start()
 	defer alertEngine.Stop()
 
 	// Update engine
@@ -64,11 +66,17 @@ func main() {
 	updateEngine.Start()
 	defer updateEngine.Stop()
 
-	// Compose reconciliation — regenerate compose files from templates on startup
-	reconciler := composereconcile.NewReconciler(registry, compose)
+	// Compose reconciliation — regenerate compose files from templates on startup.
+	// Reconciler emits critical Alerts on compose-up failures so that a typo
+	// in a service template doesn't silently break the service after self-update.
+	reconciler := composereconcile.NewReconciler(registry, compose, st)
 	if err := reconciler.Run(); err != nil {
 		slog.Warn("compose reconciliation had errors", "err", err)
 	}
+
+	// Start alerts AFTER reconciliation so the first tick evaluates a
+	// post-reconcile world (not a transient mid-restart state).
+	alertEngine.Start()
 
 	// Auth
 	authenticator := auth.New(st)

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -60,6 +60,15 @@ export interface ServiceTemplate {
   floating_tag?: boolean
   update_source?: UpdateSource
   stack_containers?: string[]
+  data_dirs?: DataDir[]
+}
+
+export interface DataDir {
+  path: string
+  label: string
+  description: string
+  clearable: boolean
+  requires_stop?: boolean
 }
 
 export interface SyncInfo {
@@ -360,6 +369,12 @@ export interface DockerStorageItem {
   reclaimable: string
 }
 
+export interface ServiceDataItem {
+  path: string
+  size: string
+  size_raw: number
+}
+
 export interface SystemInfo {
   hostname: string
   os: string
@@ -372,6 +387,7 @@ export interface SystemInfo {
   networks: NetworkIfInfo[]
   storage: StorageInfo[]
   docker_storage?: DockerStorageItem[]
+  service_data?: ServiceDataItem[]
 }
 
 export interface SystemTuning {
@@ -465,4 +481,6 @@ export const api = {
     post<{ status: string; reclaimed: string }>('/system/docker-prune', { password }),
   dockerPruneBuildCache: (password: string) =>
     post<{ status: string; reclaimed: string }>('/system/docker-prune-buildcache', { password }),
+  clearServiceData: (password: string, serviceId: string, path: string) =>
+    post<{ status: string; path: string }>('/system/service-data/clear', { password, service_id: serviceId, path }),
 }

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -552,10 +552,17 @@ const UNIT_OPTIONS = [
 function SystemInfoTab() {
   const fetcher = useCallback(() => api.systemInfo(), [])
   const { data, error, loading, refresh } = useApi(fetcher)
+  const servicesFetcher = useCallback(() => api.services(), [])
+  const { data: services } = useApi(servicesFetcher)
   const [pruning, setPruning] = useState(false)
   const [prunePassword, setPrunePassword] = useState('')
   const [pruneConfirm, setPruneConfirm] = useState<'buildcache' | 'all' | null>(null)
   const [pruneMsg, setPruneMsg] = useState('')
+  // Service data clear state — keyed by `${serviceId}|${path}` so multiple rows can be independent.
+  const [clearTarget, setClearTarget] = useState<{ serviceId: string; path: string; label: string; description: string } | null>(null)
+  const [clearPassword, setClearPassword] = useState('')
+  const [clearMsg, setClearMsg] = useState('')
+  const [clearing, setClearing] = useState(false)
 
   if (loading) return <div className="text-gray-400">Loading...</div>
   if (error) return <div className="text-red-400">Error: {error}</div>
@@ -577,6 +584,59 @@ function SystemInfoTab() {
     } finally {
       setPruning(false)
     }
+  }
+
+  async function handleClear() {
+    if (!clearTarget) return
+    if (!clearPassword) { setClearMsg('Password required'); return }
+    setClearing(true); setClearMsg('')
+    try {
+      await api.clearServiceData(clearPassword, clearTarget.serviceId, clearTarget.path)
+      setClearMsg(`Cleared ${clearTarget.label}`)
+      setClearTarget(null)
+      setClearPassword('')
+      refresh()
+    } catch (e: any) {
+      setClearMsg(`Error: ${e.message}`)
+    } finally {
+      setClearing(false)
+    }
+  }
+
+  // Build the joined view: a row per (template DataDir × measured size from agent).
+  // Service data from the agent is keyed by path; template DataDirs supply
+  // service id, label, description, and clearable flag.
+  type ServiceDataRow = {
+    serviceId: string
+    serviceName: string
+    path: string
+    label: string
+    description: string
+    clearable: boolean
+    size: string
+    sizeRaw: number
+  }
+  const serviceDataRows: ServiceDataRow[] = []
+  if (services && data?.service_data) {
+    const sizeByPath = new Map(data.service_data.map((s) => [s.path, s]))
+    for (const svc of services) {
+      const tmpl = svc.template
+      if (!tmpl.data_dirs) continue
+      for (const dd of tmpl.data_dirs) {
+        const sz = sizeByPath.get(dd.path)
+        serviceDataRows.push({
+          serviceId: tmpl.id,
+          serviceName: tmpl.display_name,
+          path: dd.path,
+          label: dd.label,
+          description: dd.description,
+          clearable: dd.clearable,
+          size: sz?.size ?? '—',
+          sizeRaw: sz?.size_raw ?? 0,
+        })
+      }
+    }
+    serviceDataRows.sort((a, b) => b.sizeRaw - a.sizeRaw)
   }
 
   const Row = ({ label, value }: { label: string; value: string | number }) => (
@@ -742,6 +802,86 @@ function SystemInfoTab() {
               </p>
             )}
           </div>
+        </Card>
+      )}
+      {serviceDataRows.length > 0 && (
+        <Card>
+          <CardTitle>Service Data Storage</CardTitle>
+          <p className="text-xs text-gray-500 mb-3">
+            Per-service host data under <span className="font-mono">/srv/truffels/data/</span>. Caches can be cleared; persistent state cannot.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 border-b border-border-subtle">
+                  <th className="pb-2 pr-4">Service</th>
+                  <th className="pb-2 pr-4">Label</th>
+                  <th className="pb-2 pr-4">Path</th>
+                  <th className="pb-2 pr-4 text-right">Size</th>
+                  <th className="pb-2 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {serviceDataRows.map((r) => (
+                  <tr key={`${r.serviceId}|${r.path}`} className="border-b border-border-subtle last:border-0">
+                    <td className="py-1.5 pr-4 text-gray-300">{r.serviceName}</td>
+                    <td className="py-1.5 pr-4 text-gray-300">{r.label}</td>
+                    <td className="py-1.5 pr-4 font-mono text-gray-500 text-xs">{r.path}</td>
+                    <td className="py-1.5 pr-4 text-right font-mono text-gray-300">{r.size}</td>
+                    <td className="py-1.5 text-right">
+                      {r.clearable ? (
+                        <button
+                          onClick={() => {
+                            setClearTarget({ serviceId: r.serviceId, path: r.path, label: r.label, description: r.description })
+                            setClearMsg('')
+                          }}
+                          className="px-3 py-1 bg-red-600/20 text-red-400 hover:bg-red-600/30 text-xs font-medium rounded transition-colors"
+                        >
+                          Clear
+                        </button>
+                      ) : (
+                        <span className="text-xs text-gray-600">view-only</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {clearTarget && (
+            <div className="mt-4 pt-4 border-t border-border-subtle space-y-3">
+              <p className="text-sm text-yellow-400">
+                <span className="font-medium">{clearTarget.label}</span> — {clearTarget.description}
+              </p>
+              <div className="flex items-center gap-3 flex-wrap">
+                <input
+                  type="password"
+                  value={clearPassword}
+                  onChange={(e) => setClearPassword(e.target.value)}
+                  placeholder="Admin password"
+                  className="px-3 py-1.5 bg-surface-overlay border border-border rounded text-sm text-white placeholder-gray-600 max-w-xs"
+                />
+                <button
+                  onClick={handleClear}
+                  disabled={clearing || !clearPassword}
+                  className="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded disabled:opacity-50"
+                >
+                  {clearing ? 'Clearing...' : 'Confirm Clear'}
+                </button>
+                <button
+                  onClick={() => { setClearTarget(null); setClearMsg('') }}
+                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-gray-200"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+          {clearMsg && (
+            <p className={`text-sm mt-2 ${clearMsg.startsWith('Error') ? 'text-red-400' : 'text-green-400'}`}>
+              {clearMsg}
+            </p>
+          )}
         </Card>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes the mempool backend OOM crashloop (~13 days running, 44 720 restarts on the prod pi) by bind-mounting the RBF cache to a host directory and giving V8 more heap. Adds visibility and recovery: per-service Data Storage panel with password-gated Clear button (mempool/cache is the only clearable today), and the restart-loop auto-stop default goes from 0 (disabled) → 10 so the next runaway loop can't hide for two weeks.

## Highlights

- **Mempool compose template** (`internal/compose/templates.go:159` + mirrored in `install.sh`): NODE_OPTIONS heap 1280 → 1792, mem_limit 1536M → 2048M, bind-mount cache at `/srv/truffels/data/mempool/cache`, backend healthcheck (HTTP probe with `start_period: 300s`), frontend healthcheck.
- **Two new agent endpoints**: `POST /v1/fs/ensure-dir` (called by reconciler for `service.EnsureDirs` before `compose up`) and `POST /v1/fs/clear-dir` (called by the new Clear button). Both validate via `validateUnderRoot` — clean path + `EvalSymlinks` parent check. clear-dir adds a basename allowlist (`cache`, `logs`) AND requires the path be exactly two levels under `dataRoot` so e.g. `/srv/truffels/data/bitcoin/blockchain/cache` can't slip past the basename check.
- **Reconciler fail-loud alert**: previously a typo in a template would leave self-update reporting `UpdateDone` while the service silently broke. Now emits `compose_reconcile_failed` (critical) so it surfaces in /monitoring.
- **Startup ordering**: `alertEngine.Start()` moved after `reconciler.Run()` — drops the 5 s race where the alert evaluator could fire against a still-being-reconciled service.
- **`handleFileReconcile` hardening**: same `validateUnderRoot` pattern applied retroactively (lines 1488-1492 used `Clean + HasPrefix` only).
- **`restart_loop_max_retries` default 0 → 10** (`settings.go:13,56` + `alerts/engine.go:219`). Existing installs pick up the new fallback on next API boot — no migration needed because the key was never seeded.
- **Service Data Storage panel**: new card in Settings → Info. Joins agent-reported sizes for `/srv/truffels/data/*` with template metadata (`DataDir`). Clearable rows get a Clear button; non-clearable show as view-only. Password gating + audit log mirror the existing Docker Storage purge flow.
- **Agent compose**: mounts `/srv/truffels/data:rw` and sets `TRUFFELS_DATA_ROOT`. install.sh pre-creates `mempool/cache` with `1000:1000` ownership.

## Test plan

- [x] `go test ./...` in `truffels-api` and `truffels-agent` (Docker) — all green.
- [x] `npx vitest run` in `truffels-web` (Docker) — 64/64.
- [x] `npx tsc --noEmit` — clean.
- [ ] Cut tag + Pre-release `v0.3.1-dev.14` (`gh release create --prerelease --notes-file`).
- [ ] Self-update on second pi (192.168.0.195) — verify mempool reconciliation happens, `/srv/truffels/data/mempool/cache/` exists with `1000:1000`, backend healthcheck transitions to `healthy` within ~5 min, web UI mempool flips to online, Settings → Info shows Service Data Storage card with `Mempool cache` row + Clear button.
- [ ] 24 h soak on second pi. No `compose_reconcile_failed` alerts, no restart-count growth.
- [ ] Promote: self-update on prod pi. Same checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)