### PR TITLE
v0.3.1-dev.15 hotfix — fix dev.14 regressions, self-healing reconciler

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -654,7 +654,7 @@ services:
         limits:
           memory: 512M
     healthcheck:
-      test: ["CMD-SHELL", "node -e 'fetch(\"http://127.0.0.1:3000/\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]
+      test: ["CMD-SHELL", "node -e 'fetch(\"http://127.0.0.1:3000/ckstats\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -890,7 +890,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.14}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.15}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -53,6 +54,7 @@ var allowedContainers = map[string]bool{
 
 var composeRoot string
 var dataRoot string
+var sizeCache *dirSizeCache
 
 var version = "dev" // overridden via -ldflags "-X main.version=v0.2.0"
 
@@ -72,6 +74,9 @@ func main() {
 	composeRoot = envOr("TRUFFELS_COMPOSE_ROOT", "/srv/truffels/compose")
 	dataRoot = envOr("TRUFFELS_DATA_ROOT", "/srv/truffels/data")
 	listen := envOr("TRUFFELS_AGENT_LISTEN", ":9090")
+
+	sizeCache = newDirSizeCache()
+	go walkDataDirsForever(sizeCache, dataRoot)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/compose/up", handleComposeUp)
@@ -978,10 +983,9 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Service data: enumerate /srv/truffels/data/* leaf paths and du each.
-	// Walking down one level past dataRoot gives us per-service entries like
-	// mempool/cache, mempool/mysql, ckpool/logs, etc. — granularity matches
-	// what the service templates declare as DataDirs in the API.
+	// Service data: serve sizes from the background cache. Paths not yet
+	// walked return "calculating..." with SizeRaw: -1 so the frontend can
+	// render the row immediately and show a placeholder.
 	var serviceData []serviceDataItem
 	if entries, err := os.ReadDir(dataRoot); err == nil {
 		for _, e := range entries {
@@ -993,27 +997,37 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				continue
 			}
-			for _, c := range children {
-				if !c.IsDir() {
-					continue
+			addRow := func(full string) {
+				if sizeCache == nil {
+					serviceData = append(serviceData, serviceDataItem{
+						Path: full, Size: "calculating...", SizeRaw: -1,
+					})
+					return
 				}
-				full := filepath.Join(servicePath, c.Name())
-				size := dirSizeBytes(full)
+				size, walked, hit := sizeCache.get(full)
+				if !hit {
+					serviceData = append(serviceData, serviceDataItem{
+						Path: full, Size: "calculating...", SizeRaw: -1,
+					})
+					return
+				}
+				sizeStr := formatBytes(size)
+				if time.Since(walked) > time.Hour {
+					sizeStr += " (stale)"
+				}
 				serviceData = append(serviceData, serviceDataItem{
-					Path:    full,
-					Size:    formatBytes(size),
-					SizeRaw: size,
+					Path: full, Size: sizeStr, SizeRaw: size,
 				})
 			}
-			// Also include the bare top-level dir (e.g. /srv/truffels/data/truffels)
-			// if it has files but no leaf subdirs the template references.
 			if len(children) == 0 {
-				size := dirSizeBytes(servicePath)
-				serviceData = append(serviceData, serviceDataItem{
-					Path:    servicePath,
-					Size:    formatBytes(size),
-					SizeRaw: size,
-				})
+				addRow(servicePath)
+				continue
+			}
+			for _, child := range children {
+				if !child.IsDir() {
+					continue
+				}
+				addRow(filepath.Join(servicePath, child.Name()))
 			}
 		}
 	}
@@ -1032,6 +1046,94 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		DockerStorage: dockerStorage,
 		ServiceData:   serviceData,
 	})
+}
+
+// dirSizeCache stores cached directory sizes. Walks are expensive on
+// blockchain-size directories; the agent populates this in a background
+// goroutine and handleSystemInfo serves from cache to keep responses fast.
+type dirSizeCache struct {
+	mu     sync.RWMutex
+	sizes  map[string]int64
+	walked map[string]time.Time
+}
+
+func newDirSizeCache() *dirSizeCache {
+	return &dirSizeCache{
+		sizes:  make(map[string]int64),
+		walked: make(map[string]time.Time),
+	}
+}
+
+func (c *dirSizeCache) get(path string) (int64, time.Time, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	size, ok := c.sizes[path]
+	if !ok {
+		return 0, time.Time{}, false
+	}
+	return size, c.walked[path], true
+}
+
+func (c *dirSizeCache) set(path string, size int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sizes[path] = size
+	c.walked[path] = time.Now()
+}
+
+func (c *dirSizeCache) forget(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.sizes, path)
+	delete(c.walked, path)
+}
+
+// walkDataDirsForever populates sizeCache by enumerating dataRoot/*/* and
+// walking each leaf. Runs forever in a goroutine; first walk happens after a
+// short delay so the HTTP server is up first.
+func walkDataDirsForever(c *dirSizeCache, root string) {
+	time.Sleep(5 * time.Second)
+	for {
+		seen := make(map[string]bool)
+		if entries, err := os.ReadDir(root); err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				servicePath := filepath.Join(root, e.Name())
+				children, err := os.ReadDir(servicePath)
+				if err != nil {
+					continue
+				}
+				if len(children) == 0 {
+					seen[servicePath] = true
+					c.set(servicePath, dirSizeBytes(servicePath))
+					continue
+				}
+				for _, child := range children {
+					if !child.IsDir() {
+						continue
+					}
+					full := filepath.Join(servicePath, child.Name())
+					seen[full] = true
+					c.set(full, dirSizeBytes(full))
+				}
+			}
+		}
+		// Forget paths that vanished between walks.
+		c.mu.RLock()
+		toDrop := make([]string, 0)
+		for path := range c.sizes {
+			if !seen[path] {
+				toDrop = append(toDrop, path)
+			}
+		}
+		c.mu.RUnlock()
+		for _, path := range toDrop {
+			c.forget(path)
+		}
+		time.Sleep(5 * time.Minute)
+	}
 }
 
 // dirSizeBytes walks `path` and returns total size in bytes. Returns 0 on any

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -54,6 +54,7 @@ var allowedContainers = map[string]bool{
 
 var composeRoot string
 var dataRoot string
+var configRoot string
 var sizeCache *dirSizeCache
 
 var version = "dev" // overridden via -ldflags "-X main.version=v0.2.0"
@@ -73,6 +74,7 @@ func main() {
 
 	composeRoot = envOr("TRUFFELS_COMPOSE_ROOT", "/srv/truffels/compose")
 	dataRoot = envOr("TRUFFELS_DATA_ROOT", "/srv/truffels/data")
+	configRoot = envOr("TRUFFELS_CONFIG_ROOT", "/srv/truffels/config")
 	listen := envOr("TRUFFELS_AGENT_LISTEN", ":9090")
 
 	sizeCache = newDirSizeCache()
@@ -1671,13 +1673,28 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Security: resolve path and ensure it stays under composeRoot.
-	// validateUnderRoot also walks the parent chain via EvalSymlinks so a
-	// symlink at /srv/truffels/compose/foo → /etc cannot be used as a write target.
-	fullPath := filepath.Join(composeRoot, filepath.Clean(req.Path))
+	// Security: accept paths under either composeRoot or configRoot.
+	// Relative paths keep the legacy behavior of joining with composeRoot;
+	// absolute paths must validate against one of the two allowed roots.
+	fullPath := req.Path
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(composeRoot, filepath.Clean(req.Path))
+	} else {
+		fullPath = filepath.Clean(fullPath)
+	}
 	if _, err := validateUnderRoot(fullPath, composeRoot); err != nil {
-		writeJSON(w, 403, map[string]string{"error": "path outside compose root: " + err.Error()})
-		return
+		// Fall back to configRoot only if it's non-empty — an empty root would
+		// match everything (HasPrefix(anything, "/") is true).
+		if configRoot == "" {
+			writeJSON(w, 403, map[string]string{"error": "path outside compose root: " + err.Error()})
+			return
+		}
+		if _, err2 := validateUnderRoot(fullPath, configRoot); err2 != nil {
+			writeJSON(w, 403, map[string]string{
+				"error": "path outside allowed roots: " + err.Error() + " / " + err2.Error(),
+			})
+			return
+		}
 	}
 
 	slog.Info("file reconcile", "path", fullPath)

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1633,8 +1633,12 @@ func validateUnderRoot(p, root string) (string, error) {
 		probe = parent
 	}
 	resolved, err := filepath.EvalSymlinks(probe)
-	if err == nil && !strings.HasPrefix(resolved+"/", root+"/") && resolved != root {
-		return "", fmt.Errorf("symlink redirects outside root")
+	if err == nil && resolved != probe {
+		// A symlink was traversed somewhere up the chain. Verify the target
+		// still lies under root; reject if it escaped.
+		if !strings.HasPrefix(resolved+"/", root+"/") && resolved != root {
+			return "", fmt.Errorf("symlink redirects outside root")
+		}
 	}
 	return cleaned, nil
 }

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // --- Health ---
@@ -1917,5 +1918,53 @@ func TestValidateUnderRoot_AllowsNestedUnderExistingRoot(t *testing.T) {
 	}
 	if cleaned != target {
 		t.Errorf("expected cleaned=%q, got %q", target, cleaned)
+	}
+}
+
+// --- dirSizeCache ---
+
+func TestDirSizeCache_HitMiss(t *testing.T) {
+	c := newDirSizeCache()
+	if _, _, hit := c.get("/foo"); hit {
+		t.Fatal("expected miss before set")
+	}
+	c.set("/foo", 42)
+	size, walked, hit := c.get("/foo")
+	if !hit {
+		t.Fatal("expected hit after set")
+	}
+	if size != 42 {
+		t.Errorf("size: %d", size)
+	}
+	if walked.IsZero() {
+		t.Error("walked timestamp should be non-zero")
+	}
+}
+
+func TestDirSizeCache_ForgetRemoves(t *testing.T) {
+	c := newDirSizeCache()
+	c.set("/foo", 1)
+	c.set("/bar", 2)
+	c.forget("/foo")
+	if _, _, hit := c.get("/foo"); hit {
+		t.Error("expected forget to remove the entry")
+	}
+	if _, _, hit := c.get("/bar"); !hit {
+		t.Error("forget must not affect other entries")
+	}
+}
+
+func TestDirSizeCache_StaleMarkerSurfacedViaTimestamp(t *testing.T) {
+	c := newDirSizeCache()
+	c.set("/foo", 12345)
+	c.mu.Lock()
+	c.walked["/foo"] = time.Now().Add(-2 * time.Hour)
+	c.mu.Unlock()
+	_, walked, hit := c.get("/foo")
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if time.Since(walked) < time.Hour {
+		t.Errorf("walked was %v ago, expected >1h", time.Since(walked))
 	}
 }

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1890,3 +1890,32 @@ func TestHandleClearDir_RejectsRelativeEscape(t *testing.T) {
 		t.Errorf("expected 403 for relative escape, got %d body=%s", w.Code, w.Body.String())
 	}
 }
+
+func TestValidateUnderRoot_AllowsMissingRoot(t *testing.T) {
+	// Replicate the production bug: the root itself doesn't exist (the agent
+	// container has no /srv/truffels/data mount). validateUnderRoot must walk
+	// past root up to the nearest existing ancestor and not flag it as a symlink
+	// redirect just because the ancestor doesn't match root.
+	tmpBase := t.TempDir()
+	root := tmpBase + "/notyet" // root itself doesn't exist
+	target := root + "/mempool/cache/subdir"
+	cleaned, err := validateUnderRoot(target, root)
+	if err != nil {
+		t.Fatalf("expected accept, got error: %v", err)
+	}
+	if cleaned != target {
+		t.Errorf("expected cleaned=%q, got %q", target, cleaned)
+	}
+}
+
+func TestValidateUnderRoot_AllowsNestedUnderExistingRoot(t *testing.T) {
+	root := t.TempDir() // root exists
+	target := root + "/foo/bar/baz"
+	cleaned, err := validateUnderRoot(target, root)
+	if err != nil {
+		t.Fatalf("expected accept, got error: %v", err)
+	}
+	if cleaned != target {
+		t.Errorf("expected cleaned=%q, got %q", target, cleaned)
+	}
+}

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1954,6 +1954,45 @@ func TestDirSizeCache_ForgetRemoves(t *testing.T) {
 	}
 }
 
+func TestHandleFileReconcile_AcceptsConfigRoot(t *testing.T) {
+	dir := t.TempDir()
+	composeRoot = dir + "/compose"
+	configRoot = dir + "/config"
+	if err := os.MkdirAll(composeRoot+"/proxy", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configRoot+"/proxy", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// composeRoot path — should still work.
+	body := `{"path":"` + composeRoot + `/proxy/docker-compose.yml","expected_content":"x: y\n"}`
+	r := httptest.NewRequest("POST", "/v1/file/reconcile", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	handleFileReconcile(w, r)
+	if w.Code != 200 {
+		t.Fatalf("composeRoot: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// configRoot path — must also work.
+	body = `{"path":"` + configRoot + `/proxy/Caddyfile","expected_content":"z\n"}`
+	r = httptest.NewRequest("POST", "/v1/file/reconcile", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	handleFileReconcile(w, r)
+	if w.Code != 200 {
+		t.Fatalf("configRoot: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// /etc/passwd — must reject.
+	body = `{"path":"/etc/passwd","expected_content":"x\n"}`
+	r = httptest.NewRequest("POST", "/v1/file/reconcile", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	handleFileReconcile(w, r)
+	if w.Code != 403 {
+		t.Errorf("/etc/passwd: expected 403, got %d", w.Code)
+	}
+}
+
 func TestDirSizeCache_StaleMarkerSurfacedViaTimestamp(t *testing.T) {
 	c := newDirSizeCache()
 	c.set("/foo", 12345)

--- a/truffels-api/internal/compose/caddyfile.go
+++ b/truffels-api/internal/compose/caddyfile.go
@@ -1,0 +1,61 @@
+package compose
+
+// RenderCaddyfile returns the canonical Caddyfile content for the proxy
+// service. The first handle block (/proxy-health) is a static OK response
+// so the proxy healthcheck doesn't depend on any upstream — fixes the
+// dev.14 false-positive where stopping mempool marked Caddy unhealthy.
+func RenderCaddyfile() string {
+	return caddyfileTemplate
+}
+
+const caddyfileTemplate = `{
+	auto_https off
+	admin off
+}
+
+:80 {
+	# Shared security headers (non-CSP)
+	header {
+		X-Content-Type-Options nosniff
+		X-Frame-Options SAMEORIGIN
+		Referrer-Policy no-referrer
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+		-Server
+	}
+
+	# Self-contained health endpoint — used by the proxy's container
+	# healthcheck. Returns 200 regardless of upstream state.
+	handle /proxy-health {
+		respond "OK" 200
+	}
+
+	# ckstats — Next.js requires unsafe-inline for SSR hydration scripts
+	handle /ckstats* {
+		header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
+		reverse_proxy truffels-ckstats:3000
+	}
+
+	# Truffels control plane
+	handle /admin* {
+		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
+		reverse_proxy truffels-web:8080
+	}
+
+	handle /api/truffels/* {
+		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
+		reverse_proxy truffels-api:8080
+	}
+
+	# Mempool — all traffic (API + websocket + frontend) goes through
+	# the mempool frontend nginx, which handles /api/ → /api/v1/ rewrite.
+	handle /ws {
+		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
+		reverse_proxy truffels-mempool-frontend:8080
+	}
+
+	handle {
+		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
+		reverse_proxy truffels-mempool-frontend:8080
+	}
+}
+`

--- a/truffels-api/internal/compose/caddyfile_test.go
+++ b/truffels-api/internal/compose/caddyfile_test.go
@@ -1,0 +1,26 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderCaddyfile_HasStaticHealthRoute(t *testing.T) {
+	got := RenderCaddyfile()
+	if !strings.Contains(got, "handle /proxy-health") {
+		t.Error("missing /proxy-health route")
+	}
+	if !strings.Contains(got, `respond "OK" 200`) {
+		t.Error("missing static OK response on /proxy-health")
+	}
+	// Existing reverse_proxy routes must still be present.
+	if !strings.Contains(got, "handle /admin*") {
+		t.Error("missing /admin* route")
+	}
+	if !strings.Contains(got, "handle /api/truffels/*") {
+		t.Error("missing /api/truffels/* route")
+	}
+	if !strings.Contains(got, "handle /ckstats*") {
+		t.Error("missing /ckstats* route")
+	}
+}

--- a/truffels-api/internal/compose/params.go
+++ b/truffels-api/internal/compose/params.go
@@ -34,6 +34,20 @@ type ProxyParams struct {
 	ImageTag string
 }
 
+type TruffelsParams struct {
+	AgentTag string
+	APITag   string
+	WebTag   string
+	// RepoSrc is the host path mounted as /repo on the agent container and used
+	// as the build context for all three truffels images. Extracted from the
+	// agent's "- <path>:/repo:rw" volume line on disk.
+	RepoSrc string
+}
+
+// repoSrcRe extracts the host path from a line like
+// "      - /home/truffel/Project-Truffels:/repo:rw"
+var repoSrcRe = regexp.MustCompile(`(?m)^\s*-\s+(\S+):/repo:rw\s*$`)
+
 // imageTagRe matches `image: <ref>` lines, capturing the full image reference.
 var imageTagRe = regexp.MustCompile(`(?m)^\s*image:\s*(\S+)\s*$`)
 
@@ -106,6 +120,27 @@ func ExtractParams(serviceID, content string) (any, error) {
 			return nil, fmt.Errorf("no image tag found for proxy")
 		}
 		return ProxyParams{ImageTag: tag}, nil
+
+	case "truffels":
+		agent := ExtractImageTag(content, "truffels/agent:")
+		api := ExtractImageTag(content, "truffels/api:")
+		web := ExtractImageTag(content, "truffels/web:")
+		if agent == "" || api == "" || web == "" {
+			return nil, fmt.Errorf("missing image tag(s) for truffels (agent=%q api=%q web=%q)", agent, api, web)
+		}
+		var repoSrc string
+		if m := repoSrcRe.FindStringSubmatch(content); m != nil {
+			repoSrc = m[1]
+		}
+		if repoSrc == "" {
+			return nil, fmt.Errorf("missing /repo:rw mount for truffels (extract RepoSrc)")
+		}
+		return TruffelsParams{
+			AgentTag: agent,
+			APITag:   api,
+			WebTag:   web,
+			RepoSrc:  repoSrc,
+		}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown service for param extraction: %q", serviceID)

--- a/truffels-api/internal/compose/params_test.go
+++ b/truffels-api/internal/compose/params_test.go
@@ -175,3 +175,53 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+func TestExtractParams_Truffels(t *testing.T) {
+	dev14Compose := `services:
+  agent:
+    image: truffels/agent:v0.3.1-dev.14
+    container_name: truffels-agent
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /srv/truffels/compose:/srv/truffels/compose:rw
+      - /home/truffel/Project-Truffels:/repo:rw
+  api:
+    image: truffels/api:v0.3.1-dev.14
+    container_name: truffels-api
+  web:
+    image: truffels/web:v0.3.1-dev.14
+    container_name: truffels-web
+`
+	p, err := ExtractParams("truffels", dev14Compose)
+	if err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+	tp := p.(TruffelsParams)
+	if tp.AgentTag != "truffels/agent:v0.3.1-dev.14" {
+		t.Errorf("agent: %q", tp.AgentTag)
+	}
+	if tp.APITag != "truffels/api:v0.3.1-dev.14" {
+		t.Errorf("api: %q", tp.APITag)
+	}
+	if tp.WebTag != "truffels/web:v0.3.1-dev.14" {
+		t.Errorf("web: %q", tp.WebTag)
+	}
+	if tp.RepoSrc != "/home/truffel/Project-Truffels" {
+		t.Errorf("repo: %q", tp.RepoSrc)
+	}
+}
+
+func TestExtractParams_Truffels_MissingRepoMount(t *testing.T) {
+	compose := `services:
+  agent:
+    image: truffels/agent:v0.3.1-dev.14
+  api:
+    image: truffels/api:v0.3.1-dev.14
+  web:
+    image: truffels/web:v0.3.1-dev.14
+`
+	_, err := ExtractParams("truffels", compose)
+	if err == nil {
+		t.Fatal("expected error when /repo:rw mount missing")
+	}
+}

--- a/truffels-api/internal/compose/reconciler.go
+++ b/truffels-api/internal/compose/reconciler.go
@@ -17,8 +17,14 @@ var dockerfileMapping = map[string]string{
 	"ckpool":  "dockerfiles/ckpool/Dockerfile",
 }
 
-// serviceIDs that have compose templates (skip truffels — self-managed).
-var reconciledServices = []string{"bitcoind", "electrs", "ckpool", "mempool", "ckstats", "proxy"}
+// serviceIDs that have compose templates.
+//
+// "truffels" is special: its compose contains the API itself, so a normal
+// `compose up` would kill the running reconciler. The reconcileService path
+// dispatches to ComposeUpDetached for that ID — the agent writes a shell
+// script to host /tmp and execs it via nsenter, so the restart survives the
+// API process exiting.
+var reconciledServices = []string{"bitcoind", "electrs", "ckpool", "mempool", "ckstats", "proxy", "truffels"}
 
 // AlertStore is the subset of the store interface the reconciler needs to
 // surface reconciliation failures as alerts. Defined here (not imported) to
@@ -92,12 +98,32 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 
 	// Ensure any declared bind-mount host directories exist with correct
 	// ownership before we hand the new compose to `docker compose up`.
+	// Non-fatal: a failure here gets a critical alert and a warning log but
+	// we still proceed to write the compose. The service will then fail loud
+	// (caught by healthcheck + restart-loop autostop from dev.14) rather than
+	// silently skipping the entire reconciliation.
 	tmpl, _ := r.registry.Get(serviceID)
 	for _, d := range tmpl.EnsureDirs {
 		if err := r.compose.FsEnsureDir(d.Path, d.UID, d.GID, d.Mode); err != nil {
-			return fmt.Errorf("ensure-dir %s: %w", d.Path, err)
+			slog.Warn("ensure-dir failed; continuing with compose write",
+				"service", serviceID, "path", d.Path, "err", err)
+			r.raiseAlert(serviceID, fmt.Sprintf("ensure-dir %s failed: %v", d.Path, err))
+			continue
 		}
 		slog.Info("ensure-dir ok", "service", serviceID, "path", d.Path)
+	}
+
+	// Proxy ships a Caddyfile alongside the compose YAML. Reconcile it via
+	// the same agent file/reconcile path so structural Caddy config changes
+	// flow through the update channel.
+	if serviceID == "proxy" {
+		caddyfile := RenderCaddyfile()
+		caddyfilePath := "/srv/truffels/config/proxy/Caddyfile"
+		if err := r.reconcileFileWithRetry(caddyfilePath, caddyfile); err != nil {
+			slog.Warn("Caddyfile reconcile failed; proceeding with compose",
+				"err", err)
+			r.raiseAlert("proxy", fmt.Sprintf("Caddyfile reconcile failed: %v", err))
+		}
 	}
 
 	// Compare and write if different
@@ -110,11 +136,19 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 		slog.Info("compose unchanged", "service", serviceID)
 	} else {
 		slog.Info("compose reconciled, restarting", "service", serviceID)
-		if err := r.compose.Up(serviceID); err != nil {
+		var upErr error
+		if serviceID == "truffels" {
+			// Detached restart — agent execs the up script in PID 1's namespace
+			// so the API can be killed mid-reconcile without orphaning the stack.
+			upErr = r.compose.ComposeUpDetached(serviceID)
+		} else {
+			upErr = r.compose.Up(serviceID)
+		}
+		if upErr != nil {
 			// Fail loud — without this, a typo in the new compose template
 			// silently breaks the service while self-update reports success.
-			r.raiseAlert(serviceID, fmt.Sprintf("compose reconcile restart failed: %v", err))
-			return fmt.Errorf("restart after reconcile: %w", err)
+			r.raiseAlert(serviceID, fmt.Sprintf("compose reconcile restart failed: %v", upErr))
+			return fmt.Errorf("restart after reconcile: %w", upErr)
 		}
 	}
 
@@ -188,4 +222,21 @@ func (r *Reconciler) reconcileWithRetry(serviceID, expected string) (bool, error
 		time.Sleep(5 * time.Second)
 	}
 	return false, lastErr
+}
+
+func (r *Reconciler) reconcileFileWithRetry(path, content string) error {
+	var lastErr error
+	for i := 0; i < 3; i++ {
+		changed, err := r.compose.FileReconcile(path, content)
+		if err == nil {
+			if changed {
+				slog.Info("config file reconciled", "path", path)
+			}
+			return nil
+		}
+		lastErr = err
+		slog.Warn("file reconcile retry", "path", path, "attempt", i+1, "err", err)
+		time.Sleep(5 * time.Second)
+	}
+	return lastErr
 }

--- a/truffels-api/internal/compose/reconciler_test.go
+++ b/truffels-api/internal/compose/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"truffels-api/internal/docker"
@@ -239,4 +240,174 @@ func newMockAgentError(t *testing.T) *httptest.Server {
 		w.WriteHeader(500)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "agent unavailable"})
 	}))
+}
+
+// TestReconciler_TruffelsTriggersDetachedRestart verifies that when the
+// truffels compose has drifted, the reconciler calls ComposeUpDetached
+// (so the API survives its own restart) rather than Up.
+func TestReconciler_TruffelsTriggersDetachedRestart(t *testing.T) {
+	dev14Compose := `services:
+  agent:
+    image: truffels/agent:v0.3.1-dev.14
+    container_name: truffels-agent
+    volumes:
+      - /home/truffel/Project-Truffels:/repo:rw
+  api:
+    image: truffels/api:v0.3.1-dev.14
+    container_name: truffels-api
+  web:
+    image: truffels/web:v0.3.1-dev.14
+    container_name: truffels-web
+`
+	var detachedCalled bool
+	var upCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/compose/read":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "content": dev14Compose,
+			})
+		case "/v1/compose/reconcile":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": true,
+			})
+		case "/v1/compose/up-detached":
+			var req struct {
+				ServiceID string `json:"service_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.ServiceID == "truffels" {
+				detachedCalled = true
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/v1/compose/up":
+			upCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{ID: "truffels", ComposeDir: "/srv/truffels/compose/truffels"},
+	})
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
+	_ = reconciler.Run()
+
+	if !detachedCalled {
+		t.Error("expected ComposeUpDetached for truffels")
+	}
+	if upCalled {
+		t.Error("ComposeUp must NOT be called for truffels (would kill the running API)")
+	}
+}
+
+// TestReconciler_ProxyWritesBothComposeAndCaddyfile verifies the proxy
+// reconciler also writes /srv/truffels/config/proxy/Caddyfile.
+func TestReconciler_ProxyWritesBothComposeAndCaddyfile(t *testing.T) {
+	oldProxy := `services:
+  proxy:
+    image: caddy:2.11.2-alpine
+    container_name: truffels-proxy
+`
+	writes := make(map[string]string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/compose/read":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "content": oldProxy,
+			})
+		case "/v1/compose/reconcile":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": true,
+			})
+		case "/v1/file/reconcile":
+			var req struct {
+				Path            string `json:"path"`
+				ExpectedContent string `json:"expected_content"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			writes[req.Path] = req.ExpectedContent
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": true,
+			})
+		case "/v1/compose/up":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{ID: "proxy", ComposeDir: "/srv/truffels/compose/proxy"},
+	})
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
+	_ = reconciler.Run()
+
+	caddy, ok := writes["/srv/truffels/config/proxy/Caddyfile"]
+	if !ok {
+		t.Errorf("Caddyfile not written; got writes=%v", writes)
+	}
+	if !strings.Contains(caddy, "/proxy-health") {
+		t.Errorf("Caddyfile missing /proxy-health route: %s", caddy)
+	}
+}
+
+// TestReconciler_EnsureDirFailsButComposeStillWritten — even if ensure-dir
+// fails (e.g. agent permission issue), the new compose still gets written
+// and a critical alert is emitted. Mempool will fail loud rather than
+// silently skipping the whole reconciliation.
+func TestReconciler_EnsureDirFailsButComposeStillWritten(t *testing.T) {
+	mempoolOld := `services:
+  mempool-backend:
+    image: mempool/backend:v3.3.1
+  mempool-frontend:
+    image: mempool/frontend:v3.3.1
+  mempool-db:
+    image: mariadb:lts
+`
+	var composeWritten bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/compose/read":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "content": mempoolOld,
+			})
+		case "/v1/fs/ensure-dir":
+			w.WriteHeader(500)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "boom"})
+		case "/v1/compose/reconcile":
+			composeWritten = true
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": true,
+			})
+		case "/v1/compose/up":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{
+			ID: "mempool", ComposeDir: "/srv/truffels/compose/mempool",
+			EnsureDirs: []model.EnsureDir{
+				{Path: "/srv/truffels/data/mempool/cache", UID: 1000, GID: 1000, Mode: "0755"},
+			},
+		},
+	})
+	store := &captureAlertStore{}
+
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), store)
+	_ = reconciler.Run()
+
+	if !composeWritten {
+		t.Error("compose should be written even when ensure-dir fails")
+	}
+	if len(store.alerts) == 0 {
+		t.Error("expected ensure-dir failure to emit an alert")
+	}
 }

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -42,6 +42,7 @@ var rawTemplates = map[string]string{
 	"mempool":  mempoolTemplate,
 	"ckstats":  ckstatsTemplate,
 	"proxy":    proxyTemplate,
+	"truffels": truffelsTemplate,
 }
 
 const bitcoinTemplate = `# Project Truffels — Bitcoin Core
@@ -414,5 +415,134 @@ networks:
   truffels-edge:
     external: true
   bitcoin-backend:
+    external: true
+`
+
+
+const truffelsTemplate = `# Project Truffels — Control Plane (agent + api + web)
+# Managed by truffels. Do not edit manually.
+
+services:
+  agent:
+    build:
+      context: {{.RepoSrc}}/truffels-agent
+      dockerfile: {{.RepoSrc}}/truffels-agent/Dockerfile
+    image: {{.AgentTag}}
+    container_name: truffels-agent
+    pid: "host"
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    restart: unless-stopped
+    networks:
+      truffels-core:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /srv/truffels/compose:/srv/truffels/compose:rw
+      - /srv/truffels/config:/srv/truffels/config:rw
+      - /srv/truffels/secrets:/srv/truffels/secrets:ro
+      - /srv/truffels/data:/srv/truffels/data:rw
+      - {{.RepoSrc}}:/repo:rw
+    environment:
+      TRUFFELS_COMPOSE_ROOT: "/srv/truffels/compose"
+      TRUFFELS_CONFIG_ROOT: "/srv/truffels/config"
+      TRUFFELS_DATA_ROOT: "/srv/truffels/data"
+      TRUFFELS_AGENT_LISTEN: ":9090"
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:9090/v1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  api:
+    build:
+      context: {{.RepoSrc}}/truffels-api
+      dockerfile: {{.RepoSrc}}/truffels-api/Dockerfile
+    image: {{.APITag}}
+    container_name: truffels-api
+    user: "1000:1000"
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      bitcoin-backend:
+      truffels-edge:
+      truffels-core:
+    depends_on:
+      agent:
+        condition: service_healthy
+    volumes:
+      - /srv/truffels/config:/srv/truffels/config:ro
+      - /srv/truffels/compose:/srv/truffels/compose
+      - /srv/truffels/secrets:/srv/truffels/secrets:ro
+      - /srv/truffels/data/truffels:/data
+      - /srv/truffels/data:/srv/truffels/data:ro
+      - /srv/truffels/backups:/srv/truffels/backups
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+    environment:
+      TRUFFELS_LISTEN: ":8080"
+      TRUFFELS_DB_PATH: "/data/truffels.db"
+      TRUFFELS_COMPOSE_ROOT: "/srv/truffels/compose"
+      TRUFFELS_CONFIG_ROOT: "/srv/truffels/config"
+      TRUFFELS_SECRETS_ROOT: "/srv/truffels/secrets"
+      TRUFFELS_DATA_ROOT: "/srv/truffels/data"
+      TRUFFELS_HOST_PROC: "/host/proc"
+      TRUFFELS_HOST_SYS: "/host/sys"
+      TRUFFELS_AGENT_URL: "http://truffels-agent:9090"
+      TRUFFELS_GITHUB_REPO: "bandrewk/truffels"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/api/truffels/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  web:
+    build:
+      context: {{.RepoSrc}}/truffels-web
+      dockerfile: {{.RepoSrc}}/truffels-web/Dockerfile
+    image: {{.WebTag}}
+    container_name: truffels-web
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETUID
+    networks:
+      truffels-edge:
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/admin/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  bitcoin-backend:
+    external: true
+  truffels-edge:
+    external: true
+  truffels-core:
     external: true
 `

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -401,7 +401,7 @@ services:
         limits:
           memory: 128M
     healthcheck:
-      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:80/"]
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:80/proxy-health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -78,6 +78,10 @@ func TestRender_Proxy(t *testing.T) {
 	assertContains(t, got, "image: caddy:2.11.2-alpine")
 	assertContains(t, got, "container_name: truffels-proxy")
 	assertContains(t, got, "memory: 128M")
+	// dev.15: healthcheck must hit a path that doesn't depend on any upstream
+	// (the Caddyfile's catch-all reverse-proxies to mempool; using "/" caused
+	// Caddy to be marked unhealthy whenever mempool was stopped).
+	assertContains(t, got, "http://127.0.0.1:80/proxy-health")
 }
 
 func TestRender_UnknownService(t *testing.T) {

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -87,6 +87,38 @@ func TestRender_UnknownService(t *testing.T) {
 	}
 }
 
+func TestRender_Truffels(t *testing.T) {
+	got, err := Render("truffels", TruffelsParams{
+		AgentTag: "truffels/agent:v0.3.1-dev.15",
+		APITag:   "truffels/api:v0.3.1-dev.15",
+		WebTag:   "truffels/web:v0.3.1-dev.15",
+		RepoSrc:  "/home/truffel/Project-Truffels",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The dev.15 mount fix is the whole point — verify it's there.
+	assertContains(t, got, "/srv/truffels/data:/srv/truffels/data:rw")
+	assertContains(t, got, "TRUFFELS_DATA_ROOT")
+	// And config flipped from :ro to :rw so the proxy Caddyfile can be reconciled.
+	assertContains(t, got, "/srv/truffels/config:/srv/truffels/config:rw")
+	assertContains(t, got, "TRUFFELS_CONFIG_ROOT")
+	// Image tags from params land in the rendered output.
+	assertContains(t, got, "image: truffels/agent:v0.3.1-dev.15")
+	assertContains(t, got, "image: truffels/api:v0.3.1-dev.15")
+	assertContains(t, got, "image: truffels/web:v0.3.1-dev.15")
+	// Build contexts pick up RepoSrc.
+	assertContains(t, got, "context: /home/truffel/Project-Truffels/truffels-agent")
+	assertContains(t, got, "context: /home/truffel/Project-Truffels/truffels-api")
+	assertContains(t, got, "context: /home/truffel/Project-Truffels/truffels-web")
+	// /repo mount on agent for source access during build.
+	assertContains(t, got, "/home/truffel/Project-Truffels:/repo:rw")
+	// Container names.
+	assertContains(t, got, "container_name: truffels-agent")
+	assertContains(t, got, "container_name: truffels-api")
+	assertContains(t, got, "container_name: truffels-web")
+}
+
 func assertContains(t *testing.T, s, substr string) {
 	t.Helper()
 	if !strings.Contains(s, substr) {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -458,6 +458,31 @@ func (c *ComposeClient) FsClearDir(path string, uid, gid int, mode string) error
 	return nil
 }
 
+// FileReconcile writes `content` to `path` via the agent's POST /v1/file/reconcile
+// endpoint. Used by the reconciler for config files (Caddyfile) that live outside
+// composeRoot. Returns (changed, error).
+func (c *ComposeClient) FileReconcile(path, content string) (bool, error) {
+	body, _ := json.Marshal(map[string]string{
+		"path":             path,
+		"expected_content": content,
+	})
+	resp, err := c.httpClient.Post(c.agentURL+"/v1/file/reconcile", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return false, fmt.Errorf("agent file reconcile: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result struct {
+		Status  string `json:"status"`
+		Error   string `json:"error"`
+		Changed bool   `json:"changed"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if resp.StatusCode != 200 {
+		return false, fmt.Errorf("agent file reconcile: %s", result.Error)
+	}
+	return result.Changed, nil
+}
+
 // DockerPrune runs a full docker cleanup via the agent (builder + image + system prune).
 func (c *ComposeClient) DockerPrune() (string, error) {
 	longClient := &http.Client{Timeout: 6 * time.Minute}

--- a/truffels-web/src/App.tsx
+++ b/truffels-web/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Layout from './components/Layout'
+import { UpdatingOverlay } from './components/UpdatingOverlay'
+import { useUpdateInProgress } from './hooks/useUpdateInProgress'
 import DashboardPage from './pages/DashboardPage'
 import ServicesPage from './pages/ServicesPage'
 import ServiceDetailPage from './pages/ServiceDetailPage'
@@ -15,6 +17,7 @@ type AuthState = 'loading' | 'setup' | 'login' | 'authenticated'
 
 export default function App() {
   const [authState, setAuthState] = useState<AuthState>('loading')
+  const updating = useUpdateInProgress()
 
   useEffect(() => {
     checkAuth()
@@ -38,31 +41,47 @@ export default function App() {
 
   if (authState === 'loading') {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-gray-400">Loading...</div>
-      </div>
+      <>
+        {updating && <UpdatingOverlay />}
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="text-gray-400">Loading...</div>
+        </div>
+      </>
     )
   }
 
   if (authState === 'setup') {
-    return <SetupPage onSetup={() => setAuthState('authenticated')} />
+    return (
+      <>
+        {updating && <UpdatingOverlay />}
+        <SetupPage onSetup={() => setAuthState('authenticated')} />
+      </>
+    )
   }
 
   if (authState === 'login') {
-    return <LoginPage onLogin={() => setAuthState('authenticated')} />
+    return (
+      <>
+        {updating && <UpdatingOverlay />}
+        <LoginPage onLogin={() => setAuthState('authenticated')} />
+      </>
+    )
   }
 
   return (
-    <Routes>
-      <Route element={<Layout onLogout={() => setAuthState('login')} />}>
-        <Route index element={<DashboardPage />} />
-        <Route path="services" element={<ServicesPage />} />
-        <Route path="services/:id" element={<ServiceDetailPage />} />
-        <Route path="alerts" element={<AlertsPage />} />
-        <Route path="updates" element={<UpdatesPage />} />
-        <Route path="monitoring" element={<MonitoringPage />} />
-        <Route path="settings" element={<SettingsPage />} />
-      </Route>
-    </Routes>
+    <>
+      {updating && <UpdatingOverlay />}
+      <Routes>
+        <Route element={<Layout onLogout={() => setAuthState('login')} />}>
+          <Route index element={<DashboardPage />} />
+          <Route path="services" element={<ServicesPage />} />
+          <Route path="services/:id" element={<ServiceDetailPage />} />
+          <Route path="alerts" element={<AlertsPage />} />
+          <Route path="updates" element={<UpdatesPage />} />
+          <Route path="monitoring" element={<MonitoringPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+        </Route>
+      </Routes>
+    </>
   )
 }

--- a/truffels-web/src/components/UpdatingOverlay.tsx
+++ b/truffels-web/src/components/UpdatingOverlay.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+
+// Full-screen overlay shown while the truffels stack is restarting during
+// a self-update. Mirrors RebootOverlay: poll /health, redirect to /admin/
+// on recovery. After 10 min of being stuck, surface a manual escape hatch.
+export function UpdatingOverlay() {
+  const [elapsed, setElapsed] = useState(0)
+  const [status, setStatus] = useState<'updating' | 'polling' | 'online'>('updating')
+
+  useEffect(() => {
+    const timer = setInterval(() => setElapsed((s) => s + 1), 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  useEffect(() => {
+    if (elapsed < 15) return
+    if (status === 'online') return
+    if (status === 'updating') setStatus('polling')
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 3000)
+    fetch('/api/truffels/health', { signal: controller.signal })
+      .then((r) => { if (r.ok) setStatus('online') })
+      .catch(() => {})
+      .finally(() => clearTimeout(timeout))
+  }, [elapsed, status])
+
+  useEffect(() => {
+    if (status === 'online') {
+      const t = setTimeout(() => { window.location.href = '/admin/' }, 1500)
+      return () => clearTimeout(t)
+    }
+  }, [status])
+
+  const minutes = Math.floor(elapsed / 60)
+  const seconds = elapsed % 60
+  const timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`
+  const stuck = elapsed >= 10 * 60 && status !== 'online'
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/95 flex items-center justify-center">
+      <div className="text-center space-y-6 max-w-md px-4">
+        <div className={`text-6xl ${status === 'online' ? 'text-green-500' : stuck ? 'text-red-500' : 'text-yellow-500'}`}>
+          {status === 'online' ? '✓' : stuck ? '⚠' : '⏳'}
+        </div>
+        <h2 className="text-2xl font-bold text-white">
+          {status === 'online'
+            ? 'Truffels Updated'
+            : stuck
+              ? 'Update is taking longer than expected'
+              : 'Truffels is updating'}
+        </h2>
+        <p className="text-gray-400">
+          {status === 'online'
+            ? 'Redirecting...'
+            : stuck
+              ? 'The truffels stack should normally come back within a few minutes. If you have host access, check `docker logs truffels-api` for clues.'
+              : status === 'polling'
+                ? 'Waiting for the API to come back online…'
+                : 'The truffels stack is being recreated. Auto-refresh will resume when it returns.'}
+        </p>
+        <div className="text-4xl font-mono text-gray-300">{timeStr}</div>
+        {status === 'polling' && !stuck && (
+          <div className="flex justify-center">
+            <div className="w-8 h-8 border-2 border-yellow-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+        {stuck && (
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded"
+          >
+            Reload page
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/truffels-web/src/hooks/useApi.ts
+++ b/truffels-web/src/hooks/useApi.ts
@@ -4,11 +4,12 @@ export function useApi<T>(fetcher: () => Promise<T>, intervalMs = 0) {
   const [data, setData] = useState<T | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [consecutiveErrors, setConsecutiveErrors] = useState(0)
 
   const refresh = useCallback(() => {
     fetcher()
-      .then((d) => { setData(d); setError(null) })
-      .catch((e) => setError(e.message))
+      .then((d) => { setData(d); setError(null); setConsecutiveErrors(0) })
+      .catch((e) => { setError(e.message); setConsecutiveErrors((n) => n + 1) })
       .finally(() => setLoading(false))
   }, [fetcher])
 
@@ -20,5 +21,5 @@ export function useApi<T>(fetcher: () => Promise<T>, intervalMs = 0) {
     }
   }, [refresh, intervalMs])
 
-  return { data, error, loading, refresh }
+  return { data, error, loading, refresh, consecutiveErrors }
 }

--- a/truffels-web/src/hooks/useUpdateInProgress.test.ts
+++ b/truffels-web/src/hooks/useUpdateInProgress.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+
+describe('useUpdateInProgress', () => {
+  it('exports the useUpdateInProgress hook function', async () => {
+    const mod = await import('./useUpdateInProgress')
+    expect(typeof mod.useUpdateInProgress).toBe('function')
+  })
+})

--- a/truffels-web/src/hooks/useUpdateInProgress.ts
+++ b/truffels-web/src/hooks/useUpdateInProgress.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react'
+
+// Polls /api/truffels/updates/logs every 5 s. Returns true when:
+// - any log entry indicates truffels is in `restarting` phase, OR
+// - 2+ consecutive polls fail AND a recent successful poll was seen <10 min ago
+// (transient network errors during the actual self-update restart window).
+export function useUpdateInProgress(): boolean {
+  const [active, setActive] = useState(false)
+  const consecFailRef = useRef(0)
+  const lastSuccessRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const res = await fetch('/api/truffels/updates/logs', { credentials: 'same-origin' })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const body = await res.json()
+        const logs: Array<{ service_id: string; status: string }> = Array.isArray(body) ? body : (body.logs ?? [])
+        const truffelsRestarting = logs.some(
+          (l) => l.service_id === 'truffels' && l.status === 'restarting',
+        )
+        if (cancelled) return
+        consecFailRef.current = 0
+        lastSuccessRef.current = Date.now()
+        setActive(truffelsRestarting)
+      } catch {
+        if (cancelled) return
+        consecFailRef.current += 1
+        const lastSuccess = lastSuccessRef.current
+        if (
+          consecFailRef.current >= 2 &&
+          lastSuccess !== null &&
+          Date.now() - lastSuccess < 10 * 60 * 1000
+        ) {
+          setActive(true)
+        }
+      }
+    }
+    void tick()
+    const id = setInterval(tick, 5000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  return active
+}

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -604,8 +604,9 @@ function SystemInfoTab() {
   }
 
   // Build the joined view: a row per (template DataDir × measured size from agent).
-  // Service data from the agent is keyed by path; template DataDirs supply
-  // service id, label, description, and clearable flag.
+  // Sizes from data.service_data are looked up by path; missing rows show "—".
+  // The panel renders as soon as services is loaded, even if the agent's size
+  // cache hasn't been populated yet (dev.15 background-cache behaviour).
   type ServiceDataRow = {
     serviceId: string
     serviceName: string
@@ -617,8 +618,8 @@ function SystemInfoTab() {
     sizeRaw: number
   }
   const serviceDataRows: ServiceDataRow[] = []
-  if (services && data?.service_data) {
-    const sizeByPath = new Map(data.service_data.map((s) => [s.path, s]))
+  if (services) {
+    const sizeByPath = new Map((data?.service_data ?? []).map((s) => [s.path, s]))
     for (const svc of services) {
       const tmpl = svc.template
       if (!tmpl.data_dirs) continue
@@ -631,12 +632,18 @@ function SystemInfoTab() {
           label: dd.label,
           description: dd.description,
           clearable: dd.clearable,
-          size: sz?.size ?? '—',
-          sizeRaw: sz?.size_raw ?? 0,
+          size: sz && sz.size_raw >= 0 ? sz.size : '—',
+          sizeRaw: sz?.size_raw ?? -1,
         })
       }
     }
-    serviceDataRows.sort((a, b) => b.sizeRaw - a.sizeRaw)
+    // Sort biggest first; rows with sizeRaw < 0 (unwalked) sink to bottom.
+    serviceDataRows.sort((a, b) => {
+      if (a.sizeRaw < 0 && b.sizeRaw < 0) return 0
+      if (a.sizeRaw < 0) return 1
+      if (b.sizeRaw < 0) return -1
+      return b.sizeRaw - a.sizeRaw
+    })
   }
 
   const Row = ({ label, value }: { label: string; value: string | number }) => (


### PR DESCRIPTION
## Summary

Fixes three regressions v0.3.1-dev.14 introduced and adds the polish to deliver them cleanly:

1. **`validateUnderRoot` false-positive** — rejected legitimate "create me a fresh subtree" requests, which is why mempool's `ensure-dir` failed and the dev.14 fix never applied.
2. **Truffels compose drift** — agent had no `/srv/truffels/data` mount on existing installs, breaking the new bind-mount before it could help. Reconciler now self-heals this via `ComposeUpDetached`.
3. **`handleSystemInfo` walks the full data tree per request** — on a 650 GB blockchain, blocked the handler for minutes; Host → Info panel rendered empty.

Plus:
- Caddy proxy healthcheck no longer false-fails when mempool is stopped — moved to a static `/proxy-health` Caddyfile route.
- New `UpdatingOverlay` during truffels self-update — no more silent stale data or login-page bouncing.
- Ensure-dir failures are non-fatal in the reconciler — alert + write compose anyway. Mempool will fail loud rather than silently skip.

## Self-healing on first dev.15 boot

The dev.14 → dev.15 upgrade flow:

1. User clicks Self-Update in the dev.14 UI.
2. dev.14's update engine pulls + builds dev.15 images, rewrites tags, runs detached restart.
3. New dev.15 API boots. Reconciler detects truffels compose is missing `/srv/truffels/data` mount, writes the new template via existing `POST /v1/file/reconcile`.
4. Reconciler calls `compose up-detached truffels` — same nsenter mechanism `applySelfUpdate` uses to swap the stack from inside the stack.
5. Stack restarts a second time with the corrected mounts. Mempool reconciliation now succeeds (Bug 1's `validateUnderRoot` is also fixed).
6. UpdatingOverlay covers both restart windows; user lands back on their previous page once `/health` is OK.

Total user actions: **one click**, no SSH, no docker commands.

## Test plan

- [x] `go test ./...` in `truffels-api` + `truffels-agent` (Docker) — all green.
- [x] `npx vitest run` + `npx tsc --noEmit` in `truffels-web` (Docker) — all green (65/65).
- [ ] After merge: cut v0.3.1-dev.15 prerelease via `gh release create --prerelease --notes-file`.
- [ ] Self-update on second pi (192.168.0.195) — verify the two-restart sequence, ensure-dir ok, mempool gets healthcheck + bind mount, Service Data Storage panel renders within ~5 min, Caddy stays healthy when mempool is stopped.
- [ ] 24 h soak. Promote to prod pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)