### PR TITLE
v0.3.1-dev.16 hotfix — clean dev.15 transition + ckstats-cron healthcheck + trend alert calm-down

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -682,6 +682,7 @@ services:
       - |
         CLEANUP_COUNTER=0
         while true; do
+          date +%s > /tmp/cron-last-run
           echo "[$(date)] Running seed..."
           pnpm seed 2>&1
           echo "[$(date)] Running update-users..."
@@ -698,6 +699,12 @@ services:
       resources:
         limits:
           memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "test $$(( $$(date +%s) - $$(cat /tmp/cron-last-run 2>/dev/null || echo 0) )) -lt 180"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
 
   ckstats-db:
     image: postgres:16.13-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416

--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.15}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.16}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1165,9 +1165,22 @@ func fetchDockerStorage() []dockerStorageItem {
 	return items
 }
 
-// walkDataDirsForever populates sizeCache by enumerating dataRoot/*/* and
-// walking each leaf. Runs forever in a goroutine; first walk happens after a
-// short delay so the HTTP server is up first.
+// walkDataDirsForever populates sizeCache by enumerating dataRoot/* AND
+// dataRoot/*/*. Indexing BOTH levels lets templates declare data dirs at
+// either granularity:
+//
+//   - bitcoind: /srv/truffels/data/bitcoin/blockchain (2 levels)
+//   - electrs:  /srv/truffels/data/electrs/db          (2 levels)
+//   - ckpool:   /srv/truffels/data/ckpool              (1 level — whole dir)
+//   - truffels: /srv/truffels/data/truffels            (1 level — whole dir)
+//
+// dev.15 only indexed the 2-level leaves when children existed, so ckpool
+// and truffels' template paths got cache misses and showed "—" in the UI.
+// Cost of indexing the parent too: one extra du -s per service per 5 min
+// — cheap.
+//
+// Runs forever in a goroutine; first walk happens after a short delay so
+// the HTTP server is up first.
 func walkDataDirsForever(c *dirSizeCache, root string) {
 	time.Sleep(5 * time.Second)
 	for {
@@ -1178,13 +1191,13 @@ func walkDataDirsForever(c *dirSizeCache, root string) {
 					continue
 				}
 				servicePath := filepath.Join(root, e.Name())
+				// Always index the top-level service path so templates that
+				// declare a 1-level path (ckpool, truffels) get a hit.
+				seen[servicePath] = true
+				c.set(servicePath, dirSizeBytes(servicePath))
+
 				children, err := os.ReadDir(servicePath)
 				if err != nil {
-					continue
-				}
-				if len(children) == 0 {
-					seen[servicePath] = true
-					c.set(servicePath, dirSizeBytes(servicePath))
 					continue
 				}
 				for _, child := range children {

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -56,6 +56,7 @@ var composeRoot string
 var dataRoot string
 var configRoot string
 var sizeCache *dirSizeCache
+var storageCache *dockerStorageCache
 
 var version = "dev" // overridden via -ldflags "-X main.version=v0.2.0"
 
@@ -79,6 +80,8 @@ func main() {
 
 	sizeCache = newDirSizeCache()
 	go walkDataDirsForever(sizeCache, dataRoot)
+
+	storageCache = newDockerStorageCache(5 * time.Minute)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/compose/up", handleComposeUp)
@@ -482,6 +485,12 @@ func handleDockerPrune(w http.ResponseWriter, r *http.Request) {
 		reclaimed = strings.Join(reclaimedParts, "; ")
 	}
 
+	// Force /system/info to refetch the storage summary so the user sees
+	// the result of the prune immediately rather than waiting up to 5 min.
+	if storageCache != nil {
+		storageCache.invalidate()
+	}
+
 	writeJSON(w, 200, map[string]string{"status": "ok", "reclaimed": reclaimed})
 }
 
@@ -505,6 +514,11 @@ func handleDockerPruneBuildCache(w http.ResponseWriter, r *http.Request) {
 			reclaimed = strings.TrimSpace(line)
 			break
 		}
+	}
+
+	// Force storage refetch — see handleDockerPrune for rationale.
+	if storageCache != nil {
+		storageCache.invalidate()
 	}
 
 	writeJSON(w, 200, map[string]string{"status": "ok", "reclaimed": reclaimed})
@@ -955,34 +969,20 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Docker storage: run docker system df and parse output
+	// Docker storage: serve from a 5-min cache. `docker system df` takes
+	// several seconds on a pi with many image layers — caching makes the
+	// /system/info handler sub-second after the first call. Cache is
+	// invalidated by destructive actions (prune handlers).
 	var dockerStorage []dockerStorageItem
-	dockerCtx, dockerCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer dockerCancel()
-	dockerCmd := exec.CommandContext(dockerCtx, "docker", "system", "df", "--format", "{{json .}}")
-	var dockerOut bytes.Buffer
-	dockerCmd.Stdout = &dockerOut
-	if err := dockerCmd.Run(); err == nil {
-		for _, line := range strings.Split(strings.TrimSpace(dockerOut.String()), "\n") {
-			if line == "" {
-				continue
-			}
-			var item struct {
-				Type        string `json:"Type"`
-				TotalCount  string `json:"TotalCount"`
-				Size        string `json:"Size"`
-				Reclaimable string `json:"Reclaimable"`
-			}
-			if err := json.Unmarshal([]byte(line), &item); err == nil {
-				count, _ := strconv.Atoi(item.TotalCount)
-				dockerStorage = append(dockerStorage, dockerStorageItem{
-					Type:        item.Type,
-					Count:       count,
-					TotalSize:   formatSize(item.Size),
-					Reclaimable: formatSize(item.Reclaimable),
-				})
-			}
+	if storageCache != nil {
+		var hit bool
+		dockerStorage, hit = storageCache.get()
+		if !hit {
+			dockerStorage = fetchDockerStorage()
+			storageCache.set(dockerStorage)
 		}
+	} else {
+		dockerStorage = fetchDockerStorage()
 	}
 
 	// Service data: serve sizes from the background cache. Paths not yet
@@ -1088,6 +1088,81 @@ func (c *dirSizeCache) forget(path string) {
 	defer c.mu.Unlock()
 	delete(c.sizes, path)
 	delete(c.walked, path)
+}
+
+// dockerStorageCache memoizes the output of `docker system df`. The command
+// takes several seconds on a pi with many containers + image layers; running
+// it on every /system/info request is the dominant cost of the handler.
+// TTL matches dirSizeCache's walk cadence so the whole Info panel is
+// "approximately 5-min fresh." Manual destructive actions (prune,
+// prune-buildcache) call invalidate() so the next fetch is live.
+type dockerStorageCache struct {
+	mu        sync.RWMutex
+	value     []dockerStorageItem
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+func newDockerStorageCache(ttl time.Duration) *dockerStorageCache {
+	return &dockerStorageCache{ttl: ttl}
+}
+
+func (c *dockerStorageCache) get() ([]dockerStorageItem, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.fetchedAt.IsZero() || time.Since(c.fetchedAt) > c.ttl {
+		return nil, false
+	}
+	return c.value, true
+}
+
+func (c *dockerStorageCache) set(v []dockerStorageItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value = v
+	c.fetchedAt = time.Now()
+}
+
+func (c *dockerStorageCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fetchedAt = time.Time{}
+}
+
+// fetchDockerStorage runs `docker system df --format {{json .}}` and parses
+// the per-type rows. Returns nil on any error so the handler can gracefully
+// degrade rather than 500.
+func fetchDockerStorage() []dockerStorageItem {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "system", "df", "--format", "{{json .}}")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	var items []dockerStorageItem
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var raw struct {
+			Type        string `json:"Type"`
+			TotalCount  string `json:"TotalCount"`
+			Size        string `json:"Size"`
+			Reclaimable string `json:"Reclaimable"`
+		}
+		if err := json.Unmarshal([]byte(line), &raw); err == nil {
+			count, _ := strconv.Atoi(raw.TotalCount)
+			items = append(items, dockerStorageItem{
+				Type:        raw.Type,
+				Count:       count,
+				TotalSize:   formatSize(raw.Size),
+				Reclaimable: formatSize(raw.Reclaimable),
+			})
+		}
+	}
+	return items
 }
 
 // walkDataDirsForever populates sizeCache by enumerating dataRoot/*/* and

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1993,6 +1993,33 @@ func TestHandleFileReconcile_AcceptsConfigRoot(t *testing.T) {
 	}
 }
 
+func TestDockerStorageCache_HitMiss(t *testing.T) {
+	c := newDockerStorageCache(100 * time.Millisecond)
+	if _, hit := c.get(); hit {
+		t.Fatal("expected miss before set")
+	}
+	c.set([]dockerStorageItem{{Type: "Images", Count: 5}})
+	if items, hit := c.get(); !hit || len(items) != 1 || items[0].Count != 5 {
+		t.Fatalf("expected hit after set; got hit=%v items=%v", hit, items)
+	}
+	time.Sleep(150 * time.Millisecond)
+	if _, hit := c.get(); hit {
+		t.Error("expected miss after TTL expiry")
+	}
+}
+
+func TestDockerStorageCache_InvalidateClearsCache(t *testing.T) {
+	c := newDockerStorageCache(1 * time.Hour)
+	c.set([]dockerStorageItem{{Type: "Images", Count: 5}})
+	if _, hit := c.get(); !hit {
+		t.Fatal("expected hit after set")
+	}
+	c.invalidate()
+	if _, hit := c.get(); hit {
+		t.Error("expected miss after invalidate")
+	}
+}
+
 func TestDirSizeCache_StaleMarkerSurfacedViaTimestamp(t *testing.T) {
 	c := newDirSizeCache()
 	c.set("/foo", 12345)

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1993,6 +1993,57 @@ func TestHandleFileReconcile_AcceptsConfigRoot(t *testing.T) {
 	}
 }
 
+// dev.16: walker must index both 1-level service dirs (ckpool, truffels)
+// and 2-level leaves (bitcoin/blockchain, electrs/db). dev.15 only did 2-level
+// when children existed, so ckpool's template path got a cache miss.
+func TestWalkDataDirs_IndexesTopLevelAndLeaves(t *testing.T) {
+	root := t.TempDir()
+	// Build a fake data tree: ckpool/logs (children exist) + truffels (also children)
+	// and a 2-level case bitcoin/blockchain.
+	for _, p := range []string{
+		root + "/ckpool/logs/pool",
+		root + "/truffels/somefile_parent",
+		root + "/bitcoin/blockchain",
+	} {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := newDirSizeCache()
+	// Drive a single walk iteration synchronously by inlining the body.
+	// Easier than waiting 5s + 5min from the goroutine.
+	entries, _ := os.ReadDir(root)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		servicePath := root + "/" + e.Name()
+		c.set(servicePath, dirSizeBytes(servicePath))
+		children, _ := os.ReadDir(servicePath)
+		for _, child := range children {
+			if !child.IsDir() {
+				continue
+			}
+			c.set(servicePath+"/"+child.Name(), dirSizeBytes(servicePath+"/"+child.Name()))
+		}
+	}
+
+	// All four paths should be in the cache.
+	wanted := []string{
+		root + "/ckpool",
+		root + "/ckpool/logs",
+		root + "/truffels",
+		root + "/bitcoin",
+		root + "/bitcoin/blockchain",
+	}
+	for _, p := range wanted {
+		if _, _, hit := c.get(p); !hit {
+			t.Errorf("expected cache hit for %q", p)
+		}
+	}
+}
+
 func TestDockerStorageCache_HitMiss(t *testing.T) {
 	c := newDockerStorageCache(100 * time.Millisecond)
 	if _, hit := c.get(); hit {

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -341,8 +341,19 @@ func (e *Engine) checkTrends() {
 	since := time.Now().Add(-time.Duration(lookback) * time.Hour)
 	oldestAllowed := time.Now().Add(-time.Duration(minDataHours) * time.Hour)
 
+	// Containers that restarted within the lookback window — skip their
+	// trend evaluation (post-restart memory growth is cache fill, not a leak).
+	restartedContainers := make(map[string]bool)
+	if events, err := e.store.GetServiceEvents(since, 1000); err == nil {
+		for _, ev := range events {
+			if ev.EventType == "restart" {
+				restartedContainers[ev.Container] = true
+			}
+		}
+	}
+
 	// Container memory trends
-	containerAlerts := evaluateContainerMemoryTrends(e.store, lookback, horizon)
+	containerAlerts := evaluateContainerMemoryTrends(e.store, lookback, horizon, oldestAllowed, restartedContainers)
 	activeContainers := make(map[string]bool)
 	for _, pa := range containerAlerts {
 		activeContainers[pa.ServiceID] = true

--- a/truffels-api/internal/alerts/trend.go
+++ b/truffels-api/internal/alerts/trend.go
@@ -99,7 +99,15 @@ type pendingAlert struct {
 }
 
 // evaluateContainerMemoryTrends checks each container's memory usage trend.
-func evaluateContainerMemoryTrends(s *store.Store, lookbackHours, horizon float64) []pendingAlert {
+//
+// oldestAllowed gates the regression: the per-container series must include
+// at least one sample older than oldestAllowed, otherwise the trend is fit
+// over too-recent data (warmup spikes right after a restart).
+//
+// restartedContainers is a set of container names that restarted within the
+// lookback window — those are skipped because extrapolating post-restart
+// cache fill is meaningless.
+func evaluateContainerMemoryTrends(s *store.Store, lookbackHours, horizon float64, oldestAllowed time.Time, restartedContainers map[string]bool) []pendingAlert {
 	since := time.Now().Add(-time.Duration(lookbackHours) * time.Hour)
 	snaps, err := s.GetContainerSnapshotsForTrend(since)
 	if err != nil || len(snaps) == 0 {
@@ -115,6 +123,20 @@ func evaluateContainerMemoryTrends(s *store.Store, lookbackHours, horizon float6
 	var alerts []pendingAlert
 	for container, snapshots := range byContainer {
 		if len(snapshots) < 2 {
+			continue
+		}
+
+		// Gate: skip if the oldest snapshot is too recent — same rule the
+		// host trend evaluator applies. Without this, a freshly-restarted
+		// container's cache-fill rate gets extrapolated as a +5249MB/h
+		// trend and the user gets a spurious critical alert.
+		if !snapshots[0].Timestamp.Before(oldestAllowed) {
+			continue
+		}
+
+		// Skip if the container restarted within the lookback window —
+		// extrapolating post-restart growth is meaningless.
+		if restartedContainers[container] {
 			continue
 		}
 

--- a/truffels-api/internal/alerts/trend_test.go
+++ b/truffels-api/internal/alerts/trend_test.go
@@ -181,7 +181,8 @@ func TestEvaluateContainerMemoryTrends_Integration(t *testing.T) {
 	}
 
 	// Rate is 100MB/h, current ~800, limit 1024 → ~2.24h to hit
-	alerts := evaluateContainerMemoryTrends(s, 6, 6)
+	oldestAllowed := time.Now().Add(-2 * time.Hour)
+	alerts := evaluateContainerMemoryTrends(s, 6, 6, oldestAllowed, nil)
 	if len(alerts) != 1 {
 		t.Fatalf("expected 1 trend alert, got %d", len(alerts))
 	}
@@ -202,9 +203,51 @@ func TestEvaluateContainerMemoryTrends_NoAlert_FlatMemory(t *testing.T) {
 		insertContainerSnap(t, s, ts, "truffels-ckpool", 500, 1024)
 	}
 
-	alerts := evaluateContainerMemoryTrends(s, 6, 6)
+	oldestAllowed := time.Now().Add(-2 * time.Hour)
+	alerts := evaluateContainerMemoryTrends(s, 6, 6, oldestAllowed, nil)
 	if len(alerts) != 0 {
 		t.Fatalf("expected 0 alerts for flat memory, got %d", len(alerts))
+	}
+}
+
+// dev.16: container trends must not fire when the series is too short.
+// This guards against spurious post-restart "+5249 MB/h" alerts.
+func TestEvaluateContainerMemoryTrends_SkipsWhenInsufficientData(t *testing.T) {
+	s := newTestStore(t)
+
+	// Only 30 minutes of fast-growing samples.
+	now := time.Now()
+	for i := 0; i <= 30; i++ {
+		ts := now.Add(-time.Duration(30-i) * time.Minute)
+		mem := 100 + float64(i)*30.0 // 100 → 1000 over 30min — steep
+		insertContainerSnap(t, s, ts, "truffels-mempool-backend", mem, 2048)
+	}
+
+	// oldestAllowed = 2h ago, but oldest sample is 30min ago → skip
+	oldestAllowed := time.Now().Add(-2 * time.Hour)
+	alerts := evaluateContainerMemoryTrends(s, 6, 6, oldestAllowed, nil)
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts for series shorter than min_data_hours, got %d", len(alerts))
+	}
+}
+
+// dev.16: container trends must not fire when the container restarted within
+// the lookback window — caches refilling looks like a leak.
+func TestEvaluateContainerMemoryTrends_SkipsAfterRestart(t *testing.T) {
+	s := newTestStore(t)
+
+	now := time.Now()
+	for i := 0; i <= 180; i++ {
+		ts := now.Add(-time.Duration(180-i) * time.Minute)
+		mem := 500 + float64(i)*300.0/180.0 // would normally fire
+		insertContainerSnap(t, s, ts, "truffels-mempool-backend", mem, 1024)
+	}
+
+	oldestAllowed := time.Now().Add(-2 * time.Hour)
+	restarted := map[string]bool{"truffels-mempool-backend": true}
+	alerts := evaluateContainerMemoryTrends(s, 6, 6, oldestAllowed, restarted)
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts after restart, got %d", len(alerts))
 	}
 }
 

--- a/truffels-api/internal/compose/params.go
+++ b/truffels-api/internal/compose/params.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // Parameter structs for each compose template.
@@ -42,6 +43,11 @@ type TruffelsParams struct {
 	// as the build context for all three truffels images. Extracted from the
 	// agent's "- <path>:/repo:rw" volume line on disk.
 	RepoSrc string
+	// Version is the bare version string (e.g. "v0.3.1-dev.16") derived from
+	// the agent image tag. Used in build.args.VERSION so docker compose build
+	// (called by applySelfUpdate) sets the ldflag and OCI label correctly even
+	// when --build-arg is dropped by buildkit on a no-args compose block.
+	Version string
 }
 
 // repoSrcRe extracts the host path from a line like
@@ -135,11 +141,17 @@ func ExtractParams(serviceID, content string) (any, error) {
 		if repoSrc == "" {
 			return nil, fmt.Errorf("missing /repo:rw mount for truffels (extract RepoSrc)")
 		}
+		// Derive bare version from the agent image tag: truffels/agent:vX → vX.
+		version := agent
+		if idx := strings.LastIndex(agent, ":"); idx >= 0 {
+			version = agent[idx+1:]
+		}
 		return TruffelsParams{
 			AgentTag: agent,
 			APITag:   api,
 			WebTag:   web,
 			RepoSrc:  repoSrc,
+			Version:  version,
 		}, nil
 
 	default:

--- a/truffels-api/internal/compose/params_test.go
+++ b/truffels-api/internal/compose/params_test.go
@@ -209,6 +209,9 @@ func TestExtractParams_Truffels(t *testing.T) {
 	if tp.RepoSrc != "/home/truffel/Project-Truffels" {
 		t.Errorf("repo: %q", tp.RepoSrc)
 	}
+	if tp.Version != "v0.3.1-dev.14" {
+		t.Errorf("version: %q", tp.Version)
+	}
 }
 
 func TestExtractParams_Truffels_MissingRepoMount(t *testing.T) {

--- a/truffels-api/internal/compose/reconciler.go
+++ b/truffels-api/internal/compose/reconciler.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,12 +20,14 @@ var dockerfileMapping = map[string]string{
 
 // serviceIDs that have compose templates.
 //
-// "truffels" is special: its compose contains the API itself, so a normal
-// `compose up` would kill the running reconciler. The reconcileService path
-// dispatches to ComposeUpDetached for that ID — the agent writes a shell
-// script to host /tmp and execs it via nsenter, so the restart survives the
-// API process exiting.
-var reconciledServices = []string{"bitcoind", "electrs", "ckpool", "mempool", "ckstats", "proxy", "truffels"}
+// "truffels" is FIRST and dispatches to ComposeUpDetached when it needs a
+// restart — the agent writes a shell script to host /tmp and execs it via
+// nsenter, so the restart survives the API process exiting. By running it
+// first, the agent gets its new mounts (e.g. /srv/truffels/config:rw) before
+// any downstream service that depends on those mounts (e.g. proxy writing
+// the Caddyfile). On a detected truffels-compose drift we short-circuit the
+// loop entirely — the next API boot picks up the rest of the services.
+var reconciledServices = []string{"truffels", "bitcoind", "electrs", "ckpool", "mempool", "ckstats", "proxy"}
 
 // AlertStore is the subset of the store interface the reconciler needs to
 // surface reconciliation failures as alerts. Defined here (not imported) to
@@ -48,6 +51,12 @@ func NewReconciler(registry *service.Registry, compose *docker.ComposeClient, al
 }
 
 // Run reads each managed compose file, renders the expected content from templates,
+// errShortCircuit signals that the reconciler dispatched a detached restart
+// (truffels stack) — the API is about to be replaced, so the remaining
+// services should not be reconciled in this cycle. The next API boot picks
+// them up.
+var errShortCircuit = fmt.Errorf("reconciler: short-circuiting after detached restart")
+
 // and writes + restarts if different. Retries on agent connection failures.
 func (r *Reconciler) Run() error {
 	seen := map[string]bool{}
@@ -65,10 +74,17 @@ func (r *Reconciler) Run() error {
 		}
 		seen[tmpl.ComposeDir] = true
 
-		if err := r.reconcileService(serviceID); err != nil {
-			slog.Warn("compose reconciliation failed", "service", serviceID, "err", err)
-			errs = append(errs, fmt.Errorf("%s: %w", serviceID, err))
+		err := r.reconcileService(serviceID)
+		if err == nil {
+			continue
 		}
+		if errors.Is(err, errShortCircuit) {
+			slog.Info("reconciliation short-circuited; next boot will resume",
+				"after_service", serviceID)
+			return nil
+		}
+		slog.Warn("compose reconciliation failed", "service", serviceID, "err", err)
+		errs = append(errs, fmt.Errorf("%s: %w", serviceID, err))
 	}
 
 	if len(errs) > 0 {
@@ -149,6 +165,13 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 			// silently breaks the service while self-update reports success.
 			r.raiseAlert(serviceID, fmt.Sprintf("compose reconcile restart failed: %v", upErr))
 			return fmt.Errorf("restart after reconcile: %w", upErr)
+		}
+		if serviceID == "truffels" {
+			// The detached script is about to recreate the API. Any further
+			// reconciliation in this cycle would hit either the dying agent
+			// (connection refused) or the about-to-be-replaced agent (still
+			// using OLD mounts). The next API boot does a clean pass.
+			return errShortCircuit
 		}
 	}
 

--- a/truffels-api/internal/compose/reconciler.go
+++ b/truffels-api/internal/compose/reconciler.go
@@ -34,6 +34,7 @@ var reconciledServices = []string{"truffels", "bitcoind", "electrs", "ckpool", "
 // avoid an import cycle with internal/store.
 type AlertStore interface {
 	UpsertAlert(*model.Alert) error
+	ResolveAlerts(alertType, serviceID string) error
 }
 
 type Reconciler struct {
@@ -171,6 +172,7 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 			// reconciliation in this cycle would hit either the dying agent
 			// (connection refused) or the about-to-be-replaced agent (still
 			// using OLD mounts). The next API boot does a clean pass.
+			r.clearAlert(serviceID)
 			return errShortCircuit
 		}
 	}
@@ -180,6 +182,9 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 		r.reconcileDockerfile(serviceID, repoPath)
 	}
 
+	// All steps succeeded — clear any stale compose_reconcile_failed alert
+	// from a prior failed cycle so the UI doesn't show a phantom problem.
+	r.clearAlert(serviceID)
 	return nil
 }
 
@@ -196,6 +201,18 @@ func (r *Reconciler) raiseAlert(serviceID, msg string) {
 		Message:   msg,
 	}); err != nil {
 		slog.Error("failed to upsert reconcile alert", "service", serviceID, "err", err)
+	}
+}
+
+// clearAlert resolves any open compose_reconcile_failed alert for this
+// service. Called when reconciliation completes successfully so a stale
+// alert from a prior failed cycle doesn't linger forever in the UI.
+func (r *Reconciler) clearAlert(serviceID string) {
+	if r.alertStore == nil {
+		return
+	}
+	if err := r.alertStore.ResolveAlerts("compose_reconcile_failed", serviceID); err != nil {
+		slog.Warn("failed to resolve stale reconcile alert", "service", serviceID, "err", err)
 	}
 }
 

--- a/truffels-api/internal/compose/reconciler_test.go
+++ b/truffels-api/internal/compose/reconciler_test.go
@@ -183,13 +183,24 @@ func newMockAgentFull(t *testing.T, contents map[string]string,
 	}))
 }
 
-// captureAlertStore records UpsertAlert calls in memory for testing.
+// captureAlertStore records UpsertAlert + ResolveAlerts calls in memory for testing.
 type captureAlertStore struct {
-	alerts []*model.Alert
+	alerts   []*model.Alert
+	resolved []resolveCall
+}
+
+type resolveCall struct {
+	alertType string
+	serviceID string
 }
 
 func (c *captureAlertStore) UpsertAlert(a *model.Alert) error {
 	c.alerts = append(c.alerts, a)
+	return nil
+}
+
+func (c *captureAlertStore) ResolveAlerts(alertType, serviceID string) error {
+	c.resolved = append(c.resolved, resolveCall{alertType, serviceID})
 	return nil
 }
 
@@ -416,6 +427,52 @@ func TestReconciler_ProxyWritesBothComposeAndCaddyfile(t *testing.T) {
 	}
 	if !strings.Contains(caddy, "/proxy-health") {
 		t.Errorf("Caddyfile missing /proxy-health route: %s", caddy)
+	}
+}
+
+// TestReconciler_ResolvesAlertOnSuccess verifies a stale
+// compose_reconcile_failed alert is resolved when the next reconciliation
+// for that service completes successfully.
+func TestReconciler_ResolvesAlertOnSuccess(t *testing.T) {
+	ckpoolUnchanged := `services:
+  ckpool:
+    image: truffels/ckpool:v1.0.0
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/compose/read":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "content": ckpoolUnchanged,
+			})
+		case "/v1/compose/reconcile":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": false,
+			})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{ID: "ckpool", ComposeDir: "/srv/truffels/compose/ckpool"},
+	})
+	store := &captureAlertStore{}
+
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), store)
+	if err := reconciler.Run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, rc := range store.resolved {
+		if rc.alertType == "compose_reconcile_failed" && rc.serviceID == "ckpool" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ResolveAlerts(compose_reconcile_failed, ckpool); got %v", store.resolved)
 	}
 }
 

--- a/truffels-api/internal/compose/reconciler_test.go
+++ b/truffels-api/internal/compose/reconciler_test.go
@@ -242,6 +242,70 @@ func newMockAgentError(t *testing.T) *httptest.Server {
 	}))
 }
 
+// TestReconciler_TruffelsShortCircuitsLoop verifies that when truffels
+// reconciliation triggers a detached restart, no subsequent service is
+// reconciled in this cycle (the next API boot picks them up).
+func TestReconciler_TruffelsShortCircuitsLoop(t *testing.T) {
+	truffelsOld := `services:
+  agent:
+    image: truffels/agent:v0.3.1-dev.15
+    container_name: truffels-agent
+    volumes:
+      - /home/truffel/Project-Truffels:/repo:rw
+  api:
+    image: truffels/api:v0.3.1-dev.15
+    container_name: truffels-api
+  web:
+    image: truffels/web:v0.3.1-dev.15
+    container_name: truffels-web
+`
+	proxyOld := `services:
+  proxy:
+    image: caddy:2.11.2-alpine
+    container_name: truffels-proxy
+`
+	var proxyComposeReadCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/compose/read":
+			var req struct {
+				ServiceID string `json:"service_id"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.ServiceID == "proxy" {
+				proxyComposeReadCalled = true
+			}
+			content := truffelsOld
+			if req.ServiceID == "proxy" {
+				content = proxyOld
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "content": content,
+			})
+		case "/v1/compose/reconcile":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "ok", "changed": true,
+			})
+		case "/v1/compose/up-detached":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	reg := service.NewTestRegistry([]model.ServiceTemplate{
+		{ID: "truffels", ComposeDir: "/srv/truffels/compose/truffels"},
+		{ID: "proxy", ComposeDir: "/srv/truffels/compose/proxy"},
+	})
+	reconciler := NewReconciler(reg, docker.NewComposeClient(srv.URL), nil)
+	_ = reconciler.Run()
+
+	if proxyComposeReadCalled {
+		t.Error("proxy must NOT be reconciled when truffels triggered a short-circuit")
+	}
+}
+
 // TestReconciler_TruffelsTriggersDetachedRestart verifies that when the
 // truffels compose has drifted, the reconciler calls ComposeUpDetached
 // (so the API survives its own restart) rather than Up.

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -427,6 +427,8 @@ services:
     build:
       context: {{.RepoSrc}}/truffels-agent
       dockerfile: {{.RepoSrc}}/truffels-agent/Dockerfile
+      args:
+        VERSION: {{.Version}}
     image: {{.AgentTag}}
     container_name: truffels-agent
     pid: "host"
@@ -463,6 +465,8 @@ services:
     build:
       context: {{.RepoSrc}}/truffels-api
       dockerfile: {{.RepoSrc}}/truffels-api/Dockerfile
+      args:
+        VERSION: {{.Version}}
     image: {{.APITag}}
     container_name: truffels-api
     user: "1000:1000"
@@ -513,6 +517,8 @@ services:
     build:
       context: {{.RepoSrc}}/truffels-web
       dockerfile: {{.RepoSrc}}/truffels-web/Dockerfile
+      args:
+        VERSION: {{.Version}}
     image: {{.WebTag}}
     container_name: truffels-web
     restart: unless-stopped

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -319,6 +319,7 @@ services:
       - |
         CLEANUP_COUNTER=0
         while true; do
+          date +%s > /tmp/cron-last-run
           echo "[$(date)] Running seed..."
           pnpm seed 2>&1
           echo "[$(date)] Running update-users..."
@@ -335,6 +336,12 @@ services:
       resources:
         limits:
           memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "test $$(( $$(date +%s) - $$(cat /tmp/cron-last-run 2>/dev/null || echo 0) )) -lt 180"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
 
   ckstats-db:
     image: {{.DBImageTag}}

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -93,14 +93,18 @@ func TestRender_UnknownService(t *testing.T) {
 
 func TestRender_Truffels(t *testing.T) {
 	got, err := Render("truffels", TruffelsParams{
-		AgentTag: "truffels/agent:v0.3.1-dev.15",
-		APITag:   "truffels/api:v0.3.1-dev.15",
-		WebTag:   "truffels/web:v0.3.1-dev.15",
+		AgentTag: "truffels/agent:v0.3.1-dev.16",
+		APITag:   "truffels/api:v0.3.1-dev.16",
+		WebTag:   "truffels/web:v0.3.1-dev.16",
 		RepoSrc:  "/home/truffel/Project-Truffels",
+		Version:  "v0.3.1-dev.16",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	// dev.16: build.args.VERSION must be present so docker compose build sets
+	// the ldflag + OCI label correctly even when buildkit drops --build-arg.
+	assertContains(t, got, "VERSION: v0.3.1-dev.16")
 	// The dev.15 mount fix is the whole point — verify it's there.
 	assertContains(t, got, "/srv/truffels/data:/srv/truffels/data:rw")
 	assertContains(t, got, "TRUFFELS_DATA_ROOT")
@@ -108,9 +112,9 @@ func TestRender_Truffels(t *testing.T) {
 	assertContains(t, got, "/srv/truffels/config:/srv/truffels/config:rw")
 	assertContains(t, got, "TRUFFELS_CONFIG_ROOT")
 	// Image tags from params land in the rendered output.
-	assertContains(t, got, "image: truffels/agent:v0.3.1-dev.15")
-	assertContains(t, got, "image: truffels/api:v0.3.1-dev.15")
-	assertContains(t, got, "image: truffels/web:v0.3.1-dev.15")
+	assertContains(t, got, "image: truffels/agent:v0.3.1-dev.16")
+	assertContains(t, got, "image: truffels/api:v0.3.1-dev.16")
+	assertContains(t, got, "image: truffels/web:v0.3.1-dev.16")
 	// Build contexts pick up RepoSrc.
 	assertContains(t, got, "context: /home/truffel/Project-Truffels/truffels-agent")
 	assertContains(t, got, "context: /home/truffel/Project-Truffels/truffels-api")

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -68,6 +68,10 @@ func TestRender_Ckstats(t *testing.T) {
 	assertContains(t, got, "image: truffels/ckstats:latest")
 	assertContains(t, got, "image: postgres:16.13-alpine")
 	assertContains(t, got, "container_name: truffels-ckstats-db")
+	// dev.16: ckstats-cron now has a healthcheck (sentinel-file mtime probe)
+	// so a wedged loop is visible instead of silently "running".
+	assertContains(t, got, "cron-last-run")
+	assertContains(t, got, "start_period: 120s")
 }
 
 func TestRender_Proxy(t *testing.T) {

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -722,6 +722,11 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 			e.alertUpdateFailed(serviceID, "build failed ("+svc+"): "+err.Error())
 			return &UpdateError{Msg: "build failed (" + svc + "): " + err.Error()}
 		}
+		// The truffelsTemplate.build.args.VERSION block (added in dev.16)
+		// is the primary mechanism that gets VERSION into the binary's
+		// ldflag and the image's OCI version label. A post-build label
+		// verification would be defense-in-depth but requires a new
+		// agent-side endpoint to expose image labels — tracked for dev.17+.
 	}
 
 	// Step 4: Detached restart — agent calls docker compose up -d via nsenter

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -734,6 +734,7 @@ function SystemInfoTab() {
       {data.docker_storage && data.docker_storage.length > 0 && (
         <Card>
           <CardTitle>Docker Storage</CardTitle>
+          <p className="text-xs text-gray-500 italic mb-2">Refreshed every 5 minutes. Manual actions update immediately.</p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -814,9 +815,10 @@ function SystemInfoTab() {
       {serviceDataRows.length > 0 && (
         <Card>
           <CardTitle>Service Data Storage</CardTitle>
-          <p className="text-xs text-gray-500 mb-3">
+          <p className="text-xs text-gray-500 mb-1">
             Per-service host data under <span className="font-mono">/srv/truffels/data/</span>. Caches can be cleared; persistent state cannot.
           </p>
+          <p className="text-xs text-gray-500 italic mb-3">Refreshed every 5 minutes. Clearing a directory updates immediately.</p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>


### PR DESCRIPTION
## Summary

dev.15 self-updated successfully on the prod pi, but the first boot left a critical `compose_reconcile_failed` alert that never auto-resolved (Caddyfile write transiently failed against the still-`:ro` agent mount, which the second boot fixed silently). The user also noticed:
- spurious `+5249 MB/h` memory trend alerts right after the mempool restart
- Host → Info loading in ~9 s (mostly `docker system df`)
- `ckpool` and `Truffels` rows showed `—` in Service Data Storage
- `truffels-ckstats-cron` has no healthcheck

This PR addresses all seven items so dev.15 → dev.16 is a quiet, clean transition.

## Bugs fixed

**A — Reconciler order + short-circuit.** `truffels` now runs FIRST in `reconciledServices`. When it detects compose drift and triggers `ComposeUpDetached`, the loop short-circuits via `errShortCircuit` sentinel — subsequent services would otherwise hit the dying agent (still on OLD mounts). The next API boot resumes from a clean state.

**B — Auto-resolve `compose_reconcile_failed` alerts.** New `AlertStore.ResolveAlerts(type, serviceID)` method; reconciler calls `clearAlert` on every successful service reconcile so stale alerts from prior cycles auto-dismiss.

**C — VERSION ldflag via build.args.** dev.15's `truffelsTemplate` dropped the `build.args.VERSION` block install.sh had. buildkit silently ignored the CLI `--build-arg` and the resulting image had `main.version = "dev"` and OCI label = `"dev"`. Added `args: { VERSION: {{.Version}} }` to all three build blocks; `TruffelsParams.Version` extracted from the agent image tag.

**D — `truffels-ckstats-cron` healthcheck.** Loop now touches `/tmp/cron-last-run` with `date +%s` at each iteration; healthcheck fails if mtime is >180 s old (3× the 60 s loop period, with slack for the every-2h `pnpm cleanup`).

**E — Container memory trend false positives.** `evaluateContainerMemoryTrends` now gates on `min_data_hours` (parity with host trends — was missing in dev.15) AND skips containers that restarted within the lookback window (cache refill ≠ leak). Closes #6.

**F — Cache `docker system df` for 5 min.** `/v1/system/info` was 8.9 s, ~7 s of which was `docker system df`. New `dockerStorageCache` with 5-min TTL; invalidated on `handleDockerPrune` / `handleDockerPruneBuildCache` so manual actions take effect immediately. Frontend adds italic subtitle on both Docker Storage and Service Data Storage cards explaining the cadence.

**G — Walker indexes top-level service dirs.** Templates declaring 1-level paths (`/srv/truffels/data/ckpool`, `/srv/truffels/data/truffels`) showed `—` because dev.15's walker only indexed 2-level leaves. Walker now sets BOTH the parent and the children.

## Test plan

- [x] `go test ./...` in `truffels-api` + `truffels-agent` — all green.
- [x] `vitest run` + `tsc --noEmit` in `truffels-web` — 65/65 + clean.
- [ ] After merge: cut v0.3.1-dev.16 prerelease via `gh release create --prerelease --notes-file`.
- [ ] Self-update from dev.15. Verify: single boot reconciliation log (truffels-only short-circuit log), no `compose_reconcile_failed` in alerts; existing stale alert from dev.15 auto-resolves; `/api/truffels/health` reports `v0.3.1-dev.16`; Settings → Info loads in <1 s; ckpool and Truffels rows show sizes; no `+5249 MB/h` trend warnings after the mempool restart settles.
- [ ] Close #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)