### PR TITLE
v0.3.1-dev.18 hotfix — Docker build retries, instant trend gate, version-selector source gate, visible code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,10 +36,40 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           use_sticky_comment: 'true'
+          # dev.18: the `code-review` plugin ran in inline-comment-only mode
+          # and posted nothing when it had nothing to flag — no signal whether
+          # the review actually ran. Replace with an inline `prompt:` (plain
+          # text, no slash command) that always produces a sticky summary
+          # comment, so we have a visible verdict per PR.
+          prompt: |
+            Review this pull request. Look for:
+            - Correctness bugs and logic errors
+            - Security issues (path traversal, injection, secret leaks, auth bypass)
+            - Concurrency / race conditions
+            - Resource leaks (file handles, goroutines, network connections)
+            - Breaking changes to public APIs or stored data formats
+            - Tests that don't actually test the behaviour they claim to
+            - Personally Identifiable Information accidentally introduced in code,
+              tests, fixtures, comments, or commit messages: real names, real
+              email addresses (anything that's not the project's GitHub noreply
+              identity `*@users.noreply.github.com`), phone numbers, physical
+              addresses, IP addresses other than RFC1918 / loopback, API keys,
+              passwords, or other secrets.
+
+            Post ONE sticky summary comment with this structure:
+            - Start with a one-line verdict: `**LGTM**` or `**Concerns flagged below**`.
+            - If concerns: list each as `- <file>:<line> — <issue>` with the smallest fix you can suggest.
+            - If none: briefly note what you actually checked (which files, which classes of bug) so the author knows you reviewed — don't just say "looks good."
+
+            CRITICAL: do NOT include any of the PII you find in the comment.
+            Flag its presence by file:line and category only (e.g.
+            "fixtures/user.json:14 — appears to contain a real email address;
+            replace with a noreply identity"). Never echo the value itself.
+            This applies to anything that looks like PII even if it's in a test
+            fixture or a comment.
+
+            Be terse. Skip style / formatting nitpicks the linter would catch.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/dockerfiles/ckpool/Dockerfile
+++ b/dockerfiles/ckpool/Dockerfile
@@ -1,21 +1,36 @@
 # ckpool v1.0.0 — multi-stage build for arm64
 FROM debian:bookworm-slim AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git build-essential autoconf automake libtool pkg-config \
-    libczmq-dev ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# retry() wraps a command in 3 attempts with backoff so a transient flake on
+# deb.debian.org or bitbucket.org doesn't kill the whole build.
+RUN set -e; \
+    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends \
+        git build-essential autoconf automake libtool pkg-config \
+        libczmq-dev ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone --depth 1 --branch v1.0.0 https://bitbucket.org/ckolivas/ckpool.git .
+# git clone retry — wipe any partial state between attempts so the next clone
+# can write into the empty working tree.
+RUN set -e; \
+    for i in 1 2 3; do \
+        rm -rf .git ./* 2>/dev/null || true; \
+        git clone --depth 1 --branch v1.0.0 https://bitbucket.org/ckolivas/ckpool.git . && break; \
+        [ $i -eq 3 ] && exit 1; \
+        sleep $((i*2)); \
+    done
 RUN ./autogen.sh && ./configure && make -j$(nproc)
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libczmq4 \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd -g 1000 ckpool \
-    && useradd -u 1000 -g ckpool -s /usr/sbin/nologin ckpool
+RUN set -e; \
+    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends libczmq4 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 1000 ckpool && \
+    useradd -u 1000 -g ckpool -s /usr/sbin/nologin ckpool
 
 COPY --from=builder /build/src/ckpool /usr/local/bin/ckpool
 COPY --from=builder /build/src/ckpmsg /usr/local/bin/ckpmsg

--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -6,8 +6,8 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 COPY ckpoolstats/package.json ckpoolstats/pnpm-lock.yaml ckpoolstats/pnpm-workspace.yaml* ./
-RUN pnpm install --no-frozen-lockfile
-RUN pnpm add dotenv
+RUN pnpm install --no-frozen-lockfile || (sleep 2 && pnpm install --no-frozen-lockfile) || (sleep 5 && pnpm install --no-frozen-lockfile)
+RUN pnpm add dotenv || (sleep 2 && pnpm add dotenv) || (sleep 5 && pnpm add dotenv)
 
 COPY ckpoolstats/ ./
 
@@ -25,9 +25,13 @@ FROM node:22-slim
 
 ENV CI=true
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cron postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+# retry() wraps apt-get in 3 attempts with backoff so a transient flake on
+# deb.debian.org doesn't kill the whole build.
+RUN set -e; \
+    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends cron postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY --from=builder /app/.next ./.next

--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.17}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.18}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/Dockerfile
+++ b/truffels-agent/Dockerfile
@@ -9,16 +9,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}
 FROM debian:bookworm-slim
 ARG VERSION=dev
 LABEL org.opencontainers.image.version="${VERSION}"
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl gnupg wget git \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
-    && chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
-       > /etc/apt/sources.list.d/docker.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
-    && rm -rf /var/lib/apt/lists/*
+# retry() wraps a command in 3 attempts with backoff so a transient flake on
+# deb.debian.org or download.docker.com doesn't kill the whole build.
+# Inline because Dockerfile RUN steps don't share shell state across layers.
+RUN set -e; \
+    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg wget git && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL --retry 3 --retry-delay 2 --retry-max-time 60 \
+        https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list && \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
 RUN git config --global --add safe.directory /repo
 COPY --from=builder /truffels-agent /usr/local/bin/truffels-agent
 ENTRYPOINT ["truffels-agent"]

--- a/truffels-api/Dockerfile
+++ b/truffels-api/Dockerfile
@@ -11,8 +11,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}
 FROM debian:bookworm-slim
 ARG VERSION=dev
 LABEL org.opencontainers.image.version="${VERSION}"
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates wget && \
+# retry() wraps a command in 3 attempts with backoff so a transient flake on
+# deb.debian.org doesn't kill the whole build.
+RUN set -e; \
+    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /truffels-api /usr/local/bin/truffels-api

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -60,6 +60,12 @@ func NewEngine(s *store.Store, r *service.Registry, c *metrics.Collector, compos
 		prevStates:         make(map[string]model.ContainerState),
 		prevContainerStats: make(map[string]docker.ContainerResourceStats),
 		containerStartedAt: make(map[string]time.Time),
+		// Initialize snapshotTick to 9 so the first ++ on first evaluate
+		// makes it 10 — triggering both the metric-snapshot (%2==0) AND
+		// the trend check (%10==0) immediately. Otherwise stale memory_trend
+		// alerts from the prior engine instance linger for up to 5 min
+		// (one full trend tick window) after every truffels self-update.
+		snapshotTick: 9,
 	}
 }
 

--- a/truffels-api/internal/alerts/engine_test.go
+++ b/truffels-api/internal/alerts/engine_test.go
@@ -171,6 +171,21 @@ func TestEngine_StartStop(t *testing.T) {
 	// Should not panic or hang
 }
 
+// dev.18: NewEngine seeds snapshotTick=9 so the first evaluate() runs the
+// trend check (tick%10==0). Otherwise stale memory_trend alerts hang
+// around for ~5 min after every engine restart (truffels self-update).
+func TestNewEngine_SeedsSnapshotTickForImmediateTrend(t *testing.T) {
+	s := newTestStore(t)
+	e := NewEngine(s, nil, nil, nil)
+	if e.snapshotTick != 9 {
+		t.Errorf("expected snapshotTick=9 after NewEngine, got %d", e.snapshotTick)
+	}
+	// One increment in evaluate() makes it 10. 10%10==0 → trend check runs.
+	if (e.snapshotTick+1)%10 != 0 {
+		t.Errorf("first evaluate must hit the trend check window (tick+1=%d, want %% 10 == 0)", e.snapshotTick+1)
+	}
+}
+
 // --- Restart loop detection ---
 
 func newTestEngine(t *testing.T) (*Engine, *store.Store) {

--- a/truffels-api/internal/api/updates.go
+++ b/truffels-api/internal/api/updates.go
@@ -13,16 +13,30 @@ import (
 	"truffels-api/internal/model"
 )
 
+// UpdateCheckResponse adds the service's UpdateSource.Type to the on-the-wire
+// UpdateCheck so the frontend can gate the version-selector dropdown on
+// "dockerhub" sources only. SHA-based sources (github, bitbucket) and
+// floating-tag (docker_digest) sources don't have meaningful pickable versions.
+type UpdateCheckResponse struct {
+	model.UpdateCheck
+	SourceType string `json:"source_type,omitempty"`
+}
+
 func (s *Server) handleGetUpdates(w http.ResponseWriter, r *http.Request) {
 	checks, err := s.store.GetAllUpdateChecks()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if checks == nil {
-		checks = []model.UpdateCheck{}
+	resp := make([]UpdateCheckResponse, 0, len(checks))
+	for _, c := range checks {
+		entry := UpdateCheckResponse{UpdateCheck: c}
+		if tmpl, ok := s.registry.Get(c.ServiceID); ok && tmpl.UpdateSource != nil {
+			entry.SourceType = string(tmpl.UpdateSource.Type)
+		}
+		resp = append(resp, entry)
 	}
-	writeJSON(w, http.StatusOK, checks)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) handleCheckUpdates(w http.ResponseWriter, r *http.Request) {

--- a/truffels-api/internal/api/updates_test.go
+++ b/truffels-api/internal/api/updates_test.go
@@ -419,6 +419,46 @@ func TestUpdatesEndpoints_RequireAuth(t *testing.T) {
 	}
 }
 
+// dev.18: /updates response carries source_type so the frontend can gate
+// the version selector dropdown on DockerHub-only.
+func TestGetUpdates_IncludesSourceType(t *testing.T) {
+	srv, st, _ := newTestServerWithEngine(t)
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "bitcoind",
+		CurrentVersion: "30.0",
+		LatestVersion:  "31.0",
+		HasUpdate:      true,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "481f4cfe348e",
+		LatestVersion:  "a01fcb3e0a53",
+		HasUpdate:      true,
+	})
+
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "GET", "/api/truffels/updates", "")
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	// Parse as []map so we can inspect arbitrary fields including source_type.
+	var resp []map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	sourceTypes := map[string]string{}
+	for _, c := range resp {
+		sid, _ := c["service_id"].(string)
+		st, _ := c["source_type"].(string)
+		sourceTypes[sid] = st
+	}
+	if sourceTypes["bitcoind"] != "dockerhub" {
+		t.Errorf("bitcoind source_type: got %q want dockerhub", sourceTypes["bitcoind"])
+	}
+	if sourceTypes["ckpool"] != "bitbucket" {
+		t.Errorf("ckpool source_type: got %q want bitbucket", sourceTypes["ckpool"])
+	}
+}
+
 // dev.17: version selector endpoint
 func TestGetUpdateVersions_UnknownService(t *testing.T) {
 	srv, _, _ := newTestServerWithEngine(t)

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -195,6 +195,10 @@ export interface UpdateCheck {
   has_update: boolean
   checked_at: string
   error?: string
+  // dev.18: gates the version-selector dropdown to "dockerhub" only.
+  // SHA-based sources (github, bitbucket) and floating-tag (docker_digest)
+  // don't have meaningful pickable versions.
+  source_type?: string
 }
 
 export interface UpdateLog {

--- a/truffels-web/src/pages/UpdatesPage.tsx
+++ b/truffels-web/src/pages/UpdatesPage.tsx
@@ -366,8 +366,10 @@ export default function UpdatesPage() {
                       </span>
                     )}
                     {/* dev.17: version selector dropdown (DockerHub services only).
-                        Lazy-fetches on first interaction. Defaults to latest. */}
-                    {!isDigest && !floating && (
+                        Lazy-fetches on first interaction. Defaults to latest.
+                        dev.18: gated on source_type==='dockerhub' so commit-SHA
+                        sources (github, bitbucket) don't show a misleading dropdown. */}
+                    {!isDigest && !floating && c.source_type === 'dockerhub' && (
                       <select
                         onFocus={() => ensureVersions(c.service_id)}
                         onMouseDown={() => ensureVersions(c.service_id)}
@@ -424,6 +426,22 @@ export default function UpdatesPage() {
                           className="px-3 py-1.5 text-sm rounded transition-colors disabled:opacity-50 bg-blue-500/20 hover:bg-blue-500/30 text-blue-400"
                         >
                           {actionPending === c.service_id ? 'Updating...' : 'Pull & Restart'}
+                        </button>
+                      )
+                    }
+                    // dev.18: non-DockerHub sources (github commit SHAs,
+                    // bitbucket commit SHAs, github-release) — fall back to
+                    // the dev.16 simple Update button on has_update. Version
+                    // comparison doesn't apply to SHAs and would mis-classify.
+                    if (c.source_type !== 'dockerhub') {
+                      if (!c.has_update) return null
+                      return (
+                        <button
+                          onClick={() => handlePreflight(c.service_id)}
+                          disabled={actionPending !== null || preflightLoading !== null}
+                          className="px-3 py-1.5 text-sm rounded transition-colors disabled:opacity-50 bg-accent/20 hover:bg-accent/30 text-accent"
+                        >
+                          {preflightLoading === c.service_id ? 'Checking...' : actionPending === c.service_id ? 'Updating...' : 'Update'}
                         </button>
                       )
                     }


### PR DESCRIPTION
## Summary

Four targeted fixes from dev.17 observations:

1. **Docker build flake** — dev.16→dev.17 self-update failed once on `apt-get install docker-ce-cli` (download.docker.com hiccup). The Dockerfile only had retry on `go mod download`.
2. **Memory trend alerts STILL showed post-update** — the dev.17 gate code is correct, but `checkTrends` only runs every 10th evaluate tick (~5 min) and the first eval on a fresh engine doesn't hit the window. Stale alerts hung around for up to 5 min before resolution.
3. **ckpool version selector said "Downgrade"** — bitbucket commit-SHA source, parseVersion(SHA) returned `[]` vs `[481]` depending on whether the SHA started with a digit. Selector should only apply to DockerHub-style semver tags.
4. **claude-code-review workflow runs ~7 min per PR and posts nothing** — the `code-review` plugin runs in inline-comment-only mode. When Claude has nothing to flag (every PR so far), the buffer is empty and no comment is posted. No signal whether the review actually ran.

## Changes

- **A — Dockerfile retries** in `truffels-agent`, `truffels-api`, `ckpool`, `ckstats`. Inline POSIX `retry()` shell function (3 attempts, 2/4/6 s backoff) for apt-get blocks. curl's built-in `--retry 3 --retry-delay 2 --retry-max-time 60` for the Docker GPG fetch. git clone wrapped in a wipe-and-retry loop so a partial clone doesn't poison retry #2. Pure resilience, no behavior change.
- **B — `snapshotTick: 9`** seeded in `NewEngine`. First evaluate's `++` makes it 10, triggering both metric snapshot (%2) and trend check (%10) immediately. Stale alerts resolve within ~5 s of engine startup instead of up to 5 min.
- **C — `source_type` in /updates response**. New `UpdateCheckResponse` wrapper struct (no DB change). Frontend gates dropdown + dynamic-button logic on `source_type === 'dockerhub'`. Non-DockerHub sources (github, bitbucket, github-release) get the dev.16 simple Update button. Floating-tag services keep Pull & Restart.
- **D — `direct_prompt` in the review workflow**. Drops the `code-review` plugin; uses an inline prompt that always produces a sticky summary comment ("LGTM" or "Concerns flagged below" with file:line callouts). Skips plugin-install step too — ~10 s faster start.

## Test plan

- [x] `go test ./...` in `truffels-api` + `truffels-agent` — all green.
- [x] `vitest run` + `tsc --noEmit` in `truffels-web` — 65/65 + clean.
- [ ] After merge: cut v0.3.1-dev.18 prerelease.
- [ ] **D** verification immediate — this PR's own claude-review run should post a sticky summary comment. If it does, the prompt works.
- [ ] **B** verification within 30 s of dev.18 boot — `curl /api/truffels/alerts | jq '.[] | select(.type=="memory_trend")'` returns empty.
- [ ] **C** verification on dev.18 UI — ckpool row has no version dropdown, bitcoind row does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)