### PR TITLE
dev.19: build resilience + version-selector regression fix

### DIFF
--- a/dockerfiles/ckpool/Dockerfile
+++ b/dockerfiles/ckpool/Dockerfile
@@ -1,10 +1,10 @@
 # ckpool v1.0.0 — multi-stage build for arm64
 FROM debian:bookworm-slim AS builder
 
-# retry() wraps a command in 3 attempts with backoff so a transient flake on
-# deb.debian.org or bitbucket.org doesn't kill the whole build.
+# retry() wraps a command in 4 attempts with 10/30/60s backoff so a transient
+# flake on deb.debian.org or bitbucket.org doesn't kill the whole build.
 RUN set -e; \
-    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
     retry apt-get update && \
     retry apt-get install -y --no-install-recommends \
         git build-essential autoconf automake libtool pkg-config \
@@ -13,19 +13,23 @@ RUN set -e; \
 
 WORKDIR /build
 # git clone retry — wipe any partial state between attempts so the next clone
-# can write into the empty working tree.
+# can write into the empty working tree. 4 attempts with 10/30/60s backoff.
 RUN set -e; \
-    for i in 1 2 3; do \
+    attempt=1; \
+    for delay in 0 10 30 60; do \
+        [ $delay -gt 0 ] && sleep $delay; \
         rm -rf .git ./* 2>/dev/null || true; \
-        git clone --depth 1 --branch v1.0.0 https://bitbucket.org/ckolivas/ckpool.git . && break; \
-        [ $i -eq 3 ] && exit 1; \
-        sleep $((i*2)); \
+        if git clone --depth 1 --branch v1.0.0 https://bitbucket.org/ckolivas/ckpool.git .; then \
+            break; \
+        fi; \
+        attempt=$((attempt+1)); \
+        [ $attempt -gt 4 ] && exit 1; \
     done
 RUN ./autogen.sh && ./configure && make -j$(nproc)
 
 FROM debian:bookworm-slim
 RUN set -e; \
-    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
     retry apt-get update && \
     retry apt-get install -y --no-install-recommends libczmq4 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -6,8 +6,8 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 COPY ckpoolstats/package.json ckpoolstats/pnpm-lock.yaml ckpoolstats/pnpm-workspace.yaml* ./
-RUN pnpm install --no-frozen-lockfile || (sleep 2 && pnpm install --no-frozen-lockfile) || (sleep 5 && pnpm install --no-frozen-lockfile)
-RUN pnpm add dotenv || (sleep 2 && pnpm add dotenv) || (sleep 5 && pnpm add dotenv)
+RUN pnpm install --no-frozen-lockfile || (sleep 10 && pnpm install --no-frozen-lockfile) || (sleep 30 && pnpm install --no-frozen-lockfile) || (sleep 60 && pnpm install --no-frozen-lockfile)
+RUN pnpm add dotenv || (sleep 10 && pnpm add dotenv) || (sleep 30 && pnpm add dotenv) || (sleep 60 && pnpm add dotenv)
 
 COPY ckpoolstats/ ./
 
@@ -25,10 +25,11 @@ FROM node:22-slim
 
 ENV CI=true
 RUN corepack enable && corepack prepare pnpm@latest --activate
-# retry() wraps apt-get in 3 attempts with backoff so a transient flake on
-# deb.debian.org doesn't kill the whole build.
+# retry() wraps apt-get in 4 attempts with 10/30/60s backoff so a transient
+# flake on deb.debian.org doesn't kill the whole build. Total worst-case sleep
+# budget: 100s before giving up.
 RUN set -e; \
-    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
     retry apt-get update && \
     retry apt-get install -y --no-install-recommends cron postgresql-client && \
     rm -rf /var/lib/apt/lists/*

--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.18}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.19}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/Dockerfile
+++ b/truffels-agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.24-bookworm AS builder
 WORKDIR /src
 COPY go.mod ./
-RUN go mod download || (sleep 2 && go mod download) || (sleep 5 && go mod download)
+RUN go mod download || (sleep 10 && go mod download) || (sleep 30 && go mod download) || (sleep 60 && go mod download)
 COPY . .
 ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}" -o /truffels-agent .
@@ -9,16 +9,18 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}
 FROM debian:bookworm-slim
 ARG VERSION=dev
 LABEL org.opencontainers.image.version="${VERSION}"
-# retry() wraps a command in 3 attempts with backoff so a transient flake on
-# deb.debian.org or download.docker.com doesn't kill the whole build.
+# retry() wraps a command in 4 attempts with 10/30/60s backoff so a transient
+# flake on deb.debian.org or download.docker.com doesn't kill the whole build.
 # Inline because Dockerfile RUN steps don't share shell state across layers.
+# Total worst-case sleep budget: 100s before giving up — long enough to ride
+# through most CDN hiccups without making a happy-path build feel slow.
 RUN set -e; \
-    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
     retry apt-get update && \
     retry apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg wget git && \
     install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL --retry 3 --retry-delay 2 --retry-max-time 60 \
+    curl -fsSL --retry 4 --retry-delay 10 --retry-max-time 120 \
         https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -720,6 +720,16 @@ type buildRequest struct {
 	Services  []string          `json:"services,omitempty"` // compose service names to build (empty = all)
 }
 
+// composeBuildMaxAttempts is the number of times handleComposeBuild will
+// re-run `docker compose build` if it fails. Tuned at 3 — with layer cache
+// enabled (no --no-cache), retries resume from the cached layer just before
+// the failed RUN step, so the cost of an extra attempt is low. Most transient
+// network flakes (download.docker.com, deb.debian.org, registry.npmjs.org)
+// are handled inside Dockerfiles via the retry shell function; this is the
+// outer safety net for flakes that outlast the in-Dockerfile budget.
+const composeBuildMaxAttempts = 3
+const composeBuildRetrySleep = 30 * time.Second
+
 func handleComposeBuild(w http.ResponseWriter, r *http.Request) {
 	var req buildRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -735,25 +745,47 @@ func handleComposeBuild(w http.ResponseWriter, r *http.Request) {
 	dir := composeDir(req.ServiceID)
 	slog.Info("building service", "service", req.ServiceID, "dir", dir)
 
+	// 20 min total budget covers 3 build attempts + 2x 30s sleeps. With layer
+	// cache enabled (--no-cache removed in dev.19), retries are typically
+	// fast because successful layers stay cached.
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	dockerArgs := []string{"docker", "compose", "-f", dir + "/docker-compose.yml", "build", "--no-cache"}
+	dockerArgs := []string{"docker", "compose", "-f", dir + "/docker-compose.yml", "build"}
 	for k, v := range req.BuildArgs {
 		dockerArgs = append(dockerArgs, "--build-arg", k+"="+v)
 	}
 	dockerArgs = append(dockerArgs, req.Services...)
-	// Run via nsenter so build-context paths resolve on the host filesystem
+	// Run via nsenter so build-context paths resolve on the host filesystem.
 	nsArgs := append([]string{"-t", "1", "-m", "--"}, dockerArgs...)
-	cmd := exec.CommandContext(ctx, "nsenter", nsArgs...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out.String()})
-		return
+
+	var lastErr error
+	var lastOutput string
+	for attempt := 1; attempt <= composeBuildMaxAttempts; attempt++ {
+		var out bytes.Buffer
+		cmd := exec.CommandContext(ctx, "nsenter", nsArgs...)
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		if err == nil {
+			writeJSON(w, 200, map[string]string{"status": "ok", "output": out.String()})
+			return
+		}
+		lastErr = err
+		lastOutput = out.String()
+		slog.Warn("compose build failed", "service", req.ServiceID, "attempt", attempt, "max", composeBuildMaxAttempts, "error", err.Error())
+		if attempt < composeBuildMaxAttempts {
+			select {
+			case <-ctx.Done():
+			case <-time.After(composeBuildRetrySleep):
+			}
+		}
 	}
-	writeJSON(w, 200, map[string]string{"status": "ok", "output": out.String()})
+	writeJSON(w, 500, map[string]string{
+		"error":    lastErr.Error(),
+		"output":   lastOutput,
+		"attempts": fmt.Sprint(composeBuildMaxAttempts),
+	})
 }
 
 // --- Helpers ---
@@ -817,10 +849,11 @@ func handleSystemRestart(w http.ResponseWriter, r *http.Request) {
 // --- System Info ---
 
 type dockerStorageItem struct {
-	Type        string `json:"type"`
-	Count       int    `json:"count"`
-	TotalSize   string `json:"total_size"`
-	Reclaimable string `json:"reclaimable"`
+	Type           string `json:"type"`
+	Count          int    `json:"count"`
+	TotalSize      string `json:"total_size"`
+	Reclaimable    string `json:"reclaimable"`
+	ReclaimableRaw int64  `json:"reclaimable_raw"` // bytes — for client-side threshold gates
 }
 
 type systemInfoResponse struct {
@@ -987,6 +1020,14 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 	// Service data: serve sizes from the background cache. Paths not yet
 	// walked return "calculating..." with SizeRaw: -1 so the frontend can
 	// render the row immediately and show a placeholder.
+	//
+	// We emit BOTH the top-level service path and any 2-level child dirs.
+	// Templates declare data dirs at either granularity:
+	//   - 1-level: ckpool (/srv/truffels/data/ckpool), truffels
+	//   - 2-level: bitcoind (.../bitcoin/blockchain), electrs, mempool, ckstats
+	// dev.18 only emitted child rows when child dirs existed, so 1-level
+	// templates got a "—" in the UI. Frontend filters by template path so
+	// extra rows are harmless.
 	var serviceData []serviceDataItem
 	if entries, err := os.ReadDir(dataRoot); err == nil {
 		for _, e := range entries {
@@ -994,10 +1035,6 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			servicePath := filepath.Join(dataRoot, e.Name())
-			children, err := os.ReadDir(servicePath)
-			if err != nil {
-				continue
-			}
 			addRow := func(full string) {
 				if sizeCache == nil {
 					serviceData = append(serviceData, serviceDataItem{
@@ -1020,8 +1057,9 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 					Path: full, Size: sizeStr, SizeRaw: size,
 				})
 			}
-			if len(children) == 0 {
-				addRow(servicePath)
+			addRow(servicePath)
+			children, err := os.ReadDir(servicePath)
+			if err != nil {
 				continue
 			}
 			for _, child := range children {
@@ -1169,11 +1207,18 @@ func fetchDockerStorage() []dockerStorageItem {
 		}
 		if err := json.Unmarshal([]byte(line), &raw); err == nil {
 			count, _ := strconv.Atoi(raw.TotalCount)
+			// Strip " (NN%)" trailer (docker appends this to Images/Containers/Volumes
+			// rows but not Build Cache). parseBytes needs a plain "47.33GB" string.
+			reclaimRaw := raw.Reclaimable
+			if i := strings.Index(reclaimRaw, " ("); i > 0 {
+				reclaimRaw = reclaimRaw[:i]
+			}
 			items = append(items, dockerStorageItem{
-				Type:        raw.Type,
-				Count:       count,
-				TotalSize:   formatSize(raw.Size),
-				Reclaimable: formatSize(raw.Reclaimable),
+				Type:           raw.Type,
+				Count:          count,
+				TotalSize:      formatSize(raw.Size),
+				Reclaimable:    formatSize(raw.Reclaimable),
+				ReclaimableRaw: int64(parseBytes(reclaimRaw)),
 			})
 		}
 	}

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -728,6 +729,80 @@ func TestHandleSystemInfo_ReturnsJSON(t *testing.T) {
 	if resp.CPUCores < 0 {
 		t.Fatal("cpu_cores should not be negative")
 	}
+}
+
+// dev.19: when a service data dir has no child subdirectories (only files,
+// e.g. truffels/truffels.db) OR has only one child (e.g. ckpool/logs),
+// the top-level service path must still be emitted as a row so 1-level
+// template paths (ckpool, truffels) get a hit instead of "—" in the UI.
+func TestHandleSystemInfo_EmitsTopLevelServiceDataPath(t *testing.T) {
+	tmpRoot := t.TempDir()
+	// Set up data dirs that mirror real-world cases:
+	//   - "ckpool" with a single child dir "logs"
+	//   - "truffels" with only a file (no child dirs)
+	//   - "bitcoin" with a child dir "blockchain" (2-level template path)
+	if err := os.MkdirAll(filepath.Join(tmpRoot, "ckpool", "logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpRoot, "truffels"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpRoot, "truffels", "truffels.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpRoot, "bitcoin", "blockchain"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prevRoot := dataRoot
+	prevCache := sizeCache
+	dataRoot = tmpRoot
+	sizeCache = newDirSizeCache()
+	// Seed cache so paths return real sizes instead of "calculating..."
+	for _, p := range []string{
+		filepath.Join(tmpRoot, "ckpool"),
+		filepath.Join(tmpRoot, "ckpool", "logs"),
+		filepath.Join(tmpRoot, "truffels"),
+		filepath.Join(tmpRoot, "bitcoin"),
+		filepath.Join(tmpRoot, "bitcoin", "blockchain"),
+	} {
+		sizeCache.set(p, 1024)
+	}
+	defer func() {
+		dataRoot = prevRoot
+		sizeCache = prevCache
+	}()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/v1/system/info", nil)
+	handleSystemInfo(w, r)
+
+	var resp systemInfoResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	gotPaths := make(map[string]bool)
+	for _, sd := range resp.ServiceData {
+		gotPaths[sd.Path] = true
+	}
+	mustHave := []string{
+		filepath.Join(tmpRoot, "ckpool"),              // 1-level template path
+		filepath.Join(tmpRoot, "truffels"),            // 1-level + no child dirs
+		filepath.Join(tmpRoot, "bitcoin", "blockchain"), // 2-level template path
+	}
+	for _, p := range mustHave {
+		if !gotPaths[p] {
+			t.Errorf("expected service_data to include %q, got paths: %v", p, mapKeys(gotPaths))
+		}
+	}
+}
+
+func mapKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // --- handleSystemTuningGet ---

--- a/truffels-api/Dockerfile
+++ b/truffels-api/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum* ./
-RUN go mod download || (sleep 2 && go mod download) || (sleep 5 && go mod download)
+RUN go mod download || (sleep 10 && go mod download) || (sleep 30 && go mod download) || (sleep 60 && go mod download)
 COPY . .
 ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}" -o /truffels-api .
@@ -11,10 +11,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION}
 FROM debian:bookworm-slim
 ARG VERSION=dev
 LABEL org.opencontainers.image.version="${VERSION}"
-# retry() wraps a command in 3 attempts with backoff so a transient flake on
-# deb.debian.org doesn't kill the whole build.
+# retry() wraps a command in 4 attempts with 10/30/60s backoff so a transient
+# flake on deb.debian.org doesn't kill the whole build. Total worst-case sleep
+# budget: 100s before giving up.
 RUN set -e; \
-    retry() { for i in 1 2 3; do "$@" && return 0; sleep $((i*2)); done; return 1; }; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
     retry apt-get update && \
     retry apt-get install -y --no-install-recommends ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*

--- a/truffels-api/internal/api/updates.go
+++ b/truffels-api/internal/api/updates.go
@@ -257,10 +257,21 @@ func (s *Server) handleRollbackService(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
-	checks, _ := s.store.GetAllUpdateChecks()
+	rawChecks, _ := s.store.GetAllUpdateChecks()
 	pendingCount, _ := s.store.PendingUpdateCount()
-	if checks == nil {
-		checks = []model.UpdateCheck{}
+
+	// dev.19: enrich checks with source_type — same shape as handleGetUpdates.
+	// Without this, the frontend's `c.source_type === 'dockerhub'` gate is
+	// always false (undefined !== "dockerhub"), so the version-selector
+	// dropdown never renders for any service. dev.18 added source_type to
+	// /updates but the UI reads /updates/status; this catches that miss.
+	checks := make([]UpdateCheckResponse, 0, len(rawChecks))
+	for _, c := range rawChecks {
+		entry := UpdateCheckResponse{UpdateCheck: c}
+		if tmpl, ok := s.registry.Get(c.ServiceID); ok && tmpl.UpdateSource != nil {
+			entry.SourceType = string(tmpl.UpdateSource.Type)
+		}
+		checks = append(checks, entry)
 	}
 
 	updating := make(map[string]bool)
@@ -306,11 +317,11 @@ func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"pending_count":    pendingCount,
-		"checks":           checks,
-		"updating":         updating,
-		"sources":          sources,
+		"pending_count":     pendingCount,
+		"checks":            checks,
+		"updating":          updating,
+		"sources":           sources,
 		"floating_services": floating,
-		"display_names":    displayNames,
+		"display_names":     displayNames,
 	})
 }

--- a/truffels-api/internal/api/updates_test.go
+++ b/truffels-api/internal/api/updates_test.go
@@ -178,6 +178,56 @@ func TestUpdateStatus_WithPending(t *testing.T) {
 	}
 }
 
+// dev.19: regression guard — /updates/status checks must include source_type
+// so the frontend's version-selector dropdown gate can fire for DockerHub
+// services. dev.18 added source_type to /updates but the UI consumes
+// /updates/status, so without this enrichment the dropdown is hidden for
+// every service (bug shipped in dev.18).
+func TestUpdateStatus_ChecksIncludeSourceType(t *testing.T) {
+	srv, st, _ := newTestServerWithEngine(t)
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "bitcoind",
+		CurrentVersion: "31.0",
+		LatestVersion:  "31.0",
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "abc123",
+		LatestVersion:  "def456",
+	})
+
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "GET", "/api/truffels/updates/status", "")
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	checks := body["checks"].([]interface{})
+	if len(checks) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(checks))
+	}
+
+	gotSourceType := map[string]string{}
+	for _, c := range checks {
+		m := c.(map[string]interface{})
+		sid, _ := m["service_id"].(string)
+		st, _ := m["source_type"].(string)
+		gotSourceType[sid] = st
+	}
+	if gotSourceType["bitcoind"] != "dockerhub" {
+		t.Errorf("bitcoind: expected source_type=dockerhub, got %q", gotSourceType["bitcoind"])
+	}
+	if gotSourceType["ckpool"] != "bitbucket" {
+		t.Errorf("ckpool: expected source_type=bitbucket, got %q", gotSourceType["ckpool"])
+	}
+}
+
 // --- POST /updates/check ---
 
 func TestCheckUpdates(t *testing.T) {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -195,10 +195,11 @@ type StorageInfo struct {
 
 // DockerStorageItem represents a row from docker system df.
 type DockerStorageItem struct {
-	Type        string `json:"type"`
-	Count       int    `json:"count"`
-	TotalSize   string `json:"total_size"`
-	Reclaimable string `json:"reclaimable"`
+	Type           string `json:"type"`
+	Count          int    `json:"count"`
+	TotalSize      string `json:"total_size"`
+	Reclaimable    string `json:"reclaimable"`
+	ReclaimableRaw int64  `json:"reclaimable_raw"` // bytes — for client-side threshold gates
 }
 
 // ServiceDataItem represents a host data directory size — populated for paths

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -371,6 +371,7 @@ export interface DockerStorageItem {
   count: number
   total_size: string
   reclaimable: string
+  reclaimable_raw: number
 }
 
 export interface ServiceDataItem {

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -757,6 +757,16 @@ function SystemInfoTab() {
         <Card>
           <CardTitle>Docker Storage</CardTitle>
           <p className="text-xs text-gray-500 italic mb-2">Refreshed every 5 minutes. Manual actions update immediately.</p>
+          {(() => {
+            const bc = data.docker_storage?.find((ds) => ds.type === 'Build Cache')
+            // Threshold: 10 GB (decimal — matches the agent's parseBytes scaling)
+            if (!bc || bc.reclaimable_raw < 10_000_000_000) return null
+            return (
+              <div className="mb-3 px-3 py-2 bg-yellow-600/10 border border-yellow-600/30 rounded text-xs text-yellow-300">
+                Build cache is using <span className="font-mono font-semibold">{bc.reclaimable}</span> that can be reclaimed. Click <span className="font-semibold">Clear Build Cache</span> below to free it.
+              </div>
+            )
+          })()}
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>


### PR DESCRIPTION
## Summary

Five fixes; the version-selector one is a real functional regression shipped in dev.18.

### Bug fixes

- **Version-selector dropdown gone on dev.18.** dev.18 added `source_type` to `/updates` so the frontend could gate the dropdown to DockerHub services only — but the UpdatesPage reads `/updates/status`, not `/updates`. That endpoint kept returning bare `[]model.UpdateCheck` without `source_type`, so the gate `c.source_type === 'dockerhub'` was always false. Dropped 5 dropdowns that should exist (bitcoind, electrs, mempool, proxy, ckstats-db) — also "correctly" hid the wrong ones (ckpool, ckstats, truffels) but for the wrong reason. Confirmed via Chrome DevTools `document.querySelectorAll('select').length === 0`. Fix enriches `/updates/status` checks with `source_type` from the registry. Regression test added.

- **Service Data Storage panel showing "—" for ckpool and truffels.** The agent's `/v1/system/info` handler iterated `/srv/truffels/data/*` and only emitted child rows when child dirs existed — so ckpool (has child dir `logs`) and truffels (has only a file) never got their top-level row emitted. UI looked up sizes by template-declared path and got cache misses. Fix: always emit top-level row, then also emit any 2-level child dirs. Test added for all three shapes.

### Build hardening (dev.17→dev.18 self-update hit a real `download.docker.com` flake)

- **Drop `--no-cache` from `docker compose build`.** BuildKit was writing cache layers as a side effect of every RUN but the flag prevented reads — each rebuild bloated cache without ever reusing it. User's pi had 63 GB of build cache across 727 entries (47 GB reclaimable) for no benefit. Now retries on transient flakes resume from the cached layer just before the failure instead of running the whole build.
- **Agent-side 3-attempt retry** around `docker compose build` with 30 s sleep between attempts. Cheap now that layer cache is on.
- **Lengthen Dockerfile retry backoff** from 2/4/6 s to 10/30/60 s (4 attempts, 100 s total budget) across truffels-agent, truffels-api, dockerfiles/ckpool, dockerfiles/ckstats. Also bumps Docker GPG curl retry, `go mod download`, `pnpm install`, and ckpool's `git clone` (kept wipe-on-retry semantics).

### Nice-to-have

- **Build cache hint banner** on Settings → Info. Yellow banner above the Docker Storage table when reclaimable build cache exceeds 10 GB, pointing at the existing Clear Build Cache button. Without it, the only signal is the table column — easy to miss.

## Test plan

- [x] `go test ./...` passes in truffels-api (424+1 = 425 tests, new `TestUpdateStatus_ChecksIncludeSourceType` covers the gate)
- [x] `go test ./...` passes in truffels-agent (new `TestHandleSystemInfo_EmitsTopLevelServiceDataPath` covers the service_data fix)
- [x] `tsc --noEmit` + `vitest run` pass in truffels-web (65 tests)
- [ ] After merge + dev.19 release + self-update: confirm dropdowns appear for the 5 DockerHub services and ckpool / truffels rows show real sizes instead of "—"
- [ ] After merge: confirm next `feature/*` PR triggers the claude-code-review workflow with visible sticky comment (the dev.18 PR was its first run; dev.19 should benefit from the merged-workflow effect)