### PR TITLE
dev.20: surface tag-variant switches in version selector

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.19}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.20}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-web/src/lib/updates.test.ts
+++ b/truffels-web/src/lib/updates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { truncDigest, formatTime, logStatusMap } from './updates'
+import { truncDigest, formatTime, logStatusMap, parseVersion, compareVersion } from './updates'
 
 describe('truncDigest', () => {
   it('returns em-dash for empty string', () => {
@@ -90,5 +90,51 @@ describe('logStatusMap', () => {
 
   it('maps unrecognized status to unknown', () => {
     expect(logStatusMap('something_else')).toBe('unknown')
+  })
+})
+
+describe('parseVersion', () => {
+  it('strips leading v prefix', () => {
+    expect(parseVersion('v31.0')).toEqual([31, 0])
+  })
+
+  it('strips tag-variant suffix', () => {
+    expect(parseVersion('31.0-arm64')).toEqual([31, 0])
+    expect(parseVersion('16.14-alpine')).toEqual([16, 14])
+  })
+
+  it('returns empty array for non-numeric input', () => {
+    expect(parseVersion('a01fcb3e0a53')).toEqual([])
+  })
+
+  it('parses multi-segment semver', () => {
+    expect(parseVersion('v0.3.1')).toEqual([0, 3, 1])
+  })
+})
+
+describe('compareVersion', () => {
+  it('returns positive for upgrade', () => {
+    expect(compareVersion('31.1', '31.0')).toBeGreaterThan(0)
+    expect(compareVersion('v3.3.1', 'v3.2.1')).toBeGreaterThan(0)
+  })
+
+  it('returns negative for downgrade', () => {
+    expect(compareVersion('30.2', '31.0')).toBeLessThan(0)
+  })
+
+  it('returns 0 for tag variants of the same semver', () => {
+    // dev.20: 31.0 and 31.0-arm64 are the same release, distinct images.
+    // compareVersion returning 0 is correct; the UI surfaces a "Switch to"
+    // button when the strings differ.
+    expect(compareVersion('31.0-arm64', '31.0')).toBe(0)
+    expect(compareVersion('31.0-arm32', '31.0-arm64')).toBe(0)
+  })
+
+  it('returns 0 for alpine variant of same semver', () => {
+    expect(compareVersion('16.14-alpine', '16.14')).toBe(0)
+  })
+
+  it('treats v-prefix as equivalent', () => {
+    expect(compareVersion('v31.0', '31.0')).toBe(0)
   })
 })

--- a/truffels-web/src/lib/updates.ts
+++ b/truffels-web/src/lib/updates.ts
@@ -37,6 +37,35 @@ export function phaseLabel(status: string): string {
   }
 }
 
+/**
+ * Parse a version string into a sortable []number.
+ * Strips leading "v" and any non-numeric suffix (e.g. "31.0-arm64" → [31, 0],
+ * "16.14-alpine" → [16, 14]). Tag variants that share a semver compare equal
+ * — they're the same release, differentiated by the tag string, not the
+ * version math (the action button in UpdatesPage handles that case).
+ */
+export function parseVersion(v: string): number[] {
+  let s = v.replace(/^v/, '')
+  s = s.replace(/[^0-9.].*$/, '')
+  if (!s) return []
+  return s.split('.').map((p) => parseInt(p, 10)).filter((n) => !isNaN(n))
+}
+
+/**
+ * Compare two version strings. Returns negative if a < b, positive if a > b,
+ * 0 if they parse to the same []number (which includes tag-variant pairs
+ * like "31.0" vs "31.0-arm64").
+ */
+export function compareVersion(a: string, b: string): number {
+  const pa = parseVersion(a), pb = parseVersion(b)
+  const n = Math.max(pa.length, pb.length)
+  for (let i = 0; i < n; i++) {
+    const av = pa[i] ?? 0, bv = pb[i] ?? 0
+    if (av !== bv) return av - bv
+  }
+  return 0
+}
+
 /** Format elapsed time since an ISO timestamp as "47s", "2m 14s", or "1h 03m". */
 export function formatElapsed(iso: string): string {
   if (!iso) return ''

--- a/truffels-web/src/pages/UpdatesPage.tsx
+++ b/truffels-web/src/pages/UpdatesPage.tsx
@@ -4,7 +4,7 @@ import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import ConfirmDialog from '@/components/ConfirmDialog'
-import { truncDigest, formatTime, logStatusMap, phaseLabel, formatElapsed } from '@/lib/updates'
+import { truncDigest, formatTime, logStatusMap, phaseLabel, formatElapsed, compareVersion } from '@/lib/updates'
 
 function DockerIcon() {
   return (
@@ -163,23 +163,6 @@ export default function UpdatesPage() {
     } finally {
       setPreflightLoading(null)
     }
-  }
-
-  // dev.17: parse a version string into a sortable []number for compare.
-  function parseVersion(v: string): number[] {
-    let s = v.replace(/^v/, '')
-    s = s.replace(/[^0-9.].*$/, '')
-    if (!s) return []
-    return s.split('.').map((p) => parseInt(p, 10)).filter((n) => !isNaN(n))
-  }
-  function compareVersion(a: string, b: string): number {
-    const pa = parseVersion(a), pb = parseVersion(b)
-    const n = Math.max(pa.length, pb.length)
-    for (let i = 0; i < n; i++) {
-      const av = pa[i] ?? 0, bv = pb[i] ?? 0
-      if (av !== bv) return av - bv
-    }
-    return 0
   }
 
   // dev.17: ensure we've fetched the versions list for a service.
@@ -447,8 +430,22 @@ export default function UpdatesPage() {
                     }
                     if (!target) return null
                     const cmp = cur ? compareVersion(target, cur) : 1
-                    // Same version → no button (no-op).
-                    if (cmp === 0) return null
+                    // dev.20: same semver, different tag string → variant switch
+                    // (e.g. 31.0 → 31.0-arm64, 16.14 → 16.14-alpine). compareVersion
+                    // returns 0 because the version math is identical; the tags
+                    // are still distinct images that we can swap between.
+                    if (cmp === 0) {
+                      if (target === cur) return null
+                      return (
+                        <button
+                          onClick={() => handlePreflight(c.service_id)}
+                          disabled={actionPending !== null || preflightLoading !== null}
+                          className="px-3 py-1.5 text-sm rounded transition-colors disabled:opacity-50 bg-blue-500/20 hover:bg-blue-500/30 text-blue-400"
+                        >
+                          {preflightLoading === c.service_id ? 'Checking...' : actionPending === c.service_id ? 'Switching...' : `Switch to ${target}`}
+                        </button>
+                      )
+                    }
                     // Downgrade.
                     if (cmp < 0) {
                       return (


### PR DESCRIPTION
## Summary

Final cleanup of the version-selector UX. After dev.19 fixed the missing dropdown, picking a tag variant like \`31.0-arm64\` over \`31.0\` produced no action button — \`parseVersion\` strips the \`-arm64\` suffix so both compare as \`[31, 0]\`, and the same-version branch returned \`null\`.

## Fix

When \`cmp === 0\` AND target string differs from current string → render a blue **"Switch to {target}"** button that calls the existing \`handlePreflight\` flow. \`parseVersion\` / \`compareVersion\` semantics unchanged.

## Refactor while we're here

\`parseVersion\` and \`compareVersion\` were inline in \`UpdatesPage.tsx\` with zero test coverage. Extracted to \`src/lib/updates.ts\` and added 9 unit tests covering:

- semver upgrade / downgrade
- tag-variant equality (\`31.0\` vs \`31.0-arm64\`, alpine)
- v-prefix stripping
- non-numeric input → empty array
- multi-segment semver

## Test plan

- [x] tsc --noEmit + vitest run pass in Docker (74 tests, +9 new)
- [ ] After dev.20 release + self-update: bitcoind dropdown shows "Switch to 31.0-arm64" instead of disappearing when a variant is selected
- [ ] Picking the currently-running tag still shows no button (true no-op)