### PR TITLE
v0.3.1-dev.21: bump mempool limits, fix auto-stop, add cache-dir metric

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -536,7 +536,7 @@ services:
     env_file:
       - /srv/truffels/secrets/mempool-backend.env
     environment:
-      NODE_OPTIONS: "--max-old-space-size=1792"
+      NODE_OPTIONS: "--max-old-space-size=2560"
       MEMPOOL_BACKEND: "electrum"
       ELECTRUM_HOST: "truffels-electrs"
       ELECTRUM_PORT: "50001"
@@ -556,7 +556,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2048M
+          memory: 3072M
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 || exit 1"]
       interval: 30s
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.20}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.21}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -2078,6 +2078,14 @@ func handleClearDir(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update the dir-size cache so the System Info "Service Data" panel
+	// reflects the clear immediately, instead of showing the pre-clear size
+	// until the next 5-min walk. The panel header says "Clearing a directory
+	// updates immediately" — this makes that contract true.
+	if sizeCache != nil {
+		sizeCache.set(cleaned, 0)
+	}
+
 	writeJSON(w, 200, map[string]interface{}{"status": "ok"})
 }
 

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -96,6 +96,7 @@ func main() {
 	mux.HandleFunc("POST /v1/compose/build", handleComposeBuild)
 	mux.HandleFunc("GET /v1/stats", handleStats)
 	mux.HandleFunc("GET /v1/health", handleHealth)
+	mux.HandleFunc("GET /v1/host/dir-size", handleHostDirSize)
 	mux.HandleFunc("POST /v1/system/shutdown", handleSystemShutdown)
 	mux.HandleFunc("POST /v1/system/restart", handleSystemRestart)
 	mux.HandleFunc("POST /v1/system/journal", handleSystemJournal)
@@ -182,6 +183,48 @@ type inspectResult struct {
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"status": "ok", "version": version})
+}
+
+// handleHostDirSize returns the cached size of a single data-dir path.
+//
+// Reads from the same `sizeCache` populated by walkDataDirsForever (5-min
+// cadence), so callers don't trigger a fresh walk. Path must be under
+// dataRoot — anything else is rejected to keep the API a narrow shim over the
+// existing cache, not a general "size any host path you want" oracle.
+//
+// Added in v0.3.1-dev.21 for the mempool cache-dir warn metric (700M / 900M
+// thresholds) — see FUTURE_WORK.md and the dev.20 rbfcache OOM post-mortem.
+func handleHostDirSize(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		writeJSON(w, 400, map[string]string{"error": "missing path"})
+		return
+	}
+	clean := filepath.Clean(path)
+	rootClean := filepath.Clean(dataRoot)
+	if clean != rootClean && !strings.HasPrefix(clean, rootClean+string(filepath.Separator)) {
+		writeJSON(w, 400, map[string]string{"error": "path not under data root"})
+		return
+	}
+	if sizeCache == nil {
+		writeJSON(w, 200, map[string]interface{}{
+			"path": clean, "size_bytes": int64(-1), "walked_at": "", "fresh": false,
+		})
+		return
+	}
+	size, walked, hit := sizeCache.get(clean)
+	if !hit {
+		writeJSON(w, 200, map[string]interface{}{
+			"path": clean, "size_bytes": int64(-1), "walked_at": "", "fresh": false,
+		})
+		return
+	}
+	writeJSON(w, 200, map[string]interface{}{
+		"path":       clean,
+		"size_bytes": size,
+		"walked_at":  walked.UTC().Format(time.RFC3339),
+		"fresh":      time.Since(walked) < time.Hour,
+	})
 }
 
 func handleComposeUp(w http.ResponseWriter, r *http.Request) {

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -148,6 +148,11 @@ func (e *Engine) evaluate() {
 				slog.Error("insert container snapshots", "err", err)
 			}
 		}
+
+		// Watched data-dir sizes: poll once per 60s tick, persist, evaluate.
+		// Currently mempool cache only — the path that has historically grown
+		// unbounded (rbfcache.json) and OOM'd the backend. Easy to extend.
+		e.evalWatchedDirs()
 	}
 
 	// Service health alerts + monitoring state change detection
@@ -173,6 +178,71 @@ func (e *Engine) evaluate() {
 		}
 		if err := e.store.PruneContainerSnapshots(time.Now().Add(-168 * time.Hour)); err != nil {
 			slog.Error("prune container snapshots", "err", err)
+		}
+		if err := e.store.PruneDirSizeSnapshots(time.Now().Add(-168 * time.Hour)); err != nil {
+			slog.Error("prune dir size snapshots", "err", err)
+		}
+	}
+}
+
+// watchedDir is a data-dir we track size for, with warn/critical thresholds
+// in bytes. Currently the only entry is mempool's cache — added after the
+// dev.20 rbfcache.json runaway that OOM'd the backend.
+type watchedDir struct {
+	serviceID    string
+	path         string
+	warnBytes    int64
+	criticalByte int64
+	humanLabel   string
+}
+
+var watchedDirs = []watchedDir{
+	{
+		serviceID:    "mempool",
+		path:         "/srv/truffels/data/mempool/cache",
+		warnBytes:    700 * 1024 * 1024,
+		criticalByte: 900 * 1024 * 1024,
+		humanLabel:   "mempool cache",
+	},
+}
+
+// evalWatchedDirs polls each watched data-dir size via the agent, persists a
+// snapshot, and upserts/resolves alerts at the configured thresholds.
+func (e *Engine) evalWatchedDirs() {
+	if e.compose == nil {
+		return
+	}
+	for _, w := range watchedDirs {
+		size, _, err := e.compose.HostDirSize(w.path)
+		if err != nil {
+			slog.Debug("dir-size fetch failed", "path", w.path, "err", err)
+			continue
+		}
+		if size < 0 {
+			// Agent hasn't walked this path yet — no data to persist or alert.
+			continue
+		}
+		if err := e.store.InsertDirSizeSnapshot(w.path, size); err != nil {
+			slog.Error("insert dir size snapshot", "path", w.path, "err", err)
+		}
+
+		critType := "dir_size_critical"
+		warnType := "dir_size_warning"
+		mb := size / (1024 * 1024)
+		switch {
+		case size >= w.criticalByte:
+			e.upsert(critType, w.serviceID, model.SeverityCritical,
+				"%s reached %d MB — will OOM the backend on next restart. Stop the service and clear the dir via Settings → Data Dirs.",
+				w.humanLabel, mb)
+			e.resolve(warnType, w.serviceID)
+		case size >= w.warnBytes:
+			e.upsert(warnType, w.serviceID, model.SeverityWarning,
+				"%s reached %d MB — approaching the size that caused the dev.20 OOM. Consider clearing via Settings → Data Dirs.",
+				w.humanLabel, mb)
+			e.resolve(critType, w.serviceID)
+		default:
+			e.resolve(warnType, w.serviceID)
+			e.resolve(critType, w.serviceID)
 		}
 	}
 }
@@ -336,7 +406,10 @@ func (e *Engine) checkDependencyHealth() {
 				if mode == "flag_and_stop" && e.compose != nil && !e.autoStopped[tmpl.ID+"_dep"] {
 					slog.Warn("auto-stopping dependent service",
 						"service", tmpl.ID, "upstream", depID)
-					if err := e.compose.Down(tmpl.ID); err != nil {
+					// Stop, not Down: containers should remain in Exited state so
+					// the user can recover with one click in the UI. Down removes
+					// them entirely and the only way back is `compose up`.
+					if err := e.compose.Stop(tmpl.ID); err != nil {
 						slog.Error("auto-stop dependent failed", "service", tmpl.ID, "err", err)
 					} else {
 						e.autoStopped[tmpl.ID+"_dep"] = true
@@ -491,7 +564,11 @@ func (e *Engine) evalRestartLoop(serviceID, containerName string, threshold, win
 			slog.Warn("auto-stopping service due to restart loop",
 				"service", serviceID, "restarts", len(recent), "max", maxRetries)
 			if e.compose != nil {
-				if err := e.compose.Down(serviceID); err != nil {
+				// Stop, not Down: containers remain in Exited state so the user
+				// can recover from the UI Start button. Down vaporises the stack
+				// and the next compose up is the only way back (see dev.20 incident
+				// where mempool auto-stop wiped the containers entirely).
+				if err := e.compose.Stop(serviceID); err != nil {
 					slog.Error("auto-stop failed", "service", serviceID, "err", err)
 				} else {
 					e.autoStopped[serviceID] = true

--- a/truffels-api/internal/api/monitoring.go
+++ b/truffels-api/internal/api/monitoring.go
@@ -85,6 +85,9 @@ func (s *Server) handleMonitoring(w http.ResponseWriter, r *http.Request) {
 		alerts = []model.Alert{}
 	}
 
+	// Watched data-dir size series (currently just mempool cache).
+	dirSeries := s.collectDirSizeSeries(since)
+
 	writeJSON(w, http.StatusOK, model.MonitoringResponse{
 		Containers: containers,
 		Events:     events,
@@ -93,8 +96,44 @@ func (s *Server) handleMonitoring(w http.ResponseWriter, r *http.Request) {
 			History: snapshots,
 			Summary: summary,
 		},
-		Alerts: alerts,
+		Alerts:   alerts,
+		DirSizes: dirSeries,
 	})
+}
+
+// dirSizeWatch mirrors alerts/engine.go watchedDirs so the API surfaces the
+// same paths the engine alerts on. Kept tiny + literal for now; if the list
+// grows or the engine and API need to share, hoist into a single registry.
+type dirSizeWatch struct {
+	label string
+	path  string
+}
+
+var dirSizeWatches = []dirSizeWatch{
+	{label: "mempool cache", path: "/srv/truffels/data/mempool/cache"},
+}
+
+func (s *Server) collectDirSizeSeries(since time.Time) []model.DirSizeSeries {
+	out := make([]model.DirSizeSeries, 0, len(dirSizeWatches))
+	for _, w := range dirSizeWatches {
+		rows, err := s.store.DirSizeSnapshotsSince(w.path, since)
+		if err != nil {
+			continue
+		}
+		points := make([]model.DirSizePoint, 0, len(rows))
+		for _, r := range rows {
+			points = append(points, model.DirSizePoint{
+				Timestamp: r.Timestamp,
+				SizeBytes: r.SizeBytes,
+			})
+		}
+		out = append(out, model.DirSizeSeries{
+			Label:  w.label,
+			Path:   w.path,
+			Points: points,
+		})
+	}
+	return out
 }
 
 func (s *Server) handleServiceMonitoring(w http.ResponseWriter, r *http.Request) {

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -174,7 +174,7 @@ services:
     env_file:
       - /srv/truffels/secrets/mempool-backend.env
     environment:
-      NODE_OPTIONS: "--max-old-space-size=1792"
+      NODE_OPTIONS: "--max-old-space-size=2560"
       MEMPOOL_BACKEND: "electrum"
       ELECTRUM_HOST: "truffels-electrs"
       ELECTRUM_PORT: "50001"
@@ -194,7 +194,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2048M
+          memory: 3072M
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 || exit 1"]
       interval: 30s

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -48,10 +48,12 @@ func TestRender_Mempool(t *testing.T) {
 	assertContains(t, got, "image: mempool/frontend:v3.3.1")
 	assertContains(t, got, "image: mariadb:lts@sha256:abc123")
 	assertContains(t, got, "container_name: truffels-mempool-backend")
-	// Backend OOM-fix shape: bind-mounted cache, bumped heap, healthcheck.
+	// Backend OOM-fix shape: bind-mounted cache, bumped heap + cgroup
+	// (raised in v0.3.1-dev.21 after rbfcache.json runaway hit the V8 heap
+	// ceiling at 1792 MB on mainnet), healthcheck.
 	assertContains(t, got, "/srv/truffels/data/mempool/cache:/backend/cache")
-	assertContains(t, got, "--max-old-space-size=1792")
-	assertContains(t, got, "memory: 2048M")
+	assertContains(t, got, "--max-old-space-size=2560")
+	assertContains(t, got, "memory: 3072M")
 	assertContains(t, got, "start_period: 300s")
 	// Frontend healthcheck.
 	assertContains(t, got, "http://127.0.0.1:8080/")

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -238,6 +239,24 @@ func (c *ComposeClient) SystemInfoGet() (*SystemInfo, error) {
 		return nil, fmt.Errorf("agent system info decode: %w", err)
 	}
 	return &info, nil
+}
+
+// HostDirSize asks the agent for the cached size of a data-dir path.
+// Returns (-1, false, nil) if the agent has not yet walked the path.
+func (c *ComposeClient) HostDirSize(path string) (int64, bool, error) {
+	resp, err := c.httpClient.Get(c.agentURL + "/v1/host/dir-size?path=" + url.QueryEscape(path))
+	if err != nil {
+		return 0, false, fmt.Errorf("agent dir-size: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out struct {
+		SizeBytes int64 `json:"size_bytes"`
+		Fresh     bool  `json:"fresh"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, false, fmt.Errorf("agent dir-size decode: %w", err)
+	}
+	return out.SizeBytes, out.Fresh, nil
 }
 
 // SystemJournal fetches journalctl output via the agent.

--- a/truffels-api/internal/model/monitoring.go
+++ b/truffels-api/internal/model/monitoring.go
@@ -77,7 +77,21 @@ type MonitoringContainer struct {
 // MonitoringResponse is the full payload for GET /monitoring.
 type MonitoringResponse struct {
 	Containers []MonitoringContainer `json:"containers"`
-	Events     []ServiceEvent       `json:"events"`
+	Events     []ServiceEvent        `json:"events"`
 	Metrics    MonitoringMetrics     `json:"metrics"`
-	Alerts     []Alert              `json:"alerts"`
+	Alerts     []Alert               `json:"alerts"`
+	DirSizes   []DirSizeSeries       `json:"dir_sizes,omitempty"`
+}
+
+// DirSizeSeries is the time series for one watched data dir, used by the
+// monitoring chart that warns about runaway caches (mempool rbfcache.json).
+type DirSizeSeries struct {
+	Label  string           `json:"label"`
+	Path   string           `json:"path"`
+	Points []DirSizePoint   `json:"points"`
+}
+
+type DirSizePoint struct {
+	Timestamp string `json:"timestamp"`
+	SizeBytes int64  `json:"size_bytes"`
 }

--- a/truffels-api/internal/service/templates/mempool.go
+++ b/truffels-api/internal/service/templates/mempool.go
@@ -8,7 +8,7 @@ var Mempool = model.ServiceTemplate{
 	Description:    "Bitcoin block explorer and mempool visualizer",
 	ContainerNames: []string{"truffels-mempool-backend", "truffels-mempool-frontend"},
 	Dependencies:   []string{"bitcoind", "electrs", "mempool-db"},
-	MemoryLimit:    "2304M",
+	MemoryLimit:    "3328M",
 	ConfigPath:       "",
 	RequiresUnpruned: true,
 	Port:           "80 (via proxy)",

--- a/truffels-api/internal/store/migrations/009_dir_size_metrics.sql
+++ b/truffels-api/internal/store/migrations/009_dir_size_metrics.sql
@@ -1,0 +1,17 @@
+-- Data-dir size snapshots (added in v0.3.1-dev.21).
+--
+-- Primary use: catch mempool's rbfcache.json runaway days before it OOMs
+-- the backend. Cache path is /srv/truffels/data/mempool/cache. The collector
+-- polls the agent every ~60s and persists one row per tick.
+--
+-- FUTURE_WORK.md noted this metric was already planned after the dev.20
+-- post-mortem, and this migration ships it.
+CREATE TABLE IF NOT EXISTS dir_size_snapshots (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+    path        TEXT NOT NULL,
+    size_bytes  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dir_size_snapshots_ts   ON dir_size_snapshots(timestamp);
+CREATE INDEX IF NOT EXISTS idx_dir_size_snapshots_path ON dir_size_snapshots(path, timestamp);

--- a/truffels-api/internal/store/monitoring.go
+++ b/truffels-api/internal/store/monitoring.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"strings"
 	"time"
 
@@ -203,6 +204,66 @@ func (s *Store) GetContainerSnapshotsByNames(since time.Time, containers []strin
 func (s *Store) PruneContainerSnapshots(olderThan time.Time) error {
 	ts := olderThan.UTC().Format("2006-01-02 15:04:05")
 	_, err := s.db.Exec(`DELETE FROM container_snapshots WHERE timestamp < ?`, ts)
+	return err
+}
+
+// InsertDirSizeSnapshot records the current size of a watched data dir.
+func (s *Store) InsertDirSizeSnapshot(path string, sizeBytes int64) error {
+	_, err := s.db.Exec(
+		`INSERT INTO dir_size_snapshots (path, size_bytes) VALUES (?, ?)`,
+		path, sizeBytes)
+	return err
+}
+
+// LatestDirSize returns the most recent recorded size (bytes) for path,
+// or (0, false, nil) if no snapshot exists yet.
+func (s *Store) LatestDirSize(path string) (int64, bool, error) {
+	var size int64
+	err := s.db.QueryRow(
+		`SELECT size_bytes FROM dir_size_snapshots WHERE path = ? ORDER BY id DESC LIMIT 1`,
+		path).Scan(&size)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return size, true, nil
+}
+
+// DirSizeSnapshot is one row from dir_size_snapshots, for charting.
+type DirSizeSnapshot struct {
+	Timestamp string `json:"timestamp"`
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// DirSizeSnapshotsSince returns all rows for path with timestamp >= since,
+// oldest-first (for chart rendering).
+func (s *Store) DirSizeSnapshotsSince(path string, since time.Time) ([]DirSizeSnapshot, error) {
+	rows, err := s.db.Query(
+		`SELECT timestamp, path, size_bytes FROM dir_size_snapshots
+		 WHERE path = ? AND timestamp >= ? ORDER BY id ASC`,
+		path, since.UTC().Format("2006-01-02 15:04:05"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []DirSizeSnapshot
+	for rows.Next() {
+		var snap DirSizeSnapshot
+		if err := rows.Scan(&snap.Timestamp, &snap.Path, &snap.SizeBytes); err != nil {
+			return nil, err
+		}
+		out = append(out, snap)
+	}
+	return out, rows.Err()
+}
+
+// PruneDirSizeSnapshots drops rows older than the given time.
+func (s *Store) PruneDirSizeSnapshots(olderThan time.Time) error {
+	ts := olderThan.UTC().Format("2006-01-02 15:04:05")
+	_, err := s.db.Exec(`DELETE FROM dir_size_snapshots WHERE timestamp < ?`, ts)
 	return err
 }
 

--- a/truffels-api/internal/store/sqlite.go
+++ b/truffels-api/internal/store/sqlite.go
@@ -54,6 +54,7 @@ func (s *Store) migrate() error {
 		"migrations/006_container_metrics.sql",
 		"migrations/007_host_io_metrics.sql",
 		"migrations/008_trend_alerts.sql",
+		"migrations/009_dir_size_metrics.sql",
 	}
 	for _, m := range migrations {
 		data, err := migrationsFS.ReadFile(m)

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -332,6 +332,17 @@ export interface ServiceMonitoringResponse {
   current: ContainerCurrentStats[]
 }
 
+export interface DirSizePoint {
+  timestamp: string
+  size_bytes: number
+}
+
+export interface DirSizeSeries {
+  label: string
+  path: string
+  points: DirSizePoint[]
+}
+
 export interface MonitoringResponse {
   containers: MonitoringContainer[]
   events: ServiceEvent[]
@@ -341,6 +352,7 @@ export interface MonitoringResponse {
     summary: MetricsSummary
   }
   alerts: Alert[]
+  dir_sizes?: DirSizeSeries[]
 }
 
 export interface BootEntry {

--- a/truffels-web/src/pages/MonitoringPage.tsx
+++ b/truffels-web/src/pages/MonitoringPage.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import { api, MetricSnapshot, MonitoringResponse } from '@/lib/api'
+import { api, DirSizeSeries, MetricSnapshot, MonitoringResponse } from '@/lib/api'
 import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
@@ -25,7 +25,13 @@ const CHART_COLORS = {
   netRx: '#10b981',
   netTx: '#ef4444',
   diskIO: '#ec4899',
+  dirSize: '#eab308',
 } as const
+
+// Threshold lines on the dir-size chart, kept in sync with the alert engine
+// (alerts/engine.go: watchedDirs). Bytes.
+const DIR_SIZE_WARN_MB = 700
+const DIR_SIZE_CRIT_MB = 900
 
 function formatDataSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -122,6 +128,82 @@ function MetricChart({ data, dataKey, color, label, unit, current, avg, peak, do
         <span>Current: <span className="text-gray-200 font-mono">{current.toFixed(1)}{unit}</span></span>
         <span>Avg: <span className="text-gray-200 font-mono">{avg.toFixed(1)}{unit}</span></span>
         <span>Peak: <span className="text-gray-200 font-mono">{peak.toFixed(1)}{unit}</span></span>
+      </div>
+    </Card>
+  )
+}
+
+// DirSizeChart renders one watched-dir size series with warn/critical hint
+// lines drawn at 700/900 MB. Used to catch the mempool rbfcache.json runaway
+// (which caused the dev.20 OOM) before it crosses the heap ceiling again.
+function DirSizeChart({ series }: { series: DirSizeSeries }) {
+  const data = series.points.map(p => ({
+    timestamp: p.timestamp,
+    size_mb: p.size_bytes / (1024 * 1024),
+  }))
+  const currentMb = data.length > 0 ? data[data.length - 1].size_mb : 0
+  const peakMb = data.length > 0 ? Math.max(...data.map(d => d.size_mb)) : 0
+  let status: 'ok' | 'warn' | 'crit' = 'ok'
+  if (currentMb >= DIR_SIZE_CRIT_MB) status = 'crit'
+  else if (currentMb >= DIR_SIZE_WARN_MB) status = 'warn'
+
+  return (
+    <Card>
+      <CardTitle>{series.label} size</CardTitle>
+      <div className="h-40">
+        {data.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+            Collecting data...
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+              <CartesianGrid stroke="rgba(255,255,255,0.05)" strokeDasharray="3 3" />
+              <XAxis
+                dataKey="timestamp"
+                tickFormatter={formatTime}
+                tick={{ fill: '#6b7280', fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fill: '#6b7280', fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={(v) => `${Math.round(v)}M`}
+              />
+              <Tooltip
+                contentStyle={{ background: '#1e1e2e', border: '1px solid #2e2e3e', borderRadius: 8, fontSize: 12 }}
+                labelFormatter={formatTimestamp}
+                formatter={(value: number) => [`${value.toFixed(0)} MB`, series.label]}
+              />
+              <Area
+                type="monotone"
+                dataKey="size_mb"
+                stroke={CHART_COLORS.dirSize}
+                fill={CHART_COLORS.dirSize}
+                fillOpacity={0.15}
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+      <div className="flex gap-4 mt-2 text-xs text-gray-400 flex-wrap items-center">
+        <span>
+          Current: <span className={`font-mono ${
+            status === 'crit' ? 'text-red-400' : status === 'warn' ? 'text-yellow-400' : 'text-gray-200'
+          }`}>{currentMb.toFixed(0)} MB</span>
+        </span>
+        <span>Peak: <span className="text-gray-200 font-mono">{peakMb.toFixed(0)} MB</span></span>
+        <span className="text-gray-500">warn ≥ {DIR_SIZE_WARN_MB} MB · critical ≥ {DIR_SIZE_CRIT_MB} MB</span>
+        {status !== 'ok' && (
+          <span className={status === 'crit' ? 'text-red-400' : 'text-yellow-400'}>
+            Clear via Settings → Data Dirs → {series.label}
+          </span>
+        )}
       </div>
     </Card>
   )
@@ -419,6 +501,15 @@ export default function MonitoringPage() {
           domain={[0, 100]}
         />
       </div>
+
+      {/* Watched data-dir sizes (mempool cache today; extendable) */}
+      {data.dir_sizes && data.dir_sizes.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {data.dir_sizes.map((s) => (
+            <DirSizeChart key={s.path} series={s} />
+          ))}
+        </div>
+      )}
 
       {/* Section B: Container Status Table */}
       <Card>


### PR DESCRIPTION
## Summary

Three independent changes addressing the dev.20 mempool OOM-loop diagnosed today.

- **Memory budget for mempool backend** — raise `--max-old-space-size` 1792 → 2560 and docker cgroup `memory:` 2048M → 3072M. Our previous 1792M heap was below mempool's mainnet working set during rbf cache restore (the on-disk `rbfcache.json` reached 511 MB → ~1.5 GB working memory on `JSON.parse`). Umbrel runs `--max-old-space-size=2048` with **no** docker cgroup limit at all.
- **Alert engine auto-stop uses `compose Stop` instead of `compose Down`** at the two call sites (`engine.go:339` dep-mode, `engine.go:494` restart-loop). Containers stay in `Exited` state and the UI Start button recovers them; previously they were `compose down`'d and vanished entirely. Verified in this session's audit log (entries 369-391 today).
- **Cache-dir size metric** from `FUTURE_WORK.md:22`. Agent exposes `GET /v1/host/dir-size?path=...` (reads from the existing in-memory `dirSizeCache`); API collector polls every 60 s and persists to a new `dir_size_snapshots` table; alert engine warns ≥ 700 MB / critical ≥ 900 MB; Monitoring page renders a new chart with current/peak readout and a clear-via-Data-Dirs hint when over threshold.

## Test plan

- [x] `go test ./...` inside Docker — `truffels-api` and `truffels-agent` all green
- [x] `tsc --noEmit` and `vitest run` inside Docker — all 74 tests pass
- [x] Updated existing template assertions to the new memory numbers
- [ ] After merge + release: in-product self-update to dev.21, then UI → Settings → Data Dirs → Mempool cache → Clear → UI → Start. Verify new chart populates and no V8 `Reached heap limit` lines in backend logs over 48 h.
- [ ] Optional synthetic alert test: temporarily drop `DIR_SIZE_WARN_MB` to e.g. 50; confirm alert + UI badge.

## Background

Today's session investigated the user-visible symptom (`block=n/a sync=sync?` on the ePaper display because mempool was down). Diagnosis revealed:

- V8 self-aborts with `FATAL ERROR: Reached heap limit` at ~1788 / 1792 MB during `Restoring rbf data from disk cache`
- `rbfcache.json` on disk is 511 MB, total cache dir 991 MB
- Mempool's `rbf-cache.ts` has 24 h TTL + 10 min cleanup but only marks txs as expiring on the stale-path code — long-lived RBF chains persist far beyond 24 h
- No upstream knob exists to bound the RBF cache size; the only ways out are bigger limits + observability + scheduled clears

Manual hand fix: user clicks Settings → Data Dirs → Mempool cache → Clear, then Start. dev.21 makes the next runaway visible before it OOMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)