### PR TITLE
updates: read Docker tags from registry API instead of Hub web API

### DIFF
--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -57,39 +58,45 @@ func checkDockerHub(image string, tagFilter string) (string, error) {
 	return versions[0], nil
 }
 
+// registryTagPageSize is the page size requested from /tags/list. The registry
+// caps this server-side, so pagination still has to be followed.
+const registryTagPageSize = 1000
+
+// registryMaxPages bounds pagination so a misbehaving registry cannot spin us
+// forever. 20 pages covers every image in the service registry with room to spare.
+const registryMaxPages = 20
+
 // ListDockerHubVersions returns ALL stable tags matching the optional
 // tagFilter, sorted by parsed version descending (highest first). Capped
 // at 20 entries so the UI selector stays compact.
 //
-// Replaces the dev.16 "first match by last_updated" behavior, which would
-// pick a recently-republished backport (e.g. btcpayserver/bitcoin:29.2
-// republished after 31.0 was the active release) over the actual highest
-// version.
+// Tags come from registry-1.docker.io rather than hub.docker.com: the Hub web
+// API sits behind Cloudflare bot management, which serves Go's HTTP client a
+// "Just a moment..." challenge page with HTTP 403 no matter what headers we
+// send (UA spoofing does not help — the block is fingerprint-based). The
+// registry API is not bot-managed and needs only an anonymous pull token.
+//
+// The registry returns bare tag names with no timestamps, which costs us
+// nothing: sorting has been version-based since dev.16, when "first match by
+// last_updated" was dropped for picking a recently-republished backport
+// (e.g. btcpayserver/bitcoin:29.2 republished after 31.0 was the active
+// release) over the actual highest version.
 func ListDockerHubVersions(image string, tagFilter string) ([]string, error) {
-	apiImage := image
-	if !strings.Contains(image, "/") {
-		apiImage = "library/" + image
-	}
-	url := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/tags/?page_size=100&ordering=last_updated", apiImage)
+	repo := normalizeRepo(image)
 
-	resp, err := httpClient.Get(url)
+	token, err := registryToken(repo)
 	if err != nil {
-		return nil, fmt.Errorf("dockerhub request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("dockerhub: HTTP %d", resp.StatusCode)
+		return nil, err
 	}
 
-	var result struct {
-		Results []struct {
-			Name        string `json:"name"`
-			LastUpdated string `json:"last_updated"`
-		} `json:"results"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("dockerhub decode: %w", err)
+	var names []string
+	next := fmt.Sprintf("https://registry-1.docker.io/v2/%s/tags/list?n=%d", repo, registryTagPageSize)
+	for page := 0; next != "" && page < registryMaxPages; page++ {
+		var err error
+		names, next, err = fetchTagPage(next, token, names)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	type parsed struct {
@@ -97,14 +104,16 @@ func ListDockerHubVersions(image string, tagFilter string) ([]string, error) {
 		version []int
 	}
 	var parsedTags []parsed
-	for _, t := range result.Results {
-		name := t.Name
+	for _, name := range names {
 		if name == "latest" || name == "edge" || name == "nightly" {
 			continue
 		}
 		lower := strings.ToLower(name)
 		if strings.Contains(lower, "-dev") || strings.Contains(lower, "-rc") ||
 			strings.Contains(lower, "alpha") || strings.Contains(lower, "beta") {
+			continue
+		}
+		if isArchVariant(name, tagFilter) {
 			continue
 		}
 		if tagFilter != "" && !matchTagFilter(name, tagFilter) {
@@ -117,8 +126,18 @@ func ListDockerHubVersions(image string, tagFilter string) ([]string, error) {
 		parsedTags = append(parsedTags, parsed{name: name, version: v})
 	}
 
+	// Ties are broken by name so the result is deterministic: sort.Slice is
+	// not stable, and per-release variants ("31.0-foo") parse to the same
+	// version as the plain tag ("31.0"). Shortest-then-lexicographic puts the
+	// plain tag first, which is what CheckLatestVersion hands back as latest.
 	sort.Slice(parsedTags, func(i, j int) bool {
-		return compareVersions(parsedTags[i].version, parsedTags[j].version) > 0
+		if c := compareVersions(parsedTags[i].version, parsedTags[j].version); c != 0 {
+			return c > 0
+		}
+		if len(parsedTags[i].name) != len(parsedTags[j].name) {
+			return len(parsedTags[i].name) < len(parsedTags[j].name)
+		}
+		return parsedTags[i].name < parsedTags[j].name
 	})
 
 	out := make([]string, 0, len(parsedTags))
@@ -129,6 +148,118 @@ func ListDockerHubVersions(image string, tagFilter string) ([]string, error) {
 		out = out[:20]
 	}
 	return out, nil
+}
+
+// fetchTagPage appends one page of /tags/list to names and returns the URL of
+// the next page ("" when the registry sent no Link rel="next" header).
+func fetchTagPage(pageURL, token string, names []string) ([]string, string, error) {
+	req, err := http.NewRequest("GET", pageURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("docker registry tags: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("docker registry tags: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return nil, "", fmt.Errorf("docker registry tags: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, "", fmt.Errorf("docker registry tags decode: %w", err)
+	}
+
+	// req.URL is the resolved base for the (relative) Link header the
+	// registry sends, e.g. `</v2/library/postgres/tags/list?n=1000&last=17.9>`.
+	return append(names, result.Tags...), nextPageURL(req.URL, resp.Header.Get("Link")), nil
+}
+
+// nextPageURL extracts the rel="next" target from a Link header and resolves
+// it against base. Returns "" when there is no next page.
+func nextPageURL(base *url.URL, link string) string {
+	for _, part := range strings.Split(link, ",") {
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end <= start {
+			continue
+		}
+		ref, err := url.Parse(strings.TrimSpace(part[start+1 : end]))
+		if err != nil {
+			continue
+		}
+		return base.ResolveReference(ref).String()
+	}
+	return ""
+}
+
+// archVariantSuffixes are the per-architecture and per-OS tag variants Docker
+// images publish alongside their plain release tag. They parse to the same
+// version as that tag, so they have to be dropped or they compete with it for
+// "latest" — and pinning a service to an arch-specific tag breaks it on any
+// other host.
+var archVariantSuffixes = map[string]bool{
+	"amd64": true, "x86_64": true, "i386": true, "386": true,
+	"arm64": true, "arm64v8": true, "aarch64": true,
+	"arm32v5": true, "arm32v6": true, "arm32v7": true,
+	"armv6": true, "armv7": true, "armhf": true,
+	"ppc64le": true, "s390x": true, "riscv64": true, "mips64le": true,
+}
+
+// isArchVariant reports whether tag is an architecture variant that was not
+// explicitly asked for. A tagFilter naming the variant (e.g. "-arm64v8") opts
+// back in, so an operator can still pin one deliberately.
+func isArchVariant(tag, tagFilter string) bool {
+	idx := strings.LastIndex(tag, "-")
+	if idx < 0 {
+		return false
+	}
+	suffix := tag[idx+1:]
+	if !archVariantSuffixes[suffix] {
+		return false
+	}
+	return !strings.Contains(tagFilter, suffix)
+}
+
+// normalizeRepo maps an image name to its registry repository path. Official
+// images ("caddy") live under "library/".
+func normalizeRepo(image string) string {
+	if !strings.Contains(image, "/") {
+		return "library/" + image
+	}
+	return image
+}
+
+// registryToken fetches an anonymous pull token for repo. Public images need
+// no credentials.
+func registryToken(repo string) (string, error) {
+	tokenURL := fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", repo)
+	resp, err := httpClient.Get(tokenURL)
+	if err != nil {
+		return "", fmt.Errorf("docker registry auth: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("docker registry auth: HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("docker registry auth decode: %w", err)
+	}
+	return result.Token, nil
 }
 
 // extractVersion pulls a []int version from a tag name. Strips a leading "v"
@@ -207,34 +338,18 @@ func compareVersions(a, b []int) int {
 // the remote digest against the locally running image digest.
 func checkDockerDigest(image, tag string) (string, error) {
 	// Official images need "library/" prefix for the registry API
-	repo := image
-	if !strings.Contains(image, "/") {
-		repo = "library/" + image
-	}
+	repo := normalizeRepo(image)
 
 	// Step 1: Get auth token (anonymous, no credentials needed for public images)
-	tokenURL := fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", repo)
-	tokenResp, err := httpClient.Get(tokenURL)
+	token, err := registryToken(repo)
 	if err != nil {
-		return "", fmt.Errorf("docker registry auth: %w", err)
-	}
-	defer tokenResp.Body.Close()
-
-	if tokenResp.StatusCode != 200 {
-		return "", fmt.Errorf("docker registry auth: HTTP %d", tokenResp.StatusCode)
-	}
-
-	var tokenResult struct {
-		Token string `json:"token"`
-	}
-	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenResult); err != nil {
-		return "", fmt.Errorf("docker registry auth decode: %w", err)
+		return "", err
 	}
 
 	// Step 2: HEAD the manifest to get the remote digest
 	manifestURL := fmt.Sprintf("https://registry-1.docker.io/v2/%s/manifests/%s", repo, tag)
 	req, _ := http.NewRequest("HEAD", manifestURL, nil)
-	req.Header.Set("Authorization", "Bearer "+tokenResult.Token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", strings.Join([]string{
 		"application/vnd.docker.distribution.manifest.list.v2+json",
 		"application/vnd.oci.image.index.v1+json",

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -71,40 +71,33 @@ func withMockClient(srv *httptest.Server) func() {
 	}
 }
 
-func TestCheckLatestVersion_DockerHub_PicksFirstStableTag(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"latest"},
-		{"v2.0.0"},
-		{"v1.9.0"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
+// newTagListServer serves the anonymous token endpoint plus a single-page
+// registry /tags/list carrying the given tag names. Paired with
+// newRedirectClient, which points every outbound request at the test server.
+func newTagListServer(tags ...string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name": "test/image",
+			"tags": tags,
+		})
 	}))
-	defer srv.Close()
-	defer withMockClient(srv)()
+}
 
-	// Override the URL by using the test server address as the image name.
-	// The function builds: https://hub.docker.com/v2/repositories/<image>/tags/...
-	// We need to intercept at the HTTP client level. The mock client routes all
-	// requests to srv regardless of host, so any image name works.
+func TestCheckLatestVersion_DockerHub_PicksFirstStableTag(t *testing.T) {
+	srv := newTagListServer("latest", "v2.0.0", "v1.9.0")
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
 	src := &model.UpdateSource{
 		Type:   model.SourceDockerHub,
 		Images: []string{"test/image"},
-	}
-
-	// The httpClient from httptest only talks to the test server, but the URL
-	// the code builds points to hub.docker.com. We need a transport that
-	// redirects all requests to the test server.
-	src.Images = []string{"test/image"}
-	httpClient = &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			// Rewrite the URL to point at our test server
-			req.URL.Scheme = "http"
-			req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
-			return http.DefaultTransport.RoundTrip(req)
-		}),
 	}
 
 	got, err := CheckLatestVersion(src, "stable")
@@ -135,21 +128,11 @@ func newRedirectClient(srv *httptest.Server) *http.Client {
 }
 
 func TestCheckLatestVersion_DockerHub_FiltersUnstableTags(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"latest"},
-		{"edge"},
-		{"nightly"},
-		{"v3.0.0-dev"},
-		{"v2.5.0-rc1"},
-		{"v2.0.0alpha1"},
-		{"v1.8.0beta2"},
-		{"v1.5.0"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	srv := newTagListServer(
+		"latest", "edge", "nightly",
+		"v3.0.0-dev", "v2.5.0-rc1", "v2.0.0alpha1", "v1.8.0beta2",
+		"v1.5.0",
+	)
 	defer srv.Close()
 
 	original := httpClient
@@ -170,15 +153,7 @@ func TestCheckLatestVersion_DockerHub_FiltersUnstableTags(t *testing.T) {
 }
 
 func TestCheckLatestVersion_DockerHub_NoSuitableTags(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"latest"},
-		{"edge"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	srv := newTagListServer("latest", "edge")
 	defer srv.Close()
 
 	original := httpClient
@@ -543,20 +518,11 @@ func TestExtractCurrentVersion_GitHubRelease_NoTag(t *testing.T) {
 }
 
 // dev.17: btcpayserver/bitcoin republishes "29.2" after "31.0" was already
-// published, so last_updated puts 29.2 first. The check must pick 31.0
-// (highest version), not 29.2 (most-recently-updated).
+// published, so any listing order that favours recency puts 29.2 first. The
+// check must pick 31.0 (highest version), not 29.2.
 func TestCheckLatestVersion_DockerHub_PicksHighestVersionNotLastUpdated(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"29.2"},  // last_updated first — but lower version
-		{"31.0"},  // higher version, less recent
-		{"30.2"},
-		{"30.1"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	// 29.2 deliberately listed before the higher versions.
+	srv := newTagListServer("29.2", "31.0", "30.2", "30.1")
 	defer srv.Close()
 	original := httpClient
 	httpClient = newRedirectClient(srv)
@@ -576,17 +542,7 @@ func TestCheckLatestVersion_DockerHub_PicksHighestVersionNotLastUpdated(t *testi
 }
 
 func TestCheckLatestVersion_DockerHub_HandlesVPrefix(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"v3.2.1"}, // last_updated first
-		{"v3.3.1"}, // higher
-		{"v3.3.0"},
-		{"v3.2.0"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	srv := newTagListServer("v3.2.1", "v3.3.1", "v3.3.0", "v3.2.0")
 	defer srv.Close()
 	original := httpClient
 	httpClient = newRedirectClient(srv)
@@ -603,17 +559,10 @@ func TestCheckLatestVersion_DockerHub_HandlesVPrefix(t *testing.T) {
 }
 
 func TestCheckLatestVersion_DockerHub_HandlesTagFilterSuffix(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"2.11.1-alpine"},
-		{"2.11.2-alpine"},
-		{"2.10.0-alpine"},
-		{"3.0.0"}, // doesn't match filter
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	srv := newTagListServer(
+		"2.11.1-alpine", "2.11.2-alpine", "2.10.0-alpine",
+		"3.0.0", // doesn't match filter
+	)
 	defer srv.Close()
 	original := httpClient
 	httpClient = newRedirectClient(srv)
@@ -631,18 +580,7 @@ func TestCheckLatestVersion_DockerHub_HandlesTagFilterSuffix(t *testing.T) {
 }
 
 func TestListDockerHubVersions_ReturnsSortedDescending(t *testing.T) {
-	tags := []struct {
-		Name string `json:"name"`
-	}{
-		{"29.2"},
-		{"31.0"},
-		{"30.2"},
-		{"30.1"},
-		{"30.2.1"},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"results": tags})
-	}))
+	srv := newTagListServer("29.2", "31.0", "30.2", "30.1", "30.2.1")
 	defer srv.Close()
 	original := httpClient
 	httpClient = newRedirectClient(srv)
@@ -659,6 +597,269 @@ func TestListDockerHubVersions_ReturnsSortedDescending(t *testing.T) {
 	for i := range got {
 		if got[i] != want[i] {
 			t.Errorf("pos %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// ---------- Docker Registry v2 tag listing ----------
+//
+// hub.docker.com sits behind Cloudflare bot management, which answers Go's
+// HTTP client with a 403 challenge page regardless of headers. Tag discovery
+// therefore goes through registry-1.docker.io, which is not bot-managed.
+
+// registryPage is one response of a paginated /tags/list endpoint.
+type registryPage struct {
+	tags []string
+	// next is the value served in the Link rel="next" header. Empty means
+	// this is the last page.
+	next string
+}
+
+// newRegistryServer serves the anonymous auth token endpoint and a paginated
+// /v2/<repo>/tags/list. Pages are keyed by the "last" query parameter; the
+// first page is keyed by "". Requests are recorded in *seen.
+func newRegistryServer(t *testing.T, pages map[string]registryPage, seen *[]*http.Request) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*seen = append(*seen, r.Clone(r.Context()))
+
+		if r.URL.Path == "/token" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/tags/list") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		page, ok := pages[r.URL.Query().Get("last")]
+		if !ok {
+			http.Error(w, "no page for last="+r.URL.Query().Get("last"), http.StatusNotFound)
+			return
+		}
+		if page.next != "" {
+			w.Header().Set("Link", "<"+r.URL.Path+"?n=1000&last="+page.next+`>; rel="next"`)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name": "test/image",
+			"tags": page.tags,
+		})
+	}))
+}
+
+func TestListDockerHubVersions_QueriesRegistryTagsList(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"": {tags: []string{"latest", "v1.9.0", "v2.0.0"}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	got, err := ListDockerHubVersions("test/image", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "v2.0.0" || got[1] != "v1.9.0" {
+		t.Errorf("expected [v2.0.0 v1.9.0], got %v", got)
+	}
+
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 requests (token, tags), got %d", len(seen))
+	}
+	if seen[0].URL.Path != "/token" {
+		t.Errorf("first request should be the token endpoint, got %s", seen[0].URL.Path)
+	}
+	if scope := seen[0].URL.Query().Get("scope"); scope != "repository:test/image:pull" {
+		t.Errorf("unexpected token scope: %s", scope)
+	}
+	if seen[1].URL.Path != "/v2/test/image/tags/list" {
+		t.Errorf("unexpected tags path: %s", seen[1].URL.Path)
+	}
+	if auth := seen[1].Header.Get("Authorization"); auth != "Bearer test-token" {
+		t.Errorf("tags request missing bearer token, got %q", auth)
+	}
+}
+
+func TestListDockerHubVersions_PrefixesOfficialImagesWithLibrary(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"": {tags: []string{"2.11.4-alpine"}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	if _, err := ListDockerHubVersions("caddy", "2-alpine"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope := seen[0].URL.Query().Get("scope"); scope != "repository:library/caddy:pull" {
+		t.Errorf("unofficial scope for official image: %s", scope)
+	}
+	if seen[1].URL.Path != "/v2/library/caddy/tags/list" {
+		t.Errorf("unexpected tags path: %s", seen[1].URL.Path)
+	}
+}
+
+func TestListDockerHubVersions_FollowsPaginationLink(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"":       {tags: []string{"v1.0.0", "v1.1.0"}, next: "v1.1.0"},
+		"v1.1.0": {tags: []string{"v1.2.0", "v3.0.0"}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	got, err := ListDockerHubVersions("test/image", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"v3.0.0", "v1.2.0", "v1.1.0", "v1.0.0"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pos %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}
+
+func TestListDockerHubVersions_TokenErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	_, err := ListDockerHubVersions("test/image", "")
+	if err == nil {
+		t.Fatal("expected error when the token endpoint fails")
+	}
+	if !strings.Contains(err.Error(), "docker registry auth: HTTP 403") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestListDockerHubVersions_TagsListErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+			return
+		}
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	_, err := ListDockerHubVersions("test/image", "")
+	if err == nil {
+		t.Fatal("expected error when tags/list fails")
+	}
+	if !strings.Contains(err.Error(), "docker registry tags: HTTP 429") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// The registry returns the complete tag list, including the per-architecture
+// variants Docker publishes alongside each release. Those parse to the same
+// version as the plain tag (31.0-arm64v8 -> [31 0]), so without filtering they
+// tie with it and an unstable sort can hand back an arch-pinned tag as the
+// update target.
+func TestListDockerHubVersions_SkipsArchVariantTags(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"": {tags: []string{
+			"31.0", "31.0-amd64", "31.0-arm32v7", "31.0-arm64v8",
+			"30.2", "30.2-amd64", "30.2-arm64v8",
+		}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	got, err := ListDockerHubVersions("btcpayserver/bitcoin", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"31.0", "30.2"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pos %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// An arch variant explicitly asked for via tagFilter must still be listed.
+func TestListDockerHubVersions_KeepsArchVariantWhenFiltered(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"": {tags: []string{"31.0", "31.0-arm64v8", "30.2-arm64v8"}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	got, err := ListDockerHubVersions("btcpayserver/bitcoin", "-arm64v8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"31.0-arm64v8", "30.2-arm64v8"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pos %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// Tags that parse to the same version must order deterministically, with the
+// plain tag ahead of any suffixed sibling — CheckLatestVersion returns [0].
+func TestListDockerHubVersions_PrefersPlainTagOnVersionTie(t *testing.T) {
+	var seen []*http.Request
+	srv := newRegistryServer(t, map[string]registryPage{
+		"": {tags: []string{"31.0-zesty", "31.0", "31.0-abc"}},
+	}, &seen)
+	defer srv.Close()
+
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	for i := 0; i < 5; i++ {
+		got, err := ListDockerHubVersions("test/image", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"31.0", "31.0-abc", "31.0-zesty"}
+		if len(got) != len(want) {
+			t.Fatalf("run %d: expected %v, got %v", i, want, got)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("run %d pos %d: got %s want %s", i, j, got[j], want[j])
+			}
 		}
 	}
 }

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -62,15 +62,6 @@ func TestExtractCurrentVersion_UnknownType(t *testing.T) {
 
 // ---------- CheckLatestVersion ----------
 
-// helper: save and restore the package-level httpClient
-func withMockClient(srv *httptest.Server) func() {
-	original := httpClient
-	httpClient = srv.Client()
-	return func() {
-		httpClient = original
-	}
-}
-
 // newTagListServer serves the anonymous token endpoint plus a single-page
 // registry /tags/list carrying the given tag names. Paired with
 // newRedirectClient, which points every outbound request at the test server.


### PR DESCRIPTION
## Problem

Every Docker Hub update check fails with `dockerhub: HTTP 403`. Affects `bitcoind`, `electrs`, `mempool`, `proxy` and `ckstats-db` — i.e. all five `dockerhub`-sourced services.

`hub.docker.com` now sits behind Cloudflare bot management. It answers Go's HTTP client with a `Just a moment...` challenge page instead of JSON:

| Client | Result |
|---|---|
| `curl` from the host | 200 |
| `wget` from inside the api container | 200 |
| real Go `http.Client`, same URL and network | **403** + challenge page, `server: cloudflare` |
| Go client + `curl` UA / full browser header set | **still 403** |

So it is not networking, DNS, rate limiting or a malformed URL — the block is TLS/HTTP2 fingerprint based, which is why User-Agent spoofing does not help. `mempool-db` was unaffected because `source: docker_digest` already talks to `registry-1.docker.io`, which is not bot-managed.

## Fix

Tag discovery moves to the registry API:

```
GET https://auth.docker.io/token?service=registry.docker.io&scope=repository:<repo>:pull
GET https://registry-1.docker.io/v2/<repo>/tags/list?n=1000   (Bearer)
```

- The anonymous token fetch is extracted out of `checkDockerDigest` into `registryToken` and shared.
- Pagination follows the `Link rel="next"` header, bounded at 20 pages — `library/postgres` alone returns more than one page.
- Losing `last_updated` costs nothing: sorting has been version-based since dev.16.

## Regression caught while verifying

The registry returns the *complete* tag list, including the per-architecture variants (`31.0-amd64`, `31.0-arm64v8`, …). Those parse to the same version as the plain tag, and `sort.Slice` is not stable — so the first live run reported `btcpayserver/bitcoin` latest as **`31.0-arm64v8`** instead of `31.0`, which would have pinned bitcoind to an arch-specific tag.

Fixed by skipping arch variants unless a `tagFilter` explicitly names one (`-arm64v8` still opts back in), plus a deterministic tie-break on tag name so the plain tag always wins.

## Verification

- Full `truffels-api` suite green, `go vet` clean.
- 8 new tests: registry endpoint + scope + bearer header, `library/` prefixing, pagination, auth error, tags error, arch-variant skip, explicit-variant opt-in, tie-break determinism (asserted over repeated runs).
- Live check against the real registry, run once and not committed:

```
btcpayserver/bitcoin   latest=31.0            top=[31.0 30.2 29.2 29.1]
getumbrel/electrs      latest=v0.11.1         top=[v0.11.1 v0.11.0 v0.10.10 v0.10.9]
mempool/backend        latest=v3.3.1          top=[v3.3.1 v3.3.0 v3.2.1 v3.2.0]
caddy (2-alpine)       latest=2.11.4-alpine   top=[2.11.4-alpine 2.11.3-alpine ...]
postgres (16-alpine)   latest=16.14-alpine    top=[16.14-alpine 16.13-alpine ...]
```

Note: the `gofmt` nit remaining in `registry.go` (comment alignment in `matchTagFilter`) predates this branch and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)