### PR TITLE
Mempool cache auto-reclaim and boot guard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.22}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.23}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -355,11 +355,27 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 	// (e.g. clear-dir erroring every time) would leave no row for
 	// LastAuditAt to find, decideReclaim would never see a prior attempt,
 	// and the engine would stop and restart the service on every 30s tick
-	// forever. Writing it here also makes the sequence crash-safe: if
-	// truffels-api restarts between Stop and Up, the attempt is already on
-	// record and won't be repeated within the cooldown window.
-	_ = e.store.LogAudit("auto_reclaim", w.serviceID,
-		fmt.Sprintf("attempting to clear %s (%d MB) and restart the service", target.Path, mb), "")
+	// forever.
+	//
+	// This ordering makes the sequence loop-safe, not availability-safe: if
+	// truffels-api crashes between Stop and Up (after this write succeeded),
+	// the cooldown blocks any retry for dir_size_autoreclaim_min_interval_hours
+	// and recovery is manual — the compose reconciler only issues Up when the
+	// compose file itself changed, not on every tick.
+	//
+	// If the write itself fails (e.g. SQLITE_FULL or an I/O error under disk
+	// pressure — precisely the condition this feature exists to relieve), we
+	// must not proceed to Stop: without this row on record, the cooldown
+	// guard above can't see this attempt on the next tick, and the engine
+	// would stop and restart the service forever. Refusing to act is the
+	// safe failure here — an oversized cache is a known, alerted condition;
+	// an unbounded stop/start loop is not.
+	if err := e.store.LogAudit("auto_reclaim", w.serviceID,
+		fmt.Sprintf("attempting to clear %s (%d MB) and restart the service", target.Path, mb), ""); err != nil {
+		e.reclaimFailed(w, false, fmt.Sprintf(
+			"could not record the reclaim attempt: %s — aborting before stopping the service to avoid an uncontrolled restart loop", err.Error()))
+		return
+	}
 
 	slog.Info("auto-reclaim starting", "service", w.serviceID, "path", target.Path, "size_mb", mb)
 

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -185,24 +185,26 @@ func (e *Engine) evaluate() {
 	}
 }
 
-// watchedDir is a data-dir we track size for, with warn/critical thresholds
-// in bytes. Currently the only entry is mempool's cache — added after the
-// dev.20 rbfcache.json runaway that OOM'd the backend.
+// watchedDir is a data-dir we track size for. Currently the only entry is
+// mempool's cache — added after the dev.20 rbfcache.json runaway that
+// OOM'd the backend.
 type watchedDir struct {
-	serviceID    string
-	path         string
-	warnBytes    int64
-	criticalByte int64
-	humanLabel   string
+	serviceID  string
+	path       string
+	humanLabel string
+	// Setting keys for the thresholds, so an operator can tune them without
+	// a release. Defaults live in the getSettingInt calls in evalWatchedDirs.
+	warnKey     string
+	criticalKey string
 }
 
 var watchedDirs = []watchedDir{
 	{
-		serviceID:    "mempool",
-		path:         "/srv/truffels/data/mempool/cache",
-		warnBytes:    700 * 1024 * 1024,
-		criticalByte: 900 * 1024 * 1024,
-		humanLabel:   "mempool cache",
+		serviceID:   "mempool",
+		path:        "/srv/truffels/data/mempool/cache",
+		humanLabel:  "mempool cache",
+		warnKey:     "dir_size_warning_mb",
+		criticalKey: "dir_size_critical_mb",
 	},
 }
 
@@ -226,16 +228,19 @@ func (e *Engine) evalWatchedDirs() {
 			slog.Error("insert dir size snapshot", "path", w.path, "err", err)
 		}
 
+		warnBytes := int64(e.getSettingInt(w.warnKey, 700)) * 1024 * 1024
+		criticalBytes := int64(e.getSettingInt(w.criticalKey, 900)) * 1024 * 1024
+
 		critType := "dir_size_critical"
 		warnType := "dir_size_warning"
 		mb := size / (1024 * 1024)
 		switch {
-		case size >= w.criticalByte:
+		case size >= criticalBytes:
 			e.upsert(critType, w.serviceID, model.SeverityCritical,
 				"%s reached %d MB — will OOM the backend on next restart. Stop the service and clear the dir via Settings → Data Dirs.",
 				w.humanLabel, mb)
 			e.resolve(warnType, w.serviceID)
-		case size >= w.warnBytes:
+		case size >= warnBytes:
 			e.upsert(warnType, w.serviceID, model.SeverityWarning,
 				"%s reached %d MB — approaching the size that caused the dev.20 OOM. Consider clearing via Settings → Data Dirs.",
 				w.humanLabel, mb)
@@ -244,7 +249,110 @@ func (e *Engine) evalWatchedDirs() {
 			e.resolve(warnType, w.serviceID)
 			e.resolve(critType, w.serviceID)
 		}
+
+		if size >= criticalBytes {
+			e.tryReclaim(w, size)
+		}
 	}
+}
+
+// tryReclaim executes the stop → clear → start cycle the dir_size_critical
+// alert prescribes, once every guardrail in decideReclaim passes.
+//
+// It resolves the target through the service template's DataDirs rather than
+// trusting w.path directly: a directory that is not declared Clearable and
+// RequiresStop cannot be reached from here, so entries like mempool/mysql are
+// structurally out of range.
+func (e *Engine) tryReclaim(w watchedDir, size int64) {
+	tmpl, ok := e.registry.Get(w.serviceID)
+	if !ok {
+		return
+	}
+
+	var target *model.DataDir
+	for i := range tmpl.DataDirs {
+		if tmpl.DataDirs[i].Path == w.path {
+			target = &tmpl.DataDirs[i]
+			break
+		}
+	}
+	if target == nil {
+		slog.Warn("auto-reclaim: watched dir is not declared in DataDirs",
+			"service", w.serviceID, "path", w.path)
+		return
+	}
+
+	running := false
+	for _, name := range tmpl.ContainerNames {
+		if cs, err := docker.InspectContainer(name); err == nil && cs.Status == "running" {
+			running = true
+			break
+		}
+	}
+
+	last, hasLast, err := e.store.LastAuditAt("auto_reclaim", w.serviceID)
+	if err != nil {
+		slog.Error("auto-reclaim: audit lookup failed", "service", w.serviceID, "err", err)
+		return
+	}
+
+	decision := decideReclaim(reclaimInput{
+		SizeBytes:          size,
+		CriticalBytes:      int64(e.getSettingInt(w.criticalKey, 900)) * 1024 * 1024,
+		Enabled:            e.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true",
+		MinInterval:        time.Duration(e.getSettingInt("dir_size_autoreclaim_min_interval_hours", 24)) * time.Hour,
+		LastReclaim:        last,
+		HasLastReclaim:     hasLast,
+		Now:                time.Now().UTC(),
+		ServiceRunning:     running,
+		TargetClearable:    target.Clearable,
+		TargetRequiresStop: target.RequiresStop,
+	})
+	if !decision.Act {
+		slog.Debug("auto-reclaim skipped", "service", w.serviceID, "reason", decision.Reason)
+		return
+	}
+
+	mb := size / (1024 * 1024)
+	slog.Info("auto-reclaim starting", "service", w.serviceID, "path", w.path, "size_mb", mb)
+
+	if err := e.compose.Stop(w.serviceID); err != nil {
+		e.reclaimFailed(w, "stop failed: "+err.Error())
+		return
+	}
+	if err := e.compose.FsClearDir(w.path, 1000, 1000, "0755"); err != nil {
+		// Bring the service back before reporting — a stopped service is
+		// worse than a full cache.
+		if upErr := e.compose.Up(w.serviceID); upErr != nil {
+			slog.Error("auto-reclaim: restart after failed clear also failed",
+				"service", w.serviceID, "err", upErr)
+		}
+		e.reclaimFailed(w, "clear-dir failed: "+err.Error())
+		return
+	}
+	if err := e.compose.Up(w.serviceID); err != nil {
+		// One retry: this is the dangerous state, the service is down.
+		if err2 := e.compose.Up(w.serviceID); err2 != nil {
+			e.reclaimFailed(w, "service did not restart after clear: "+err2.Error())
+			return
+		}
+	}
+
+	_ = e.store.LogAudit("auto_reclaim", w.serviceID,
+		fmt.Sprintf("cleared %s (%d MB) and restarted the service", w.path, mb), "")
+	e.resolve("auto_reclaim_failed", w.serviceID)
+	slog.Info("auto-reclaim complete", "service", w.serviceID, "reclaimed_mb", mb)
+}
+
+// reclaimFailed raises a critical alert and writes the failure to the audit
+// log. Deliberately no automatic retry: a repeated stop/start loop is worse
+// than an oversized cache.
+func (e *Engine) reclaimFailed(w watchedDir, detail string) {
+	slog.Error("auto-reclaim failed", "service", w.serviceID, "detail", detail)
+	_ = e.store.LogAudit("auto_reclaim_failed", w.serviceID, detail, "")
+	e.upsert("auto_reclaim_failed", w.serviceID, model.SeverityCritical,
+		"automatic %s reclaim failed: %s — clear it manually via Settings → Data Dirs",
+		w.humanLabel, detail)
 }
 
 func (e *Engine) checkDisk(disk model.DiskUsage) {

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"truffels-api/internal/docker"
@@ -45,6 +46,21 @@ type Engine struct {
 	// detected from RestartCount deltas because the engine had no prior
 	// baseline.
 	containerStartedAt map[string]time.Time
+
+	// reclaiming guards tryReclaim so at most one stop/clear/start cycle
+	// runs at a time. tryReclaim runs on its own goroutine because each
+	// ComposeClient call (Stop/FsClearDir/Up) can take up to the agent's
+	// 6-minute HTTP timeout — up to four such calls back to back would
+	// otherwise stall this engine's single evaluate() goroutine for ~24
+	// minutes, during which no other alert (temperature, disk, container
+	// health, restart-loop) would be checked and no metric snapshot would
+	// be written.
+	reclaiming atomic.Bool
+
+	// reclaimDone, when non-nil, receives one value after each tryReclaim
+	// goroutine finishes. Test-only synchronization hook so tests can wait
+	// for the goroutine instead of sleeping; production code never sets it.
+	reclaimDone chan struct{}
 }
 
 func NewEngine(s *store.Store, r *service.Registry, c *metrics.Collector, compose *docker.ComposeClient) *Engine {
@@ -251,19 +267,36 @@ func (e *Engine) evalWatchedDirs() {
 		}
 
 		if size >= criticalBytes {
-			e.tryReclaim(w, size)
+			if e.reclaiming.CompareAndSwap(false, true) {
+				go func(w watchedDir, size, criticalBytes int64) {
+					defer func() {
+						e.reclaiming.Store(false)
+						if e.reclaimDone != nil {
+							e.reclaimDone <- struct{}{}
+						}
+					}()
+					e.tryReclaim(w, size, criticalBytes)
+				}(w, size, criticalBytes)
+			} else {
+				slog.Debug("auto-reclaim: previous attempt still running, skipping this tick",
+					"service", w.serviceID)
+			}
 		}
 	}
 }
 
 // tryReclaim executes the stop → clear → start cycle the dir_size_critical
-// alert prescribes, once every guardrail in decideReclaim passes.
+// alert prescribes, once every guardrail in decideReclaim passes. Called on
+// its own goroutine (see evalWatchedDirs) — never called concurrently with
+// itself because of the e.reclaiming CAS guard, but still runs concurrently
+// with the rest of the engine's evaluate() loop, so it must not touch any of
+// the Engine's maps.
 //
 // It resolves the target through the service template's DataDirs rather than
 // trusting w.path directly: a directory that is not declared Clearable and
 // RequiresStop cannot be reached from here, so entries like mempool/mysql are
 // structurally out of range.
-func (e *Engine) tryReclaim(w watchedDir, size int64) {
+func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 	tmpl, ok := e.registry.Get(w.serviceID)
 	if !ok {
 		return
@@ -298,7 +331,7 @@ func (e *Engine) tryReclaim(w watchedDir, size int64) {
 
 	decision := decideReclaim(reclaimInput{
 		SizeBytes:          size,
-		CriticalBytes:      int64(e.getSettingInt(w.criticalKey, 900)) * 1024 * 1024,
+		CriticalBytes:      criticalBytes,
 		Enabled:            e.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true",
 		MinInterval:        time.Duration(e.getSettingInt("dir_size_autoreclaim_min_interval_hours", 24)) * time.Hour,
 		LastReclaim:        last,
@@ -314,45 +347,73 @@ func (e *Engine) tryReclaim(w watchedDir, size int64) {
 	}
 
 	mb := size / (1024 * 1024)
-	slog.Info("auto-reclaim starting", "service", w.serviceID, "path", w.path, "size_mb", mb)
+
+	// Log the attempt BEFORE touching the service, not on success. The 24h
+	// cooldown above is enforced by decideReclaim reading this exact row
+	// back via LastAuditAt("auto_reclaim", serviceID) on the next tick. If
+	// this were only written after a successful Up, a persistent failure
+	// (e.g. clear-dir erroring every time) would leave no row for
+	// LastAuditAt to find, decideReclaim would never see a prior attempt,
+	// and the engine would stop and restart the service on every 30s tick
+	// forever. Writing it here also makes the sequence crash-safe: if
+	// truffels-api restarts between Stop and Up, the attempt is already on
+	// record and won't be repeated within the cooldown window.
+	_ = e.store.LogAudit("auto_reclaim", w.serviceID,
+		fmt.Sprintf("attempting to clear %s (%d MB) and restart the service", target.Path, mb), "")
+
+	slog.Info("auto-reclaim starting", "service", w.serviceID, "path", target.Path, "size_mb", mb)
 
 	if err := e.compose.Stop(w.serviceID); err != nil {
-		e.reclaimFailed(w, "stop failed: "+err.Error())
+		// A Stop-request timeout can still have taken effect on the agent
+		// side, so we can't assert the service is still running here —
+		// treat it as possibly down.
+		e.reclaimFailed(w, true, "stop failed: "+err.Error())
 		return
 	}
-	if err := e.compose.FsClearDir(w.path, 1000, 1000, "0755"); err != nil {
+	if err := e.compose.FsClearDir(target.Path, 1000, 1000, "0755"); err != nil {
 		// Bring the service back before reporting — a stopped service is
 		// worse than a full cache.
 		if upErr := e.compose.Up(w.serviceID); upErr != nil {
-			slog.Error("auto-reclaim: restart after failed clear also failed",
-				"service", w.serviceID, "err", upErr)
+			e.reclaimFailed(w, true, fmt.Sprintf(
+				"clear-dir failed: %s; restart after failed clear also failed: %s", err.Error(), upErr.Error()))
+			return
 		}
-		e.reclaimFailed(w, "clear-dir failed: "+err.Error())
+		e.reclaimFailed(w, false, "clear-dir failed: "+err.Error())
 		return
 	}
 	if err := e.compose.Up(w.serviceID); err != nil {
 		// One retry: this is the dangerous state, the service is down.
 		if err2 := e.compose.Up(w.serviceID); err2 != nil {
-			e.reclaimFailed(w, "service did not restart after clear: "+err2.Error())
+			e.reclaimFailed(w, true, "service did not restart after clear: "+err2.Error())
 			return
 		}
 	}
 
-	_ = e.store.LogAudit("auto_reclaim", w.serviceID,
-		fmt.Sprintf("cleared %s (%d MB) and restarted the service", w.path, mb), "")
 	e.resolve("auto_reclaim_failed", w.serviceID)
 	slog.Info("auto-reclaim complete", "service", w.serviceID, "reclaimed_mb", mb)
 }
 
 // reclaimFailed raises a critical alert and writes the failure to the audit
-// log. Deliberately no automatic retry: a repeated stop/start loop is worse
-// than an oversized cache.
-func (e *Engine) reclaimFailed(w watchedDir, detail string) {
-	slog.Error("auto-reclaim failed", "service", w.serviceID, "detail", detail)
+// log. There is no in-process retry here — the "auto_reclaim" audit row
+// tryReclaim writes before it ever touches the service is what stops a
+// repeated stop/start loop, by consuming the cooldown decideReclaim checks
+// on the next tick regardless of whether this attempt succeeded.
+//
+// serviceMayBeDown selects the remediation text: several failure paths
+// leave the service stopped (or in an unknown state after a Stop timeout),
+// and telling the operator to "clear manually" without mentioning that is
+// misleading — they need to start the service first.
+func (e *Engine) reclaimFailed(w watchedDir, serviceMayBeDown bool, detail string) {
+	slog.Error("auto-reclaim failed", "service", w.serviceID, "detail", detail, "service_may_be_down", serviceMayBeDown)
 	_ = e.store.LogAudit("auto_reclaim_failed", w.serviceID, detail, "")
+
+	remediation := "clear it manually via Settings → Data Dirs"
+	if serviceMayBeDown {
+		remediation = "the service may be stopped — check its status in Services and start it, then clear the cache manually via Settings → Data Dirs if it's still oversized"
+	}
 	e.upsert("auto_reclaim_failed", w.serviceID, model.SeverityCritical,
-		"automatic %s reclaim failed: %s — clear it manually via Settings → Data Dirs",
-		w.humanLabel, detail)
+		"automatic %s reclaim failed: %s — %s",
+		w.humanLabel, detail, remediation)
 }
 
 func (e *Engine) checkDisk(disk model.DiskUsage) {

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -252,9 +252,13 @@ func (e *Engine) evalWatchedDirs() {
 		mb := size / (1024 * 1024)
 		switch {
 		case size >= criticalBytes:
+			tail := "Stop the service and clear the dir via Settings → Data Dirs."
+			if e.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true" {
+				tail = "It will be cleared automatically and the service restarted (~60 s)."
+			}
 			e.upsert(critType, w.serviceID, model.SeverityCritical,
-				"%s reached %d MB — will OOM the backend on next restart. Stop the service and clear the dir via Settings → Data Dirs.",
-				w.humanLabel, mb)
+				"%s reached %d MB — will OOM the backend on next restart. %s",
+				w.humanLabel, mb, tail)
 			e.resolve(warnType, w.serviceID)
 		case size >= warnBytes:
 			e.upsert(warnType, w.serviceID, model.SeverityWarning,

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"truffels-api/internal/docker"
@@ -47,15 +46,27 @@ type Engine struct {
 	// baseline.
 	containerStartedAt map[string]time.Time
 
-	// reclaiming guards tryReclaim so at most one stop/clear/start cycle
-	// runs at a time. tryReclaim runs on its own goroutine because each
-	// ComposeClient call (Stop/FsClearDir/Up) can take up to the agent's
-	// 6-minute HTTP timeout — up to four such calls back to back would
-	// otherwise stall this engine's single evaluate() goroutine for ~24
-	// minutes, during which no other alert (temperature, disk, container
-	// health, restart-loop) would be checked and no metric snapshot would
-	// be written.
-	reclaiming atomic.Bool
+	// reclaimSlot is a one-token semaphore guarding tryReclaim, so at most
+	// one stop/clear/start cycle runs at a time. tryReclaim runs on its own
+	// goroutine because each ComposeClient call (Stop/FsClearDir/Up) can take
+	// up to the agent's 6-minute HTTP timeout — up to four such calls back to
+	// back would otherwise stall this engine's single evaluate() goroutine
+	// for ~24 minutes, during which no other alert (temperature, disk,
+	// container health, restart-loop) would be checked and no metric snapshot
+	// would be written.
+	//
+	// evalWatchedDirs takes the token with a non-blocking receive; the
+	// goroutine returns it when it finishes. Stop() takes the token and never
+	// returns it, which both waits for an in-flight reclaim and prevents a
+	// new one from starting once shutdown has begun.
+	//
+	// A channel and not a mutex on purpose: the reclaim path and evaluate()
+	// deliberately share no mutable state, and a lock both take would
+	// introduce exactly the coupling this design avoids. It is also why this
+	// is not a sync.WaitGroup — Stop() runs concurrently with evaluate(), and
+	// Wait() racing an Add() that lifts the counter off zero is documented
+	// misuse.
+	reclaimSlot chan struct{}
 
 	// reclaimDone, when non-nil, receives one value after each tryReclaim
 	// goroutine finishes. Test-only synchronization hook so tests can wait
@@ -76,6 +87,7 @@ func NewEngine(s *store.Store, r *service.Registry, c *metrics.Collector, compos
 		prevStates:         make(map[string]model.ContainerState),
 		prevContainerStats: make(map[string]docker.ContainerResourceStats),
 		containerStartedAt: make(map[string]time.Time),
+		reclaimSlot:        newReclaimSlot(),
 		// Initialize snapshotTick to 9 so the first ++ on first evaluate
 		// makes it 10 — triggering both the metric-snapshot (%2==0) AND
 		// the trend check (%10==0) immediately. Otherwise stale memory_trend
@@ -85,12 +97,34 @@ func NewEngine(s *store.Store, r *service.Registry, c *metrics.Collector, compos
 	}
 }
 
-func (e *Engine) Start() {
-	go e.loop()
+// newReclaimSlot returns the reclaim semaphore in its idle state: the single
+// token is present, so the next taker may run a reclaim.
+func newReclaimSlot() chan struct{} {
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+	return ch
 }
 
+func (e *Engine) Start() {
+	go func() {
+		// Before the first tick: recover a reclaim sequence that a restart of
+		// truffels-api cut in half. Runs on this goroutine, ahead of loop(),
+		// so no periodic reclaim can begin until recovery has settled.
+		e.recoverInterruptedReclaims()
+		e.loop()
+	}()
+}
+
+// Stop signals the evaluation loop to exit and blocks until any in-flight
+// reclaim has finished. Waiting matters: a reclaim abandoned between Stop and
+// Up leaves the service down with nothing but a generic service_unhealthy
+// warning to show for it. Taking the token and never giving it back also
+// stops evaluate() from starting a fresh reclaim during shutdown.
 func (e *Engine) Stop() {
 	close(e.stopCh)
+	if e.reclaimSlot != nil {
+		<-e.reclaimSlot
+	}
 }
 
 func (e *Engine) loop() {
@@ -252,14 +286,34 @@ func (e *Engine) evalWatchedDirs() {
 		mb := size / (1024 * 1024)
 		switch {
 		case size >= criticalBytes:
-			tail := "Stop the service and clear the dir via Settings → Data Dirs."
-			if e.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true" {
-				tail = "It will be cleared automatically and the service restarted (~60 s)."
-			}
+			// One verdict, used twice: for the wording of this alert and for
+			// the action below. Deriving the message from the same decision
+			// that drives the action is what stops the alert from promising
+			// an automatic reclaim while a guardrail is refusing one.
+			decision, target := e.reclaimVerdict(w, size, criticalBytes)
 			e.upsert(critType, w.serviceID, model.SeverityCritical,
 				"%s reached %d MB — will OOM the backend on next restart. %s",
-				w.humanLabel, mb, tail)
+				w.humanLabel, mb, reclaimTail(decision))
 			e.resolve(warnType, w.serviceID)
+
+			select {
+			case <-e.reclaimSlot:
+				go func(w watchedDir, size int64, decision reclaimDecision, target model.DataDir) {
+					defer func() {
+						// Return the token before signalling the test hook so
+						// a test that waits on reclaimDone always observes an
+						// idle slot afterwards.
+						e.reclaimSlot <- struct{}{}
+						if e.reclaimDone != nil {
+							e.reclaimDone <- struct{}{}
+						}
+					}()
+					e.tryReclaim(w, size, decision, target)
+				}(w, size, decision, target)
+			default:
+				slog.Debug("auto-reclaim: previous attempt still running or engine stopping, skipping this tick",
+					"service", w.serviceID)
+			}
 		case size >= warnBytes:
 			e.upsert(warnType, w.serviceID, model.SeverityWarning,
 				"%s reached %d MB — approaching the size that caused the dev.20 OOM. Consider clearing via Settings → Data Dirs.",
@@ -269,54 +323,121 @@ func (e *Engine) evalWatchedDirs() {
 			e.resolve(warnType, w.serviceID)
 			e.resolve(critType, w.serviceID)
 		}
+	}
+}
 
-		if size >= criticalBytes {
-			if e.reclaiming.CompareAndSwap(false, true) {
-				go func(w watchedDir, size, criticalBytes int64) {
-					defer func() {
-						e.reclaiming.Store(false)
-						if e.reclaimDone != nil {
-							e.reclaimDone <- struct{}{}
-						}
-					}()
-					e.tryReclaim(w, size, criticalBytes)
-				}(w, size, criticalBytes)
+// Audit actions that make up a reclaim sequence. The attempt row is written
+// before the service is touched; exactly one terminal row follows it once the
+// sequence has finished, however it finished. An attempt with no terminal row
+// after it means truffels-api died mid-sequence — see
+// recoverInterruptedReclaims.
+const (
+	auditReclaimAttempt   = "auto_reclaim"
+	auditReclaimComplete  = "auto_reclaim_complete"
+	auditReclaimFailed    = "auto_reclaim_failed"
+	auditReclaimRecovered = "auto_reclaim_recovered"
+)
+
+// reclaimTerminalActions are the audit actions that close a reclaim sequence.
+var reclaimTerminalActions = []string{auditReclaimComplete, auditReclaimFailed, auditReclaimRecovered}
+
+// recoverInterruptedReclaims restarts a service whose reclaim sequence was cut
+// in half by a restart of truffels-api — including the stack self-update path,
+// which restarts the API by design. Without this, an API restart inside the
+// stop→up window leaves the service stopped forever: the next tick sees
+// ServiceRunning=false and refuses to act, and the only visible symptom is a
+// Warning-severity service_unhealthy that looks exactly like a user-initiated
+// stop.
+//
+// Detection compares row *ids*, never timestamps: audit_log.timestamp has
+// one-second resolution, so an attempt and its terminal row written in the
+// same second are indistinguishable by time. id is the table's INTEGER
+// PRIMARY KEY and strictly increasing.
+func (e *Engine) recoverInterruptedReclaims() {
+	for _, w := range watchedDirs {
+		attemptID, hasAttempt, err := e.store.LastAuditID(w.serviceID, auditReclaimAttempt)
+		if err != nil {
+			slog.Error("auto-reclaim recovery: attempt lookup failed", "service", w.serviceID, "err", err)
+			continue
+		}
+		if !hasAttempt {
+			continue
+		}
+		termID, hasTerm, err := e.store.LastAuditID(w.serviceID, reclaimTerminalActions...)
+		if err != nil {
+			slog.Error("auto-reclaim recovery: terminal lookup failed", "service", w.serviceID, "err", err)
+			continue
+		}
+		if hasTerm && termID > attemptID {
+			continue // the last sequence finished; nothing to recover
+		}
+
+		slog.Warn("auto-reclaim: previous attempt has no terminal audit row — recovering",
+			"service", w.serviceID, "attempt_id", attemptID)
+
+		// Raise before acting: compose.Up can block for as long as the
+		// agent's HTTP timeout, and the operator should see the condition
+		// immediately rather than after it returns.
+		e.upsert("auto_reclaim_interrupted", w.serviceID, model.SeverityCritical,
+			"An automatic %s reclaim was interrupted by a restart of truffels-api — %s may have been left stopped. Restarting it now.",
+			w.humanLabel, w.serviceID)
+
+		detail := "restart issued after an interrupted reclaim"
+		switch {
+		case e.compose == nil:
+			detail = "no compose client available to restart the service after an interrupted reclaim"
+			slog.Error("auto-reclaim recovery: no compose client", "service", w.serviceID)
+		default:
+			if err := e.compose.Up(w.serviceID); err != nil {
+				detail = "restart after an interrupted reclaim failed: " + err.Error()
+				slog.Error("auto-reclaim recovery: restart failed", "service", w.serviceID, "err", err)
+				e.upsert("auto_reclaim_interrupted", w.serviceID, model.SeverityCritical,
+					"An automatic %s reclaim was interrupted by a restart of truffels-api and the recovery restart failed: %s — start %s manually from Services.",
+					w.humanLabel, err.Error(), w.serviceID)
 			} else {
-				slog.Debug("auto-reclaim: previous attempt still running, skipping this tick",
-					"service", w.serviceID)
+				slog.Info("auto-reclaim recovery: service restarted", "service", w.serviceID)
 			}
+		}
+
+		// Terminal row either way: the sequence is closed, and one recovery
+		// attempt per interruption is the contract. A failed restart is
+		// carried by the Critical alert above, not by a retry loop.
+		if err := e.store.LogAudit(auditReclaimRecovered, w.serviceID, detail, ""); err != nil {
+			slog.Error("auto-reclaim recovery: could not record the recovery", "service", w.serviceID, "err", err)
 		}
 	}
 }
 
-// tryReclaim executes the stop → clear → start cycle the dir_size_critical
-// alert prescribes, once every guardrail in decideReclaim passes. Called on
-// its own goroutine (see evalWatchedDirs) — never called concurrently with
-// itself because of the e.reclaiming CAS guard, but still runs concurrently
-// with the rest of the engine's evaluate() loop, so it must not touch any of
-// the Engine's maps.
+// reclaimVerdict resolves the reclaim target through the service template's
+// DataDirs and runs every guardrail. It only reads — registry, container
+// state, settings, audit log — and mutates nothing, so it is safe to call
+// from evaluate().
 //
-// It resolves the target through the service template's DataDirs rather than
-// trusting w.path directly: a directory that is not declared Clearable and
+// Resolving the target through DataDirs rather than trusting w.path is the
+// safety property: a directory that is not declared Clearable and
 // RequiresStop cannot be reached from here, so entries like mempool/mysql are
 // structurally out of range.
-func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
+func (e *Engine) reclaimVerdict(w watchedDir, size, criticalBytes int64) (reclaimDecision, model.DataDir) {
+	if e.registry == nil {
+		return reclaimDecision{false, reasonNoTemplate}, model.DataDir{}
+	}
 	tmpl, ok := e.registry.Get(w.serviceID)
 	if !ok {
-		return
+		return reclaimDecision{false, reasonNoTemplate}, model.DataDir{}
 	}
 
-	var target *model.DataDir
-	for i := range tmpl.DataDirs {
-		if tmpl.DataDirs[i].Path == w.path {
-			target = &tmpl.DataDirs[i]
+	var target model.DataDir
+	found := false
+	for _, d := range tmpl.DataDirs {
+		if d.Path == w.path {
+			target, found = d, true
 			break
 		}
 	}
-	if target == nil {
+	if !found {
 		slog.Warn("auto-reclaim: watched dir is not declared in DataDirs",
 			"service", w.serviceID, "path", w.path)
-		return
+		return reclaimDecision{false, reasonNotDeclared}, model.DataDir{}
 	}
 
 	running := false
@@ -327,13 +448,13 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 		}
 	}
 
-	last, hasLast, err := e.store.LastAuditAt("auto_reclaim", w.serviceID)
+	last, hasLast, err := e.store.LastAuditAt(auditReclaimAttempt, w.serviceID)
 	if err != nil {
 		slog.Error("auto-reclaim: audit lookup failed", "service", w.serviceID, "err", err)
-		return
+		return reclaimDecision{false, reasonAuditLookupFailed}, target
 	}
 
-	decision := decideReclaim(reclaimInput{
+	return decideReclaim(reclaimInput{
 		SizeBytes:          size,
 		CriticalBytes:      criticalBytes,
 		Enabled:            e.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true",
@@ -344,7 +465,16 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 		ServiceRunning:     running,
 		TargetClearable:    target.Clearable,
 		TargetRequiresStop: target.RequiresStop,
-	})
+	}), target
+}
+
+// tryReclaim executes the stop → clear → start cycle the dir_size_critical
+// alert prescribes, once the verdict computed by reclaimVerdict says every
+// guardrail passes. Called on its own goroutine (see evalWatchedDirs) — never
+// called concurrently with itself because of the reclaimSlot semaphore, but
+// still runs concurrently with the rest of the engine's evaluate() loop, so
+// it must not touch any of the Engine's maps.
+func (e *Engine) tryReclaim(w watchedDir, size int64, decision reclaimDecision, target model.DataDir) {
 	if !decision.Act {
 		slog.Debug("auto-reclaim skipped", "service", w.serviceID, "reason", decision.Reason)
 		return
@@ -353,19 +483,20 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 	mb := size / (1024 * 1024)
 
 	// Log the attempt BEFORE touching the service, not on success. The 24h
-	// cooldown above is enforced by decideReclaim reading this exact row
-	// back via LastAuditAt("auto_reclaim", serviceID) on the next tick. If
+	// cooldown is enforced by decideReclaim reading this exact row back via
+	// LastAuditAt(auditReclaimAttempt, serviceID) on the next tick. If
 	// this were only written after a successful Up, a persistent failure
 	// (e.g. clear-dir erroring every time) would leave no row for
 	// LastAuditAt to find, decideReclaim would never see a prior attempt,
 	// and the engine would stop and restart the service on every 30s tick
 	// forever.
 	//
-	// This ordering makes the sequence loop-safe, not availability-safe: if
-	// truffels-api crashes between Stop and Up (after this write succeeded),
-	// the cooldown blocks any retry for dir_size_autoreclaim_min_interval_hours
-	// and recovery is manual — the compose reconciler only issues Up when the
-	// compose file itself changed, not on every tick.
+	// This ordering makes the sequence loop-safe. Availability across an API
+	// restart mid-sequence is handled separately, by the terminal row written
+	// at the end of this function and recoverInterruptedReclaims reading it
+	// back at the next engine start — the cooldown alone would otherwise
+	// block any retry for dir_size_autoreclaim_min_interval_hours, and the
+	// compose reconciler only issues Up when the compose file itself changed.
 	//
 	// If the write itself fails (e.g. SQLITE_FULL or an I/O error under disk
 	// pressure — precisely the condition this feature exists to relieve), we
@@ -374,7 +505,7 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 	// would stop and restart the service forever. Refusing to act is the
 	// safe failure here — an oversized cache is a known, alerted condition;
 	// an unbounded stop/start loop is not.
-	if err := e.store.LogAudit("auto_reclaim", w.serviceID,
+	if err := e.store.LogAudit(auditReclaimAttempt, w.serviceID,
 		fmt.Sprintf("attempting to clear %s (%d MB) and restart the service", target.Path, mb), ""); err != nil {
 		e.reclaimFailed(w, false, fmt.Sprintf(
 			"could not record the reclaim attempt: %s — aborting before stopping the service to avoid an uncontrolled restart loop", err.Error()))
@@ -409,7 +540,20 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 		}
 	}
 
+	// Terminal row on the success path. Two jobs: it is the only distinguishable
+	// trace a successful reclaim leaves behind, and it is what tells the next
+	// engine start that this sequence ran to completion — without it,
+	// recoverInterruptedReclaims cannot tell "finished" from "killed between
+	// Stop and Up" and would restart the service on every API start.
+	if err := e.store.LogAudit(auditReclaimComplete, w.serviceID,
+		fmt.Sprintf("cleared %s (%d MB) and restarted the service", target.Path, mb), ""); err != nil {
+		// Nothing to roll back — the service is already back up. The cost is a
+		// spurious recovery Up (and its alert) at the next engine start.
+		slog.Error("auto-reclaim: could not record completion", "service", w.serviceID, "err", err)
+	}
+
 	e.resolve("auto_reclaim_failed", w.serviceID)
+	e.resolve("auto_reclaim_interrupted", w.serviceID)
 	slog.Info("auto-reclaim complete", "service", w.serviceID, "reclaimed_mb", mb)
 }
 
@@ -425,7 +569,8 @@ func (e *Engine) tryReclaim(w watchedDir, size, criticalBytes int64) {
 // misleading — they need to start the service first.
 func (e *Engine) reclaimFailed(w watchedDir, serviceMayBeDown bool, detail string) {
 	slog.Error("auto-reclaim failed", "service", w.serviceID, "detail", detail, "service_may_be_down", serviceMayBeDown)
-	_ = e.store.LogAudit("auto_reclaim_failed", w.serviceID, detail, "")
+	// Terminal row for the sequence — see reclaimTerminalActions.
+	_ = e.store.LogAudit(auditReclaimFailed, w.serviceID, detail, "")
 
 	remediation := "clear it manually via Settings → Data Dirs"
 	if serviceMayBeDown {

--- a/truffels-api/internal/alerts/engine_test.go
+++ b/truffels-api/internal/alerts/engine_test.go
@@ -198,6 +198,7 @@ func newTestEngine(t *testing.T) (*Engine, *store.Store) {
 		autoStopped:        make(map[string]bool),
 		prevStates:         make(map[string]model.ContainerState),
 		prevContainerStats: make(map[string]docker.ContainerResourceStats),
+		reclaimSlot:        newReclaimSlot(),
 	}
 	return e, s
 }
@@ -462,6 +463,7 @@ func newTestEngineWithRegistry(t *testing.T, tmpls []model.ServiceTemplate) (*En
 		autoStopped:        make(map[string]bool),
 		prevStates:         make(map[string]model.ContainerState),
 		prevContainerStats: make(map[string]docker.ContainerResourceStats),
+		reclaimSlot:        newReclaimSlot(),
 	}
 	return e, s
 }

--- a/truffels-api/internal/alerts/reclaim.go
+++ b/truffels-api/internal/alerts/reclaim.go
@@ -34,23 +34,63 @@ type reclaimDecision struct {
 	Reason string
 }
 
+// Refusal reasons. Named because they are matched, not just logged:
+// reclaimTail turns them into the operator-facing tail of the
+// dir_size_critical alert, and a silent string edit would silently change
+// what the alert tells the operator to do.
+const (
+	reasonNotClearable      = "target dir is not marked clearable+requires-stop"
+	reasonDisabled          = "auto-reclaim disabled by setting"
+	reasonBelowThreshold    = "below critical threshold"
+	reasonNotRunning        = "service is not running"
+	reasonCooldown          = "inside minimum interval since last reclaim"
+	reasonNoTemplate        = "no service template for the watched dir"
+	reasonNotDeclared       = "watched dir is not declared in the service template"
+	reasonAuditLookupFailed = "audit lookup failed"
+)
+
 // decideReclaim applies every guardrail in a fixed order. The safety checks
 // come first so a misconfigured target can never reach the size comparison.
 func decideReclaim(in reclaimInput) reclaimDecision {
 	if !in.TargetClearable || !in.TargetRequiresStop {
-		return reclaimDecision{false, "target dir is not marked clearable+requires-stop"}
+		return reclaimDecision{false, reasonNotClearable}
 	}
 	if !in.Enabled {
-		return reclaimDecision{false, "auto-reclaim disabled by setting"}
+		return reclaimDecision{false, reasonDisabled}
 	}
 	if in.SizeBytes < in.CriticalBytes {
-		return reclaimDecision{false, "below critical threshold"}
+		return reclaimDecision{false, reasonBelowThreshold}
 	}
 	if !in.ServiceRunning {
-		return reclaimDecision{false, "service is not running"}
+		return reclaimDecision{false, reasonNotRunning}
 	}
 	if in.HasLastReclaim && in.Now.Sub(in.LastReclaim) < in.MinInterval {
-		return reclaimDecision{false, "inside minimum interval since last reclaim"}
+		return reclaimDecision{false, reasonCooldown}
 	}
 	return reclaimDecision{true, ""}
+}
+
+// reclaimTail is the tail of the dir_size_critical alert message. It is
+// derived from the same verdict that drives the action, so the alert can no
+// longer promise an automatic reclaim while a guardrail is refusing one —
+// previously the tail was chosen from the enabled flag alone, which meant
+// that after a failed reclaim the critical alert kept telling the operator
+// "it will be cleared automatically" for the whole cooldown window while
+// nothing was going to happen, suppressing the manual clear that was by then
+// the only remedy.
+func reclaimTail(d reclaimDecision) string {
+	const manual = "Stop the service and clear the dir via Settings → Data Dirs."
+	switch {
+	case d.Act:
+		return "It will be cleared automatically and the service restarted (~60 s)."
+	case d.Reason == reasonCooldown:
+		return "An automatic reclaim already ran recently and will not run again until the configured minimum interval has elapsed. " + manual
+	case d.Reason == reasonNotRunning:
+		return "Automatic reclaim only runs while the service is running — start the service, or clear the dir via Settings → Data Dirs."
+	default:
+		// Disabled, a target that is not clearable, a missing template, an
+		// unreadable audit log: in every case the operator is the only actor
+		// left, so say so plainly rather than naming an internal reason.
+		return manual
+	}
 }

--- a/truffels-api/internal/alerts/reclaim.go
+++ b/truffels-api/internal/alerts/reclaim.go
@@ -1,0 +1,56 @@
+package alerts
+
+import "time"
+
+// reclaimInput is everything decideReclaim needs. Kept as plain data so the
+// decision is testable without Docker, a store, or a real clock — same shape
+// as the trend evaluation in trend.go.
+type reclaimInput struct {
+	SizeBytes     int64
+	CriticalBytes int64
+
+	Enabled        bool
+	MinInterval    time.Duration
+	LastReclaim    time.Time
+	HasLastReclaim bool
+	Now            time.Time
+
+	// False when no container of the service is running. Also covers initial
+	// block download implicitly: during IBD electrs is not healthy, so mempool
+	// is not running either.
+	ServiceRunning bool
+
+	// Mirrored from the service template's DataDir entry. Both must be true;
+	// this is what keeps the reclaim off directories like mempool/mysql.
+	TargetClearable    bool
+	TargetRequiresStop bool
+}
+
+// reclaimDecision carries the verdict and, when refusing, why. Reason is
+// written to the debug log so an operator can tell "not triggered" from
+// "triggered but blocked".
+type reclaimDecision struct {
+	Act    bool
+	Reason string
+}
+
+// decideReclaim applies every guardrail in a fixed order. The safety checks
+// come first so a misconfigured target can never reach the size comparison.
+func decideReclaim(in reclaimInput) reclaimDecision {
+	if !in.TargetClearable || !in.TargetRequiresStop {
+		return reclaimDecision{false, "target dir is not marked clearable+requires-stop"}
+	}
+	if !in.Enabled {
+		return reclaimDecision{false, "auto-reclaim disabled by setting"}
+	}
+	if in.SizeBytes < in.CriticalBytes {
+		return reclaimDecision{false, "below critical threshold"}
+	}
+	if !in.ServiceRunning {
+		return reclaimDecision{false, "service is not running"}
+	}
+	if in.HasLastReclaim && in.Now.Sub(in.LastReclaim) < in.MinInterval {
+		return reclaimDecision{false, "inside minimum interval since last reclaim"}
+	}
+	return reclaimDecision{true, ""}
+}

--- a/truffels-api/internal/alerts/reclaim_engine_test.go
+++ b/truffels-api/internal/alerts/reclaim_engine_test.go
@@ -1,9 +1,12 @@
 package alerts
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -254,5 +257,67 @@ func TestTryReclaim_SkipsWhenServiceStopped(t *testing.T) {
 	stop, clear, up := mock.counts()
 	if stop != 0 || clear != 0 || up != 0 {
 		t.Fatalf("expected zero agent mutations when service is stopped, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+}
+
+// TestTryReclaim_AuditWriteFailureAbortsBeforeStop is the regression test
+// for fix-round-2's Important finding: if the pre-Stop "auto_reclaim" audit
+// write itself fails (e.g. SQLITE_FULL under disk pressure — the exact
+// condition this feature exists to relieve), tryReclaim must abort before
+// calling Stop, since a missing audit row is what would otherwise let the
+// cooldown guard miss this attempt and loop forever.
+//
+// SQLite's query_only pragma is used to force the write to fail while reads
+// (LastAuditAt, settings lookups) keep succeeding. This matters: closing the
+// whole store connection (the technique used by round-1's regression test)
+// also breaks LastAuditAt's read, which would trip the pre-existing "audit
+// lookup failed" guard a few lines earlier instead of exercising the write
+// failure this test targets — and OS-level file permissions don't reliably
+// force a write failure here because `go test` runs as root in the CI
+// container, which bypasses standard permission bits. query_only reproduces
+// the real SQLITE_FULL shape (reads still work, writes don't) without
+// either problem. e.store.DB() is the store package's existing test-only
+// accessor, already used the same way elsewhere in this package (see
+// trend_test.go).
+//
+// Because query_only blocks every write on this connection for the
+// remainder of the call — not just the one this test targets — the
+// auto_reclaim_failed alert that reclaimFailed raises also fails to persist
+// (an accurate reflection of a real SQLITE_FULL: the alert write would
+// likely fail for the same reason the audit write did, since it's the same
+// disk). What we can and do assert directly: zero Stop/Clear/Up calls, and
+// — via captured log output, since reclaimFailed logs unconditionally
+// before attempting any DB write — that the abort path actually ran with
+// its distinguishing message, not the pre-existing "audit lookup failed"
+// early return.
+func TestTryReclaim_AuditWriteFailureAbortsBeforeStop(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	if _, err := e.store.DB().Exec("PRAGMA query_only = ON"); err != nil {
+		t.Fatalf("set query_only: %v", err)
+	}
+	t.Cleanup(func() { _, _ = e.store.DB().Exec("PRAGMA query_only = OFF") })
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 0 || clear != 0 || up != 0 {
+		t.Fatalf("expected zero agent mutations when the audit write fails, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "could not record the reclaim attempt") {
+		t.Fatalf("expected log evidence the write-failure abort path ran (not the earlier audit-lookup guard), got: %s", logged)
+	}
+	if strings.Contains(logged, "audit lookup failed") {
+		t.Fatalf("hit the pre-existing LastAuditAt read-failure guard instead of the write-failure path under test: %s", logged)
+	}
+	if !strings.Contains(logged, "auto-reclaim failed") {
+		t.Fatalf("expected the alert-raising log line to have run, got: %s", logged)
 	}
 }

--- a/truffels-api/internal/alerts/reclaim_engine_test.go
+++ b/truffels-api/internal/alerts/reclaim_engine_test.go
@@ -171,14 +171,30 @@ func TestTryReclaim_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get audit log: %v", err)
 	}
-	var reclaimRows int
+	var reclaimRows, completeRows int
 	for _, ent := range entries {
-		if ent.Action == "auto_reclaim" && ent.Target == "mempool" {
+		if ent.Target != "mempool" {
+			continue
+		}
+		switch ent.Action {
+		case auditReclaimAttempt:
 			reclaimRows++
+		case auditReclaimComplete:
+			completeRows++
 		}
 	}
 	if reclaimRows != 1 {
 		t.Fatalf("expected exactly 1 auto_reclaim audit row, got %d", reclaimRows)
+	}
+	// A success used to leave no distinguishable trace at all, and — worse —
+	// nothing that told the next engine start the sequence had finished.
+	if completeRows != 1 {
+		t.Fatalf("expected exactly 1 auto_reclaim_complete audit row, got %d", completeRows)
+	}
+	attemptID, _, _ := e.store.LastAuditID("mempool", auditReclaimAttempt)
+	termID, hasTerm, _ := e.store.LastAuditID("mempool", reclaimTerminalActions...)
+	if !hasTerm || termID <= attemptID {
+		t.Fatalf("terminal row must follow the attempt row by id (attempt=%d terminal=%d has=%v)", attemptID, termID, hasTerm)
 	}
 
 	alerts, _ := e.store.GetActiveAlerts()
@@ -320,4 +336,161 @@ func TestTryReclaim_AuditWriteFailureAbortsBeforeStop(t *testing.T) {
 	if !strings.Contains(logged, "auto-reclaim failed") {
 		t.Fatalf("expected the alert-raising log line to have run, got: %s", logged)
 	}
+}
+
+// --- Interrupted-sequence recovery (fix round 3, Important I1) ---
+//
+// An ordinary restart of truffels-api inside the reclaim's stop→up window —
+// including the stack self-update path, which restarts the API by design —
+// used to leave mempool stopped indefinitely: the cooldown row is written
+// before Stop, so the next tick refused to act, and the only symptom was a
+// Warning-severity service_unhealthy indistinguishable from a user-initiated
+// stop.
+
+// TestRecoverInterruptedReclaim_RestartsService seeds an attempt row with no
+// terminal row after it — exactly what a mid-sequence death leaves behind —
+// and asserts the engine restarts the service once and raises a Critical
+// alert. The container is deliberately "exited" here: that is the state an
+// interrupted sequence leaves, and it is also the state that makes every
+// later tick refuse to act.
+func TestRecoverInterruptedReclaim_RestartsService(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 10*1024*1024, "exited", true, true)
+
+	if err := e.store.LogAudit(auditReclaimAttempt, "mempool",
+		"attempting to clear /srv/truffels/data/mempool/cache (950 MB) and restart the service", ""); err != nil {
+		t.Fatalf("seed attempt row: %v", err)
+	}
+
+	e.recoverInterruptedReclaims()
+
+	if _, _, up := mock.counts(); up != 1 {
+		t.Fatalf("expected exactly 1 compose Up after an interrupted reclaim, got %d", up)
+	}
+
+	active, _ := e.store.GetActiveAlerts()
+	var found bool
+	for _, a := range active {
+		if a.Type == "auto_reclaim_interrupted" && a.ServiceID == "mempool" {
+			found = true
+			if a.Severity != model.SeverityCritical {
+				t.Errorf("expected Critical severity, got %v", a.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected an auto_reclaim_interrupted alert, active alerts: %+v", active)
+	}
+
+	// Recovery is one-shot per interruption: the terminal row it writes must
+	// keep the next engine start from restarting the service all over again.
+	e.recoverInterruptedReclaims()
+	if _, _, up := mock.counts(); up != 1 {
+		t.Fatalf("recovery must run once per interruption, got %d Up calls after a second start", up)
+	}
+}
+
+// TestRecoverInterruptedReclaim_CompletedSequenceUntouched is the regression
+// test for the correctness trap this branch has already hit once: the two
+// rows below are written back to back and therefore share an audit_log
+// timestamp (one-second resolution), so "is the terminal row after the
+// attempt?" can only be answered by comparing ids. A timestamp comparison
+// would call this completed sequence interrupted and stop/start the service
+// on every single API start.
+func TestRecoverInterruptedReclaim_CompletedSequenceUntouched(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 10*1024*1024, "running", true, true)
+
+	_ = e.store.LogAudit(auditReclaimAttempt, "mempool", "attempting", "")
+	_ = e.store.LogAudit(auditReclaimComplete, "mempool", "cleared", "")
+
+	entries, _ := e.store.GetAuditLog(10)
+	if len(entries) >= 2 && entries[0].Timestamp != entries[1].Timestamp {
+		t.Logf("note: the two rows landed in different seconds (%q vs %q); the identical-timestamp case is pinned deterministically by store.TestLastAuditID_SameTimestampOrdersByID",
+			entries[1].Timestamp, entries[0].Timestamp)
+	}
+
+	e.recoverInterruptedReclaims()
+
+	if _, _, up := mock.counts(); up != 0 {
+		t.Fatalf("a completed sequence must not be recovered, got %d Up calls", up)
+	}
+	active, _ := e.store.GetActiveAlerts()
+	for _, a := range active {
+		if a.Type == "auto_reclaim_interrupted" {
+			t.Fatalf("a completed sequence must not raise auto_reclaim_interrupted: %+v", a)
+		}
+	}
+}
+
+// TestRecoverInterruptedReclaim_FailedSequenceUntouched pins that a reclaim
+// that failed and said so is a finished sequence, not an interrupted one.
+func TestRecoverInterruptedReclaim_FailedSequenceUntouched(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 10*1024*1024, "running", true, true)
+
+	_ = e.store.LogAudit(auditReclaimAttempt, "mempool", "attempting", "")
+	_ = e.store.LogAudit(auditReclaimFailed, "mempool", "clear-dir failed", "")
+
+	e.recoverInterruptedReclaims()
+
+	if _, _, up := mock.counts(); up != 0 {
+		t.Fatalf("a failed-but-terminated sequence must not be recovered, got %d Up calls", up)
+	}
+}
+
+// --- Alert copy tracks the real verdict (fix round 3, Important I2) ---
+
+// TestDirSizeCritical_TailPromisesReclaimWhenItWillRun is the positive case.
+func TestDirSizeCritical_TailPromisesReclaimWhenItWillRun(t *testing.T) {
+	e, _ := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+
+	waitReclaim(t, e)
+
+	msg := criticalDirSizeMessage(t, e)
+	if !strings.Contains(msg, "cleared automatically") {
+		t.Fatalf("expected the alert to announce the automatic reclaim, got: %s", msg)
+	}
+}
+
+// TestDirSizeCritical_TailDropsPromiseInsideCooldown covers the reported
+// defect: after a reclaim attempt (successful or failed) the cooldown blocks
+// any further attempt, and the alert used to keep promising an automatic
+// clear "(~60 s)" for the whole window — suppressing the manual clear that
+// was by then the only remedy.
+func TestDirSizeCritical_TailDropsPromiseInsideCooldown(t *testing.T) {
+	e, _ := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+	_ = e.store.LogAudit(auditReclaimAttempt, "mempool", "prior attempt", "")
+
+	waitReclaim(t, e)
+
+	msg := criticalDirSizeMessage(t, e)
+	if strings.Contains(msg, "cleared automatically") {
+		t.Fatalf("alert promises an automatic reclaim the cooldown is refusing: %s", msg)
+	}
+	if !strings.Contains(msg, "Settings → Data Dirs") {
+		t.Fatalf("expected the manual remediation to be named, got: %s", msg)
+	}
+}
+
+// TestDirSizeCritical_TailDropsPromiseWhenNotRunning covers the other
+// guardrail the old wording ignored.
+func TestDirSizeCritical_TailDropsPromiseWhenNotRunning(t *testing.T) {
+	e, _ := newReclaimTestEngine(t, 950*1024*1024, "exited", true, true)
+
+	waitReclaim(t, e)
+
+	msg := criticalDirSizeMessage(t, e)
+	if strings.Contains(msg, "cleared automatically") {
+		t.Fatalf("alert promises an automatic reclaim while the service is stopped: %s", msg)
+	}
+}
+
+func criticalDirSizeMessage(t *testing.T, e *Engine) string {
+	t.Helper()
+	active, _ := e.store.GetActiveAlerts()
+	for _, a := range active {
+		if a.Type == "dir_size_critical" && a.ServiceID == "mempool" {
+			return a.Message
+		}
+	}
+	t.Fatalf("no dir_size_critical alert raised, active alerts: %+v", active)
+	return ""
 }

--- a/truffels-api/internal/alerts/reclaim_engine_test.go
+++ b/truffels-api/internal/alerts/reclaim_engine_test.go
@@ -1,0 +1,258 @@
+package alerts
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"truffels-api/internal/docker"
+	"truffels-api/internal/model"
+)
+
+// reclaimTestDirPath must match watchedDirs[0].path (the mempool cache entry)
+// so evalWatchedDirs' single watched-dir loop exercises the reclaim path.
+const reclaimTestDirPath = "/srv/truffels/data/mempool/cache"
+
+// mockComposeAgent is a fake agent HTTP server serving the endpoints
+// ComposeClient hits during a reclaim attempt: dir-size, stop, clear-dir,
+// and up. Each endpoint has an independent call counter and an optional
+// failure switch so tests can force stop/clear/up to fail individually.
+type mockComposeAgent struct {
+	mu sync.Mutex
+
+	dirSizeBytes int64
+
+	stopCalls, clearCalls, upCalls int
+	failStop, failClear, failUp    bool
+}
+
+func newMockComposeAgent(t *testing.T, dirSizeBytes int64) (*httptest.Server, *mockComposeAgent) {
+	t.Helper()
+	m := &mockComposeAgent{dirSizeBytes: dirSizeBytes}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		switch r.URL.Path {
+		case "/v1/host/dir-size":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"size_bytes": m.dirSizeBytes, "fresh": true,
+			})
+		case "/v1/compose/stop":
+			m.stopCalls++
+			if m.failStop {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "stop failed"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/v1/fs/clear-dir":
+			m.clearCalls++
+			if m.failClear {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "clear-dir failed"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/v1/compose/up":
+			m.upCalls++
+			if m.failUp {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "up failed"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, m
+}
+
+func (m *mockComposeAgent) counts() (stop, clear, up int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stopCalls, m.clearCalls, m.upCalls
+}
+
+// reclaimTestTemplate builds a mempool service template with a single
+// DataDirs entry matching watchedDirs[0].path.
+func reclaimTestTemplate(clearable, requiresStop bool) model.ServiceTemplate {
+	return model.ServiceTemplate{
+		ID:             "mempool",
+		DisplayName:    "mempool",
+		ContainerNames: []string{"truffels-mempool-backend"},
+		DataDirs: []model.DataDir{
+			{
+				Path:         reclaimTestDirPath,
+				Label:        "cache",
+				Clearable:    clearable,
+				RequiresStop: requiresStop,
+			},
+		},
+	}
+}
+
+// newReclaimTestEngine wires an engine with a mock compose agent (size,
+// stop/clear/up) and a mock inspect agent (container running state), and
+// arms e.reclaimDone so the caller can wait for tryReclaim's goroutine
+// instead of sleeping.
+func newReclaimTestEngine(t *testing.T, dirSizeBytes int64, containerStatus string, clearable, requiresStop bool) (*Engine, *mockComposeAgent) {
+	t.Helper()
+	setupMockAgent(t, map[string]model.ContainerState{
+		"truffels-mempool-backend": {Name: "truffels-mempool-backend", Status: containerStatus},
+	})
+
+	tmpl := reclaimTestTemplate(clearable, requiresStop)
+	e, _ := newTestEngineWithRegistry(t, []model.ServiceTemplate{tmpl})
+
+	srv, mock := newMockComposeAgent(t, dirSizeBytes)
+	e.compose = docker.NewComposeClient(srv.URL)
+	e.reclaimDone = make(chan struct{}, 1)
+
+	return e, mock
+}
+
+// waitReclaim runs evalWatchedDirs and blocks until the spawned tryReclaim
+// goroutine (if any) has completed, or the deadline is hit.
+func waitReclaim(t *testing.T, e *Engine) {
+	t.Helper()
+	e.evalWatchedDirs()
+	select {
+	case <-e.reclaimDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for tryReclaim to complete")
+	}
+}
+
+// TestTryReclaim_FailedClearDoesNotLoop is the regression test for the
+// Critical defect found in fix round 1: a failed reclaim attempt must still
+// consume the cooldown, or the engine stops and restarts the service every
+// tick forever. clear-dir fails, the rollback up succeeds (service stays
+// running), and evalWatchedDirs is driven twice — Stop must be called
+// exactly once.
+func TestTryReclaim_FailedClearDoesNotLoop(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+	mock.failClear = true
+
+	waitReclaim(t, e)
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 1 {
+		t.Fatalf("expected exactly 1 stop call across two attempts, got %d (clear=%d up=%d)", stop, clear, up)
+	}
+}
+
+// TestTryReclaim_HappyPath asserts the full stop -> clear -> up sequence,
+// exactly one auto_reclaim audit row, and that any existing
+// auto_reclaim_failed alert is resolved.
+func TestTryReclaim_HappyPath(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+
+	// Seed a pre-existing failure alert to confirm it gets resolved.
+	e.upsert("auto_reclaim_failed", "mempool", model.SeverityCritical, "prior failure")
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 1 || clear != 1 || up != 1 {
+		t.Fatalf("expected stop=1 clear=1 up=1, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+
+	entries, err := e.store.GetAuditLog(50)
+	if err != nil {
+		t.Fatalf("get audit log: %v", err)
+	}
+	var reclaimRows int
+	for _, ent := range entries {
+		if ent.Action == "auto_reclaim" && ent.Target == "mempool" {
+			reclaimRows++
+		}
+	}
+	if reclaimRows != 1 {
+		t.Fatalf("expected exactly 1 auto_reclaim audit row, got %d", reclaimRows)
+	}
+
+	alerts, _ := e.store.GetActiveAlerts()
+	for _, a := range alerts {
+		if a.Type == "auto_reclaim_failed" {
+			t.Fatalf("expected auto_reclaim_failed alert to be resolved, still active: %+v", a)
+		}
+	}
+}
+
+// TestTryReclaim_RespectsMinInterval pre-seeds an auto_reclaim audit row one
+// hour old (well inside the 24h default cooldown) and asserts no agent
+// mutation happens.
+func TestTryReclaim_RespectsMinInterval(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+
+	_ = e.store.LogAudit("auto_reclaim", "mempool", "prior attempt", "")
+	// LogAudit uses the DB's own timestamp (now), which is inside the 24h
+	// window by construction — no need to backdate for the interval guard
+	// to trigger.
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 0 || clear != 0 || up != 0 {
+		t.Fatalf("expected zero agent mutations, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+}
+
+// TestTryReclaim_RefusesNonClearableDir points the watched dir at a
+// DataDirs entry that is not Clearable and asserts FsClearDir (and Stop) are
+// never called.
+func TestTryReclaim_RefusesNonClearableDir(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", false, true)
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 0 || clear != 0 || up != 0 {
+		t.Fatalf("expected zero agent mutations for non-clearable dir, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+}
+
+// TestTryReclaim_ClearFailsRollsBackUp asserts Up is called even when
+// clear-dir returns an error, and that the failure alert is raised.
+func TestTryReclaim_ClearFailsRollsBackUp(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "running", true, true)
+	mock.failClear = true
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 1 || clear != 1 || up != 1 {
+		t.Fatalf("expected stop=1 clear=1 up=1 (rollback), got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+
+	alerts, _ := e.store.GetActiveAlerts()
+	var found bool
+	for _, a := range alerts {
+		if a.Type == "auto_reclaim_failed" && a.ServiceID == "mempool" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected auto_reclaim_failed alert to be raised, active alerts: %+v", alerts)
+	}
+}
+
+// TestTryReclaim_SkipsWhenServiceStopped asserts zero agent mutations when
+// the container is not running.
+func TestTryReclaim_SkipsWhenServiceStopped(t *testing.T) {
+	e, mock := newReclaimTestEngine(t, 950*1024*1024, "exited", true, true)
+
+	waitReclaim(t, e)
+
+	stop, clear, up := mock.counts()
+	if stop != 0 || clear != 0 || up != 0 {
+		t.Fatalf("expected zero agent mutations when service is stopped, got stop=%d clear=%d up=%d", stop, clear, up)
+	}
+}

--- a/truffels-api/internal/alerts/reclaim_test.go
+++ b/truffels-api/internal/alerts/reclaim_test.go
@@ -1,0 +1,69 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+)
+
+// baseInput is a case that should reclaim. Each test mutates one field so a
+// failure names exactly one guardrail.
+func baseInput() reclaimInput {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	return reclaimInput{
+		SizeBytes:       950 * 1024 * 1024,
+		CriticalBytes:   900 * 1024 * 1024,
+		Enabled:         true,
+		MinInterval:     24 * time.Hour,
+		LastReclaim:     now.Add(-48 * time.Hour),
+		HasLastReclaim:  true,
+		Now:             now,
+		ServiceRunning:  true,
+		TargetClearable: true,
+		TargetRequiresStop: true,
+	}
+}
+
+func TestDecideReclaim_ActsWhenAllConditionsMet(t *testing.T) {
+	d := decideReclaim(baseInput())
+	if !d.Act {
+		t.Fatalf("expected Act=true, got false (%s)", d.Reason)
+	}
+}
+
+func TestDecideReclaim_Guardrails(t *testing.T) {
+	now := baseInput().Now
+	cases := []struct {
+		name   string
+		mutate func(*reclaimInput)
+	}{
+		{"below threshold", func(i *reclaimInput) { i.SizeBytes = 800 * 1024 * 1024 }},
+		{"disabled", func(i *reclaimInput) { i.Enabled = false }},
+		{"inside min interval", func(i *reclaimInput) { i.LastReclaim = now.Add(-1 * time.Hour) }},
+		{"service not running", func(i *reclaimInput) { i.ServiceRunning = false }},
+		{"target not clearable", func(i *reclaimInput) { i.TargetClearable = false }},
+		{"target not requires-stop", func(i *reclaimInput) { i.TargetRequiresStop = false }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := baseInput()
+			tc.mutate(&in)
+			d := decideReclaim(in)
+			if d.Act {
+				t.Errorf("expected Act=false for %q", tc.name)
+			}
+			if d.Reason == "" {
+				t.Error("expected a non-empty Reason when refusing")
+			}
+		})
+	}
+}
+
+// A first-ever reclaim has no prior audit entry and must not be blocked.
+func TestDecideReclaim_NoPriorReclaimIsAllowed(t *testing.T) {
+	in := baseInput()
+	in.HasLastReclaim = false
+	in.LastReclaim = time.Time{}
+	if d := decideReclaim(in); !d.Act {
+		t.Fatalf("expected Act=true on first reclaim, got %s", d.Reason)
+	}
+}

--- a/truffels-api/internal/api/auth.go
+++ b/truffels-api/internal/api/auth.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -128,8 +129,42 @@ func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// maxAuditLimit caps ?limit= so a client cannot ask the API to materialise
+// the entire audit_log in one response.
+const maxAuditLimit = 1000
+
+// handleAuditLog serves GET /api/audit.
+//
+// ?limit= (default 100, capped at maxAuditLimit) and ?action= are both
+// optional; omitting them keeps the previous unfiltered 100-row behaviour for
+// existing callers. The action filter exists because the client used to pull
+// an unfiltered page and scan it for a single rare action (auto_reclaim,
+// which fires roughly weekly by design) — once 100 logins, service actions
+// and update rows had accumulated, the row it was looking for had silently
+// fallen off the end.
 func (s *Server) handleAuditLog(w http.ResponseWriter, r *http.Request) {
-	entries, err := s.store.GetAuditLog(100)
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be a positive integer"})
+			return
+		}
+		if n > maxAuditLimit {
+			n = maxAuditLimit
+		}
+		limit = n
+	}
+
+	var (
+		entries []store.AuditEntry
+		err     error
+	)
+	if action := r.URL.Query().Get("action"); action != "" {
+		entries, err = s.store.GetAuditLogByAction(action, limit)
+	} else {
+		entries, err = s.store.GetAuditLog(limit)
+	}
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/truffels-api/internal/api/handlers_test.go
+++ b/truffels-api/internal/api/handlers_test.go
@@ -427,6 +427,64 @@ func TestHandleAuditLog(t *testing.T) {
 	}
 }
 
+// TestHandleAuditLog_LimitAndActionFilter covers the two query parameters the
+// handler used to ignore. The client sent ?limit= and got a hardcoded 100
+// rows back, then scanned that unfiltered page for a single rare action —
+// which quietly stopped being present once 100 logins and service actions had
+// accumulated ahead of it.
+func TestHandleAuditLog_LimitAndActionFilter(t *testing.T) {
+	srv, st := newTestServer(t)
+	for i := 0; i < 5; i++ {
+		_ = st.LogAudit("noise", "", "", "")
+	}
+	_ = st.LogAudit("auto_reclaim", "mempool", "attempting", "")
+	for i := 0; i < 5; i++ {
+		_ = st.LogAudit("noise", "", "", "")
+	}
+
+	get := func(query string) []map[string]interface{} {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := authenticatedRequest(t, srv, "GET", "/api/truffels/audit"+query, "")
+		srv.Router().ServeHTTP(w, req)
+		if w.Code != 200 {
+			t.Fatalf("GET %s: expected 200, got %d: %s", query, w.Code, w.Body.String())
+		}
+		var entries []map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &entries); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return entries
+	}
+
+	// limit is honoured, not ignored.
+	if entries := get("?limit=3"); len(entries) != 3 {
+		t.Fatalf("expected 3 entries with ?limit=3, got %d", len(entries))
+	}
+
+	// The action filter reaches past the noise that would bury the row.
+	entries := get("?limit=1&action=auto_reclaim")
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 auto_reclaim entry, got %d", len(entries))
+	}
+	if entries[0]["action"] != "auto_reclaim" {
+		t.Fatalf("expected the auto_reclaim row, got %v", entries[0]["action"])
+	}
+
+	// No parameters keeps the previous behaviour for existing callers.
+	if entries := get(""); len(entries) < 11 {
+		t.Fatalf("unfiltered default must still return the whole recent log, got %d", len(entries))
+	}
+
+	// A nonsensical limit is rejected rather than silently reinterpreted.
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "GET", "/api/truffels/audit?limit=0", "")
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for ?limit=0, got %d", w.Code)
+	}
+}
+
 // --- System Restart / Shutdown ---
 
 func TestSystemRestart_WrongPassword(t *testing.T) {

--- a/truffels-api/internal/api/settings.go
+++ b/truffels-api/internal/api/settings.go
@@ -30,6 +30,10 @@ var settingsDefaults = map[string]string{
 	"trend_alert_lookback_hours":     "6",
 	"trend_alert_min_data_hours":     "2",
 	"allow_downgrade":                "false",
+	"dir_size_warning_mb":                     "700",
+	"dir_size_critical_mb":                    "900",
+	"dir_size_autoreclaim_enabled":            "true",
+	"dir_size_autoreclaim_min_interval_hours": "24",
 }
 
 type settingsResponse struct {
@@ -52,6 +56,10 @@ type settingsResponse struct {
 	TrendAlertLookbackHours  int     `json:"trend_alert_lookback_hours"`
 	TrendAlertMinDataHours   int     `json:"trend_alert_min_data_hours"`
 	AllowDowngrade           bool    `json:"allow_downgrade"`
+	DirSizeWarningMB                   int  `json:"dir_size_warning_mb"`
+	DirSizeCriticalMB                  int  `json:"dir_size_critical_mb"`
+	DirSizeAutoreclaimEnabled          bool `json:"dir_size_autoreclaim_enabled"`
+	DirSizeAutoreclaimMinIntervalHours int  `json:"dir_size_autoreclaim_min_interval_hours"`
 }
 
 func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
@@ -75,6 +83,10 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		TrendAlertLookbackHours:  s.getSettingInt("trend_alert_lookback_hours", 6),
 		TrendAlertMinDataHours:   s.getSettingInt("trend_alert_min_data_hours", 2),
 		AllowDowngrade:           s.getSettingStr("allow_downgrade", "false") == "true",
+		DirSizeWarningMB:                   s.getSettingInt("dir_size_warning_mb", 700),
+		DirSizeCriticalMB:                  s.getSettingInt("dir_size_critical_mb", 900),
+		DirSizeAutoreclaimEnabled:          s.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true",
+		DirSizeAutoreclaimMinIntervalHours: s.getSettingInt("dir_size_autoreclaim_min_interval_hours", 24),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -83,6 +95,16 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	var body map[string]json.RawMessage
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	// Validate the dir_size_* settings before writing anything. These drive
+	// the unattended stop/clear/restart auto-reclaim behaviour, so a bad
+	// value (e.g. dir_size_critical_mb = 0) has real consequences — see
+	// task-3b brief. This pass must complete before the first SetSetting
+	// call below for any of these keys.
+	if msg := s.validateDirSizeSettings(body); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
 		return
 	}
 
@@ -424,6 +446,72 @@ func (s *Server) handleSystemTuningSet(w http.ResponseWriter, r *http.Request) {
 
 	_ = s.store.LogAudit("system_tuning", "", "Tuning: "+body.Action+"="+body.Value, r.RemoteAddr)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// validateDirSizeSettings validates the dir_size_* keys in an incoming PUT
+// body, if present. It returns a non-empty error message (naming the
+// offending key) if validation fails, or "" if the request is valid.
+//
+// The two thresholds are compared as "effective" values: the value in this
+// request if the key is present, otherwise the value currently stored (or
+// its default). A PUT may carry only one of the two thresholds, so
+// validating the request body in isolation is not enough to catch e.g.
+// dir_size_warning_mb raised above an unrelated, already-stored critical
+// value.
+func (s *Server) validateDirSizeSettings(body map[string]json.RawMessage) string {
+	if raw, ok := body["dir_size_critical_mb"]; ok {
+		n, valid := parseIntFromRaw(raw)
+		if !valid || n < 1 {
+			return "dir_size_critical_mb must be an integer >= 1"
+		}
+	}
+	if raw, ok := body["dir_size_warning_mb"]; ok {
+		n, valid := parseIntFromRaw(raw)
+		if !valid || n < 1 {
+			return "dir_size_warning_mb must be an integer >= 1"
+		}
+	}
+	if raw, ok := body["dir_size_autoreclaim_min_interval_hours"]; ok {
+		n, valid := parseIntFromRaw(raw)
+		if !valid || n < 1 {
+			return "dir_size_autoreclaim_min_interval_hours must be an integer >= 1"
+		}
+	}
+
+	warningRaw, warningPresent := body["dir_size_warning_mb"]
+	criticalRaw, criticalPresent := body["dir_size_critical_mb"]
+	if warningPresent || criticalPresent {
+		effectiveWarning := s.getSettingInt("dir_size_warning_mb", 700)
+		if warningPresent {
+			effectiveWarning, _ = parseIntFromRaw(warningRaw)
+		}
+		effectiveCritical := s.getSettingInt("dir_size_critical_mb", 900)
+		if criticalPresent {
+			effectiveCritical, _ = parseIntFromRaw(criticalRaw)
+		}
+		if effectiveWarning >= effectiveCritical {
+			return "dir_size_warning_mb must be strictly less than dir_size_critical_mb"
+		}
+	}
+
+	return ""
+}
+
+// parseIntFromRaw extracts an int from a raw JSON value that may be encoded
+// as a JSON number or as a numeric string (handleUpdateSettings accepts
+// both). Returns ok=false if the value can't be parsed as an integer.
+func parseIntFromRaw(raw json.RawMessage) (n int, ok bool) {
+	var num float64
+	if err := json.Unmarshal(raw, &num); err == nil {
+		return int(num), true
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		if v, err := strconv.Atoi(str); err == nil {
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func (s *Server) getSettingStr(key, def string) string {

--- a/truffels-api/internal/api/settings_test.go
+++ b/truffels-api/internal/api/settings_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- dir_size_* settings (Task 3b: expose auto-reclaim settings) ---
+
+func TestSettingsGet_DirSizeDefaults(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "GET", "/api/truffels/settings", "")
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp settingsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.DirSizeWarningMB != 700 {
+		t.Errorf("expected dir_size_warning_mb=700, got %d", resp.DirSizeWarningMB)
+	}
+	if resp.DirSizeCriticalMB != 900 {
+		t.Errorf("expected dir_size_critical_mb=900, got %d", resp.DirSizeCriticalMB)
+	}
+	if resp.DirSizeAutoreclaimEnabled != true {
+		t.Errorf("expected dir_size_autoreclaim_enabled=true, got %v", resp.DirSizeAutoreclaimEnabled)
+	}
+	if resp.DirSizeAutoreclaimMinIntervalHours != 24 {
+		t.Errorf("expected dir_size_autoreclaim_min_interval_hours=24, got %d", resp.DirSizeAutoreclaimMinIntervalHours)
+	}
+}
+
+func TestSettingsPut_DirSizeValidValues_Roundtrip(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body := `{
+		"dir_size_warning_mb": 500,
+		"dir_size_critical_mb": 800,
+		"dir_size_autoreclaim_enabled": true,
+		"dir_size_autoreclaim_min_interval_hours": 12
+	}`
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "PUT", "/api/truffels/settings", body)
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w2 := httptest.NewRecorder()
+	req2 := authenticatedRequest(t, srv, "GET", "/api/truffels/settings", "")
+	srv.Router().ServeHTTP(w2, req2)
+
+	if w2.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	var resp settingsResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.DirSizeWarningMB != 500 {
+		t.Errorf("expected dir_size_warning_mb=500, got %d", resp.DirSizeWarningMB)
+	}
+	if resp.DirSizeCriticalMB != 800 {
+		t.Errorf("expected dir_size_critical_mb=800, got %d", resp.DirSizeCriticalMB)
+	}
+	if resp.DirSizeAutoreclaimEnabled != true {
+		t.Errorf("expected dir_size_autoreclaim_enabled=true, got %v", resp.DirSizeAutoreclaimEnabled)
+	}
+	if resp.DirSizeAutoreclaimMinIntervalHours != 12 {
+		t.Errorf("expected dir_size_autoreclaim_min_interval_hours=12, got %d", resp.DirSizeAutoreclaimMinIntervalHours)
+	}
+}
+
+func TestSettingsPut_DirSizeCriticalZero_Rejected(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "PUT", "/api/truffels/settings",
+		`{"dir_size_critical_mb": 0}`)
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errBody map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &errBody)
+	if !strings.Contains(errBody["error"], "dir_size_critical_mb") {
+		t.Errorf("expected error to name dir_size_critical_mb, got %q", errBody["error"])
+	}
+}
+
+func TestSettingsPut_WarningAboveStoredCritical_Rejected(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// Body carries only the warning threshold. The stored (default) critical
+	// is 900, so the effective comparison must use the stored value, not
+	// just what's in this request body.
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "PUT", "/api/truffels/settings",
+		`{"dir_size_warning_mb": 2000}`)
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errBody map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &errBody)
+	if !strings.Contains(errBody["error"], "dir_size_warning_mb") {
+		t.Errorf("expected error to name dir_size_warning_mb, got %q", errBody["error"])
+	}
+
+	// And the bad value must not have been persisted.
+	w2 := httptest.NewRecorder()
+	req2 := authenticatedRequest(t, srv, "GET", "/api/truffels/settings", "")
+	srv.Router().ServeHTTP(w2, req2)
+	var resp settingsResponse
+	_ = json.Unmarshal(w2.Body.Bytes(), &resp)
+	if resp.DirSizeWarningMB != 700 {
+		t.Errorf("rejected PUT must not persist: expected dir_size_warning_mb still 700, got %d", resp.DirSizeWarningMB)
+	}
+}
+
+func TestSettingsPut_AutoreclaimKillSwitch(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := authenticatedRequest(t, srv, "PUT", "/api/truffels/settings",
+		`{"dir_size_autoreclaim_enabled": false}`)
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w2 := httptest.NewRecorder()
+	req2 := authenticatedRequest(t, srv, "GET", "/api/truffels/settings", "")
+	srv.Router().ServeHTTP(w2, req2)
+
+	var resp settingsResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.DirSizeAutoreclaimEnabled != false {
+		t.Fatalf("expected dir_size_autoreclaim_enabled=false after kill switch, got %v", resp.DirSizeAutoreclaimEnabled)
+	}
+}

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -213,7 +213,14 @@ services:
         limits:
           memory: 3072M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1; rc=$$?; rm -f /backend/cache/.starting 2>/dev/null; exit $$rc"]
+      # Clears the boot-guard sentinel, but only on a probe that actually
+      # succeeded: Docker also runs this during start_period (those runs just
+      # don't count toward the retries budget), so an unconditional rm deletes the
+      # sentinel at t≈30s while the backend is still parsing the cache — and
+      # the guard would then be inert for exactly the slow-start OOM loop it
+      # exists to break. rc is captured before the rm so a failing rm can
+      # never flip a passing check to failing.
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1; rc=$$?; if [ $$rc -eq 0 ]; then rm -f /backend/cache/.starting 2>/dev/null; fi; exit $$rc"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -213,7 +213,7 @@ services:
         limits:
           memory: 3072M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 && rm -f /backend/cache/.starting || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1; rc=$$?; rm -f /backend/cache/.starting 2>/dev/null; exit $$rc"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -165,6 +165,23 @@ services:
     image: {{.BackendImageTag}}
     container_name: truffels-mempool-backend
     restart: unless-stopped
+    # Boot guard: the sentinel is written at every start and removed by the
+    # healthcheck on first success. If it is still here at the next start, the
+    # previous one never became healthy — almost always a heap OOM while
+    # reloading an oversized cache — so drop the cache and rebuild from live
+    # data. Ported from Start9Labs/mempool-startos.
+    # Must exec start.sh (the image's own Cmd): it renders mempool-config.json
+    # from the MEMPOOL_* env vars before starting node.
+    command:
+      - /bin/sh
+      - -c
+      - >-
+        if [ -e /backend/cache/.starting ]; then
+        echo "mempool: previous start did not reach readiness; clearing backend disk cache to break a possible out-of-memory boot loop" >&2;
+        rm -rf /backend/cache/* /backend/cache/.[!.]* 2>/dev/null || true;
+        fi;
+        : > /backend/cache/.starting;
+        exec /backend/start.sh
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -196,7 +213,7 @@ services:
         limits:
           memory: 3072M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8999/api/v1/blocks/tip/height >/dev/null 2>&1 && rm -f /backend/cache/.starting || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -57,6 +57,16 @@ func TestRender_Mempool(t *testing.T) {
 	assertContains(t, got, "start_period: 300s")
 	// Frontend healthcheck.
 	assertContains(t, got, "http://127.0.0.1:8080/")
+	// Boot guard: a start that never became healthy leaves the sentinel behind,
+	// so the next start clears the cache instead of OOMing on the same file.
+	assertContains(t, got, "/backend/cache/.starting")
+	assertContains(t, got, "exec /backend/start.sh")
+	// Must wrap start.sh, not node — start.sh renders mempool-config.json from
+	// the MEMPOOL_* env vars, so wrapping node would drop all configuration.
+	if strings.Contains(got, "exec node ") {
+		t.Error("boot guard must exec /backend/start.sh, not node directly")
+	}
+	assertContains(t, got, "rm -f /backend/cache/.starting")
 }
 
 func TestRender_Ckstats(t *testing.T) {

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -79,6 +79,15 @@ func TestRender_Mempool(t *testing.T) {
 	if strings.Contains(got, "&& rm -f /backend/cache/.starting || exit 1") {
 		t.Error("healthcheck must not couple rm's exit status to service health")
 	}
+	// ...and the removal must happen ONLY on a successful probe. Docker runs
+	// the healthcheck during start_period as well (those runs merely don't
+	// count toward `retries`), so an unconditional rm deletes the sentinel at
+	// the first probe — t≈30s, while the backend is still parsing an
+	// oversized rbfcache.json — and the boot guard is then inert for exactly
+	// the slow-start OOM loop it exists to break. Pinning the `if` keeps both
+	// properties at once: conditional removal, and an rm whose own exit
+	// status can never flip the verdict.
+	assertContains(t, got, "if [ $$rc -eq 0 ]; then rm -f /backend/cache/.starting")
 }
 
 func TestRender_Ckstats(t *testing.T) {

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -67,6 +67,18 @@ func TestRender_Mempool(t *testing.T) {
 		t.Error("boot guard must exec /backend/start.sh, not node directly")
 	}
 	assertContains(t, got, "rm -f /backend/cache/.starting")
+	// The healthcheck's exit status must reflect wget alone, not wget-&& rm.
+	// Capture the real status before cleanup so a failed rm (e.g. read-only or
+	// mis-owned cache dir) can never flip a passing check to failing.
+	// $$ (not $) because this is a docker-compose file: compose interpolates
+	// bare $VAR/$? itself, so a literal $ must be written as $$ in the
+	// template or compose silently blanks "rc" and mangles "$?" before the
+	// shell ever sees it — asserting the doubled form pins that behavior.
+	assertContains(t, got, "rc=$$?")
+	assertContains(t, got, "exit $$rc")
+	if strings.Contains(got, "&& rm -f /backend/cache/.starting || exit 1") {
+		t.Error("healthcheck must not couple rm's exit status to service health")
+	}
 }
 
 func TestRender_Ckstats(t *testing.T) {

--- a/truffels-api/internal/store/sqlite.go
+++ b/truffels-api/internal/store/sqlite.go
@@ -173,6 +173,41 @@ func (s *Store) LastAuditAt(action, target string) (time.Time, bool, error) {
 	return ts.UTC(), true, nil
 }
 
+// LastAuditID returns the rowid of the most recent audit_log entry for the
+// given target whose action is any of actions. The bool is false when no such
+// entry exists.
+//
+// This exists alongside LastAuditAt because audit_log.timestamp has
+// one-second resolution: two rows written inside the same second carry
+// identical timestamps, so "did B happen after A?" cannot be answered by
+// comparing them. id is the table's INTEGER PRIMARY KEY and therefore
+// strictly increasing, which makes it the only reliable ordering key for
+// sequence questions. LastAuditAt is still the right tool for age/cooldown
+// questions and is unchanged.
+func (s *Store) LastAuditID(target string, actions ...string) (int64, bool, error) {
+	if len(actions) == 0 {
+		return 0, false, nil
+	}
+	args := make([]interface{}, 0, len(actions)+1)
+	for _, a := range actions {
+		args = append(args, a)
+	}
+	args = append(args, target)
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(actions)), ",")
+
+	var id int64
+	err := s.db.QueryRow(
+		`SELECT id FROM audit_log WHERE action IN (`+placeholders+`) AND target = ?
+		 ORDER BY id DESC LIMIT 1`, args...).Scan(&id)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
 type AuditEntry struct {
 	ID        int64  `json:"id"`
 	Timestamp string `json:"timestamp"`

--- a/truffels-api/internal/store/sqlite.go
+++ b/truffels-api/internal/store/sqlite.go
@@ -152,6 +152,27 @@ func (s *Store) GetAuditLog(limit int) ([]AuditEntry, error) {
 	return entries, rows.Err()
 }
 
+// LastAuditAt returns the timestamp of the most recent audit_log entry for the
+// given action/target pair. The bool is false when no such entry exists.
+// Used by guardrails that must survive an API restart.
+func (s *Store) LastAuditAt(action, target string) (time.Time, bool, error) {
+	var raw string
+	err := s.db.QueryRow(
+		`SELECT timestamp FROM audit_log WHERE action = ? AND target = ?
+		 ORDER BY id DESC LIMIT 1`, action, target).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	ts, err := time.Parse("2006-01-02 15:04:05", raw)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return ts.UTC(), true, nil
+}
+
 type AuditEntry struct {
 	ID        int64  `json:"id"`
 	Timestamp string `json:"timestamp"`

--- a/truffels-api/internal/store/sqlite.go
+++ b/truffels-api/internal/store/sqlite.go
@@ -129,10 +129,25 @@ func (s *Store) LogAudit(action, target, detail, ip string) error {
 	return err
 }
 
-// GetAuditLog returns recent audit entries.
+// GetAuditLog returns recent audit entries, newest first.
 func (s *Store) GetAuditLog(limit int) ([]AuditEntry, error) {
-	rows, err := s.db.Query(
-		`SELECT id, timestamp, action, target, detail, ip FROM audit_log ORDER BY id DESC LIMIT ?`, limit)
+	return scanAuditRows(s.db.Query(
+		`SELECT id, timestamp, action, target, detail, ip FROM audit_log
+		 ORDER BY id DESC LIMIT ?`, limit))
+}
+
+// GetAuditLogByAction returns recent audit entries for one action, newest
+// first. Server-side filtering exists so a caller that only cares about a
+// rare action (auto_reclaim fires roughly weekly) does not have to page the
+// whole log to find it — unfiltered, a handful of logins and service actions
+// pushes it off the end of any sane page size.
+func (s *Store) GetAuditLogByAction(action string, limit int) ([]AuditEntry, error) {
+	return scanAuditRows(s.db.Query(
+		`SELECT id, timestamp, action, target, detail, ip FROM audit_log
+		 WHERE action = ? ORDER BY id DESC LIMIT ?`, action, limit))
+}
+
+func scanAuditRows(rows *sql.Rows, err error) ([]AuditEntry, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/truffels-api/internal/store/sqlite_test.go
+++ b/truffels-api/internal/store/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"truffels-api/internal/model"
 )
@@ -128,6 +129,32 @@ func TestAuditLog_Limit(t *testing.T) {
 	entries, _ := s.GetAuditLog(3)
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries with limit, got %d", len(entries))
+	}
+}
+
+func TestLastAuditAt(t *testing.T) {
+	s := newTestStore(t)
+
+	// No matching row yet.
+	if _, ok, err := s.LastAuditAt("auto_reclaim", "mempool"); err != nil || ok {
+		t.Fatalf("expected no row, got ok=%v err=%v", ok, err)
+	}
+
+	if err := s.LogAudit("auto_reclaim", "mempool", "cleared 900 MB", ""); err != nil {
+		t.Fatalf("LogAudit: %v", err)
+	}
+
+	ts, ok, err := s.LastAuditAt("auto_reclaim", "mempool")
+	if err != nil || !ok {
+		t.Fatalf("expected a row, got ok=%v err=%v", ok, err)
+	}
+	if time.Since(ts) > time.Minute {
+		t.Errorf("timestamp %v is not recent", ts)
+	}
+
+	// A different target must not match.
+	if _, ok, _ := s.LastAuditAt("auto_reclaim", "ckstats"); ok {
+		t.Error("target filter did not apply")
 	}
 }
 

--- a/truffels-api/internal/store/sqlite_test.go
+++ b/truffels-api/internal/store/sqlite_test.go
@@ -140,37 +140,31 @@ func TestLastAuditAt(t *testing.T) {
 		t.Fatalf("expected no row, got ok=%v err=%v", ok, err)
 	}
 
-	// Insert first row for this action/target pair.
-	if err := s.LogAudit("auto_reclaim", "mempool", "cleared 900 MB", ""); err != nil {
-		t.Fatalf("LogAudit first: %v", err)
+	// Old row, written directly so it carries a timestamp far in the past.
+	// LogAudit only ever writes datetime('now') at one-second resolution, which
+	// is too coarse to distinguish two rows written back to back — and this
+	// test must be able to tell which row LastAuditAt picked.
+	if _, err := s.db.Exec(
+		`INSERT INTO audit_log (action, target, detail, ip, timestamp)
+		 VALUES (?, ?, ?, ?, ?)`,
+		"auto_reclaim", "mempool", "old", "", "2020-01-01 00:00:00"); err != nil {
+		t.Fatalf("insert old row: %v", err)
 	}
-
-	// Insert second row for the same action/target pair.
-	// This tests that LastAuditAt returns the most recent (not the oldest).
-	if err := s.LogAudit("auto_reclaim", "mempool", "cleared 1000 MB", ""); err != nil {
-		t.Fatalf("LogAudit second: %v", err)
+	if err := s.LogAudit("auto_reclaim", "mempool", "new", ""); err != nil {
+		t.Fatalf("LogAudit: %v", err)
 	}
 
 	ts, ok, err := s.LastAuditAt("auto_reclaim", "mempool")
 	if err != nil || !ok {
 		t.Fatalf("expected a row, got ok=%v err=%v", ok, err)
 	}
+	// The decisive assertion: swapping ORDER BY id DESC for ASC returns the
+	// 2020 row and fails here.
+	if ts.Year() == 2020 {
+		t.Fatal("LastAuditAt returned the oldest row, not the most recent")
+	}
 	if time.Since(ts) > time.Minute {
 		t.Errorf("timestamp %v is not recent", ts)
-	}
-
-	// Verify the returned timestamp corresponds to the second (most recent) row
-	// by checking that the most recent entry has detail="cleared 1000 MB".
-	entries, err := s.GetAuditLog(2)
-	if err != nil {
-		t.Fatalf("GetAuditLog: %v", err)
-	}
-	if len(entries) < 2 {
-		t.Fatalf("expected at least 2 entries, got %d", len(entries))
-	}
-	// Most recent entry is first in the returned list (ORDER BY id DESC)
-	if entries[0].Detail != "cleared 1000 MB" {
-		t.Fatalf("expected most recent detail to be 'cleared 1000 MB', got %q", entries[0].Detail)
 	}
 
 	// A different target must not match.

--- a/truffels-api/internal/store/sqlite_test.go
+++ b/truffels-api/internal/store/sqlite_test.go
@@ -173,6 +173,53 @@ func TestLastAuditAt(t *testing.T) {
 	}
 }
 
+// TestLastAuditID_SameTimestampOrdersByID pins the reason LastAuditID exists.
+// The alert engine has to answer "did a terminal row follow this attempt?",
+// and audit_log.timestamp cannot answer it: its resolution is one second, so
+// an attempt and its terminal row written back to back are equal by time.
+// Both rows are forced onto the identical timestamp here so the ordering can
+// only come from id — a timestamp-based implementation fails this test.
+func TestLastAuditID_SameTimestampOrdersByID(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, ok, err := s.LastAuditID("mempool", "auto_reclaim"); err != nil || ok {
+		t.Fatalf("expected no row, got ok=%v err=%v", ok, err)
+	}
+
+	if err := s.LogAudit("auto_reclaim", "mempool", "attempt", ""); err != nil {
+		t.Fatalf("LogAudit: %v", err)
+	}
+	if err := s.LogAudit("auto_reclaim_complete", "mempool", "done", ""); err != nil {
+		t.Fatalf("LogAudit: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE audit_log SET timestamp = '2026-08-05 12:00:00'`); err != nil {
+		t.Fatalf("flatten timestamps: %v", err)
+	}
+
+	attemptID, ok, err := s.LastAuditID("mempool", "auto_reclaim")
+	if err != nil || !ok {
+		t.Fatalf("expected the attempt row, got ok=%v err=%v", ok, err)
+	}
+	termID, ok, err := s.LastAuditID("mempool", "auto_reclaim_complete", "auto_reclaim_failed")
+	if err != nil || !ok {
+		t.Fatalf("expected the terminal row, got ok=%v err=%v", ok, err)
+	}
+	if termID <= attemptID {
+		t.Fatalf("terminal row must sort after the attempt by id, got attempt=%d terminal=%d", attemptID, termID)
+	}
+
+	// A different target must not match, and neither must an unrelated action.
+	if _, ok, _ := s.LastAuditID("ckstats", "auto_reclaim"); ok {
+		t.Error("target filter did not apply")
+	}
+	if _, ok, _ := s.LastAuditID("mempool", "auto_reclaim_failed"); ok {
+		t.Error("action filter did not apply")
+	}
+	if _, ok, _ := s.LastAuditID("mempool"); ok {
+		t.Error("an empty action set must match nothing")
+	}
+}
+
 // --- Service Enabled ---
 
 func TestService_DefaultEnabled(t *testing.T) {

--- a/truffels-api/internal/store/sqlite_test.go
+++ b/truffels-api/internal/store/sqlite_test.go
@@ -140,8 +140,15 @@ func TestLastAuditAt(t *testing.T) {
 		t.Fatalf("expected no row, got ok=%v err=%v", ok, err)
 	}
 
+	// Insert first row for this action/target pair.
 	if err := s.LogAudit("auto_reclaim", "mempool", "cleared 900 MB", ""); err != nil {
-		t.Fatalf("LogAudit: %v", err)
+		t.Fatalf("LogAudit first: %v", err)
+	}
+
+	// Insert second row for the same action/target pair.
+	// This tests that LastAuditAt returns the most recent (not the oldest).
+	if err := s.LogAudit("auto_reclaim", "mempool", "cleared 1000 MB", ""); err != nil {
+		t.Fatalf("LogAudit second: %v", err)
 	}
 
 	ts, ok, err := s.LastAuditAt("auto_reclaim", "mempool")
@@ -150,6 +157,20 @@ func TestLastAuditAt(t *testing.T) {
 	}
 	if time.Since(ts) > time.Minute {
 		t.Errorf("timestamp %v is not recent", ts)
+	}
+
+	// Verify the returned timestamp corresponds to the second (most recent) row
+	// by checking that the most recent entry has detail="cleared 1000 MB".
+	entries, err := s.GetAuditLog(2)
+	if err != nil {
+		t.Fatalf("GetAuditLog: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 entries, got %d", len(entries))
+	}
+	// Most recent entry is first in the returned list (ORDER BY id DESC)
+	if entries[0].Detail != "cleared 1000 MB" {
+		t.Fatalf("expected most recent detail to be 'cleared 1000 MB', got %q", entries[0].Detail)
 	}
 
 	// A different target must not match.

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -434,6 +434,19 @@ export interface Settings {
   trend_alert_lookback_hours: number
   trend_alert_min_data_hours: number
   allow_downgrade: boolean
+  dir_size_warning_mb: number
+  dir_size_critical_mb: number
+  dir_size_autoreclaim_enabled: boolean
+  dir_size_autoreclaim_min_interval_hours: number
+}
+
+export interface AuditEntry {
+  id: number
+  timestamp: string
+  action: string
+  target?: string
+  detail?: string
+  ip?: string
 }
 
 export interface UpdateVersions {
@@ -490,6 +503,7 @@ export const api = {
   serviceMonitoring: (id: string, hours = 24) => get<ServiceMonitoringResponse>(`/services/${id}/monitoring?hours=${hours}`),
   settings: () => get<Settings>('/settings'),
   updateSettings: (settings: Partial<Settings>) => put<{ status: string }>('/settings', settings),
+  getAuditLog: (limit = 100) => get<AuditEntry[]>(`/audit?limit=${limit}`),
   systemRestart: (password: string) => post<{ status: string }>('/system/restart', { password }),
   systemShutdown: (password: string) => post<{ status: string }>('/system/shutdown', { password }),
   systemJournal: (lines = 200, priority = '', unit = '', since = '', boot = 0) => {

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -503,7 +503,10 @@ export const api = {
   serviceMonitoring: (id: string, hours = 24) => get<ServiceMonitoringResponse>(`/services/${id}/monitoring?hours=${hours}`),
   settings: () => get<Settings>('/settings'),
   updateSettings: (settings: Partial<Settings>) => put<{ status: string }>('/settings', settings),
-  getAuditLog: (limit = 100) => get<AuditEntry[]>(`/audit?limit=${limit}`),
+  // action filters server-side. Without it a caller looking for a rare
+  // action has to page the whole log and hope the row is still on the page.
+  getAuditLog: (limit = 100, action?: string) =>
+    get<AuditEntry[]>(`/audit?limit=${limit}${action ? `&action=${encodeURIComponent(action)}` : ''}`),
   systemRestart: (password: string) => post<{ status: string }>('/system/restart', { password }),
   systemShutdown: (password: string) => post<{ status: string }>('/system/shutdown', { password }),
   systemJournal: (lines = 200, priority = '', unit = '', since = '', boot = 0) => {

--- a/truffels-web/src/pages/MonitoringPage.tsx
+++ b/truffels-web/src/pages/MonitoringPage.tsx
@@ -28,10 +28,14 @@ const CHART_COLORS = {
   dirSize: '#eab308',
 } as const
 
-// Threshold lines on the dir-size chart, kept in sync with the alert engine
-// (alerts/engine.go: watchedDirs). Bytes.
-const DIR_SIZE_WARN_MB = 700
-const DIR_SIZE_CRIT_MB = 900
+// Fallbacks for the dir-size chart's thresholds, used only until the settings
+// request resolves (or if it fails). The live values come from Settings —
+// dir_size_warning_mb / dir_size_critical_mb — because an operator can change
+// them, and a chart drawing a green badge on a directory the alert engine is
+// about to reclaim is worse than no badge. These two numbers match the
+// engine's own defaults in alerts/engine.go (evalWatchedDirs).
+const DIR_SIZE_WARN_MB_DEFAULT = 700
+const DIR_SIZE_CRIT_MB_DEFAULT = 900
 
 function formatDataSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -48,6 +52,14 @@ function formatTime(ts: string): string {
 function formatTimestamp(ts: string): string {
   const d = new Date(ts)
   return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+// audit_log timestamps arrive as SQLite's "YYYY-MM-DD HH:MM:SS" in UTC. The
+// space separator is outside the format the ES spec requires engines to
+// parse — V8 accepts it, JavaScriptCore has historically returned Invalid
+// Date — so normalise to the ISO "T" form before appending the zone.
+function formatAuditTimestamp(ts: string): string {
+  return new Date(ts.replace(' ', 'T') + 'Z').toLocaleString()
 }
 
 function formatUptime(startedAt: string): string {
@@ -133,10 +145,11 @@ function MetricChart({ data, dataKey, color, label, unit, current, avg, peak, do
   )
 }
 
-// DirSizeChart renders one watched-dir size series with warn/critical hint
-// lines drawn at 700/900 MB. Used to catch the mempool rbfcache.json runaway
-// (which caused the dev.20 OOM) before it crosses the heap ceiling again.
-function DirSizeChart({ series }: { series: DirSizeSeries }) {
+// DirSizeChart renders one watched-dir size series against the operator's
+// configured warn/critical thresholds. Used to catch the mempool rbfcache.json
+// runaway (which caused the dev.20 OOM) before it crosses the heap ceiling
+// again.
+function DirSizeChart({ series, warnMb, critMb }: { series: DirSizeSeries; warnMb: number; critMb: number }) {
   const data = series.points.map(p => ({
     timestamp: p.timestamp,
     size_mb: p.size_bytes / (1024 * 1024),
@@ -144,8 +157,8 @@ function DirSizeChart({ series }: { series: DirSizeSeries }) {
   const currentMb = data.length > 0 ? data[data.length - 1].size_mb : 0
   const peakMb = data.length > 0 ? Math.max(...data.map(d => d.size_mb)) : 0
   let status: 'ok' | 'warn' | 'crit' = 'ok'
-  if (currentMb >= DIR_SIZE_CRIT_MB) status = 'crit'
-  else if (currentMb >= DIR_SIZE_WARN_MB) status = 'warn'
+  if (currentMb >= critMb) status = 'crit'
+  else if (currentMb >= warnMb) status = 'warn'
 
   return (
     <Card>
@@ -198,7 +211,7 @@ function DirSizeChart({ series }: { series: DirSizeSeries }) {
           }`}>{currentMb.toFixed(0)} MB</span>
         </span>
         <span>Peak: <span className="text-gray-200 font-mono">{peakMb.toFixed(0)} MB</span></span>
-        <span className="text-gray-500">warn ≥ {DIR_SIZE_WARN_MB} MB · critical ≥ {DIR_SIZE_CRIT_MB} MB</span>
+        <span className="text-gray-500">warn ≥ {warnMb} MB · critical ≥ {critMb} MB</span>
         {status !== 'ok' && (
           <span className={status === 'crit' ? 'text-red-400' : 'text-yellow-400'}>
             Clear via Settings → Data Dirs → {series.label}
@@ -220,9 +233,23 @@ export default function MonitoringPage() {
   const fetcher = useCallback(() => api.monitoring(hours), [hours])
   const { data, error, loading } = useApi(fetcher, 10000)
 
-  const auditFetcher = useCallback(() => api.getAuditLog(100), [])
+  // Ask the server for the one row we want instead of paging the whole log
+  // every 10s and scanning it: auto_reclaim fires roughly weekly by design,
+  // so on an unfiltered feed of logins, service actions, updates and tuning
+  // changes it drops off the page within days and the readout silently
+  // reverts to "never".
+  const auditFetcher = useCallback(() => api.getAuditLog(1, 'auto_reclaim'), [])
   const { data: auditEntries } = useApi(auditFetcher, 10000)
-  const lastReclaim = auditEntries?.find((e: AuditEntry) => e.action === 'auto_reclaim')
+  const lastReclaim: AuditEntry | undefined = auditEntries?.[0]
+
+  // Thresholds are operator-configurable, so read them rather than assuming
+  // the defaults (see DIR_SIZE_*_DEFAULT).
+  // Re-read slowly (60s) rather than once on mount, so a threshold changed in
+  // Settings shows up here without a reload.
+  const settingsFetcher = useCallback(() => api.settings(), [])
+  const { data: settings } = useApi(settingsFetcher, 60000)
+  const dirWarnMb = settings?.dir_size_warning_mb ?? DIR_SIZE_WARN_MB_DEFAULT
+  const dirCritMb = settings?.dir_size_critical_mb ?? DIR_SIZE_CRIT_MB_DEFAULT
 
   const sortedContainers = useMemo(() => {
     if (!data) return []
@@ -511,12 +538,12 @@ export default function MonitoringPage() {
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {data.dir_sizes.map((s) => (
-              <DirSizeChart key={s.path} series={s} />
+              <DirSizeChart key={s.path} series={s} warnMb={dirWarnMb} critMb={dirCritMb} />
             ))}
           </div>
           <p className="text-sm text-gray-400">
             {lastReclaim
-              ? `Last automatic reclaim: ${new Date(lastReclaim.timestamp + 'Z').toLocaleString()}`
+              ? `Last automatic reclaim: ${formatAuditTimestamp(lastReclaim.timestamp)}`
               : 'No automatic reclaim has run yet.'}
           </p>
         </>

--- a/truffels-web/src/pages/MonitoringPage.tsx
+++ b/truffels-web/src/pages/MonitoringPage.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import { api, DirSizeSeries, MetricSnapshot, MonitoringResponse } from '@/lib/api'
+import { api, AuditEntry, DirSizeSeries, MetricSnapshot, MonitoringResponse } from '@/lib/api'
 import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
@@ -219,6 +219,10 @@ export default function MonitoringPage() {
 
   const fetcher = useCallback(() => api.monitoring(hours), [hours])
   const { data, error, loading } = useApi(fetcher, 10000)
+
+  const auditFetcher = useCallback(() => api.getAuditLog(100), [])
+  const { data: auditEntries } = useApi(auditFetcher, 10000)
+  const lastReclaim = auditEntries?.find((e: AuditEntry) => e.action === 'auto_reclaim')
 
   const sortedContainers = useMemo(() => {
     if (!data) return []
@@ -504,11 +508,18 @@ export default function MonitoringPage() {
 
       {/* Watched data-dir sizes (mempool cache today; extendable) */}
       {data.dir_sizes && data.dir_sizes.length > 0 && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {data.dir_sizes.map((s) => (
-            <DirSizeChart key={s.path} series={s} />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {data.dir_sizes.map((s) => (
+              <DirSizeChart key={s.path} series={s} />
+            ))}
+          </div>
+          <p className="text-sm text-gray-400">
+            {lastReclaim
+              ? `Last automatic reclaim: ${new Date(lastReclaim.timestamp + 'Z').toLocaleString()}`
+              : 'No automatic reclaim has run yet.'}
+          </p>
+        </>
       )}
 
       {/* Section B: Container Status Table */}

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -483,11 +483,14 @@ function AlertsTab({ settings, saving, onSave }: {
             </div>
           </div>
         </div>
+        {warnMb >= criticalMb && (
+          <p className="text-sm text-yellow-400 mt-3">Warning threshold should be lower than critical threshold.</p>
+        )}
       </Card>
 
       <div className="flex justify-end">
         <button
-          disabled={!changed || saving || tempWarning >= tempCritical}
+          disabled={!changed || saving || tempWarning >= tempCritical || warnMb >= criticalMb}
           onClick={() => onSave({
             temp_warning: tempWarning,
             temp_critical: tempCritical,

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -315,6 +315,10 @@ function AlertsTab({ settings, saving, onSave }: {
   const [trendHorizon, setTrendHorizon] = useState(settings.trend_alert_horizon_hours)
   const [trendLookback, setTrendLookback] = useState(settings.trend_alert_lookback_hours)
   const [trendMinData, setTrendMinData] = useState(settings.trend_alert_min_data_hours)
+  const [reclaimEnabled, setReclaimEnabled] = useState(settings.dir_size_autoreclaim_enabled)
+  const [warnMb, setWarnMb] = useState(settings.dir_size_warning_mb)
+  const [criticalMb, setCriticalMb] = useState(settings.dir_size_critical_mb)
+  const [reclaimIntervalH, setReclaimIntervalH] = useState(settings.dir_size_autoreclaim_min_interval_hours)
 
   const changed = tempWarning !== settings.temp_warning
     || tempCritical !== settings.temp_critical
@@ -322,6 +326,10 @@ function AlertsTab({ settings, saving, onSave }: {
     || trendHorizon !== settings.trend_alert_horizon_hours
     || trendLookback !== settings.trend_alert_lookback_hours
     || trendMinData !== settings.trend_alert_min_data_hours
+    || reclaimEnabled !== settings.dir_size_autoreclaim_enabled
+    || warnMb !== settings.dir_size_warning_mb
+    || criticalMb !== settings.dir_size_critical_mb
+    || reclaimIntervalH !== settings.dir_size_autoreclaim_min_interval_hours
 
   return (
     <div className="space-y-6">
@@ -417,6 +425,66 @@ function AlertsTab({ settings, saving, onSave }: {
         </div>
       </Card>
 
+      <Card>
+        <CardTitle>Mempool Cache Auto-Reclaim</CardTitle>
+        <p className="text-sm text-gray-400 mb-4">
+          Watches the mempool backend's cache directory and warns as it grows.
+          The rbfcache.json runaway that caused the dev.20 OOM is the reason
+          these thresholds exist.
+        </p>
+        <label className="flex items-center gap-3 cursor-pointer mb-4">
+          <input
+            type="checkbox" checked={reclaimEnabled} onChange={(e) => setReclaimEnabled(e.target.checked)}
+            className="accent-accent w-4 h-4"
+          />
+          <span className="text-sm text-white font-medium">Reclaim the mempool cache automatically</span>
+        </label>
+        <p className="text-sm text-gray-400 mb-4">
+          When the cache passes the critical threshold, the service is stopped, the
+          cache directory is cleared and the service is started again. This takes
+          about 60 seconds, during which the statistics charts have a gap. Without
+          it the cache keeps growing until the backend runs out of heap.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-lg">
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Warning threshold</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number" min={100} step={1}
+                value={warnMb}
+                onChange={(e) => setWarnMb(Number(e.target.value))}
+                className="w-full px-3 py-2 bg-surface-overlay border border-border rounded text-sm text-white"
+              />
+              <span className="text-sm text-gray-400">MB</span>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Critical threshold</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number" min={100} step={1}
+                value={criticalMb}
+                onChange={(e) => setCriticalMb(Number(e.target.value))}
+                className="w-full px-3 py-2 bg-surface-overlay border border-border rounded text-sm text-white"
+              />
+              <span className="text-sm text-gray-400">MB</span>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Min interval between reclaims</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number" min={1} step={1}
+                value={reclaimIntervalH}
+                onChange={(e) => setReclaimIntervalH(Number(e.target.value))}
+                className="w-full px-3 py-2 bg-surface-overlay border border-border rounded text-sm text-white"
+              />
+              <span className="text-sm text-gray-400">h</span>
+            </div>
+          </div>
+        </div>
+      </Card>
+
       <div className="flex justify-end">
         <button
           disabled={!changed || saving || tempWarning >= tempCritical}
@@ -427,6 +495,10 @@ function AlertsTab({ settings, saving, onSave }: {
             trend_alert_horizon_hours: trendHorizon,
             trend_alert_lookback_hours: trendLookback,
             trend_alert_min_data_hours: trendMinData,
+            dir_size_autoreclaim_enabled: reclaimEnabled,
+            dir_size_warning_mb: warnMb,
+            dir_size_critical_mb: criticalMb,
+            dir_size_autoreclaim_min_interval_hours: reclaimIntervalH,
           })}
           className="px-4 py-2 bg-accent text-black font-medium rounded text-sm hover:bg-accent/90 transition-colors disabled:opacity-50"
         >


### PR DESCRIPTION
## Problem

The mempool backend's on-disk cache grows without an upstream bound. Measured on a running node over five days: a ~500 MB floor rising ~64 MB/day, reaching 954 MB with `rbfcache.json` alone at 467 MB and a transient peak of 1276 MB.

Upstream `mempool/mempool` v3.3.1 has **no size limit on the RBF cache** — `backend/src/api/rbf-cache.ts` only expires entries after 24 h and has no byte or entry cap. Umbrel sets `MEMPOOL_RBF_CACHE_MAX_BYTES`, but that key does not exist in v3.3.1's `config.ts` and appears zero times in the upstream repo, so it is a no-op.

The cost is not only memory. The V8 heap sat at 80 % of its ceiling (2.16 / 2.69 GB), warned every 60 s, and produced multi-second stop-the-world GC pauses — 28 % of `/api/v1/blocks` requests exceeded 3 s in a 40-sample run.

The alert engine already detects the condition and has been raising `dir_size_critical` with the message *"Stop the service and clear the dir via Settings → Data Dirs."* Nothing acted on it. **This automates the action the system already prescribes.**

## Evidence

Three 30-minute soaks on a live node, same cadence and sampling:

| | full config, 993 MB cache | lite mode, empty cache | full config, empty cache |
|---|---|---|---|
| backend RSS, settled | 2.412 GiB | 1.808 GiB | **1.882 GiB** |
| `heap limit` warnings / 30 min | ~30 | 0 | **0** |
| `/api/v1/blocks` median | 0.003 s | 1.0 s | **0.009 s** |
| statistics + charts | yes | **no** | yes |

The entire win comes from clearing the cache. A lite-mode variant (`DATABASE_ENABLED=false`) was measured and rejected: it buys 74 MB — inside the noise — and costs the charts plus a 100× slower block list.

## What this adds

**Auto-reclaim.** When a watched directory crosses the critical threshold, the alert engine stops the service, clears the directory through the agent, and starts it again. Guardrails live in one pure function (`decideReclaim`, mirroring the existing `trend.go` split) and are unit-tested: enabled, above threshold, service running, 24 h minimum interval, and — the safety-critical one — the target must be declared in the service template's `DataDirs` with both `Clearable` and `RequiresStop`. `mempool/mysql` is declared not clearable and is unreachable from this path; deletion goes through the agent's existing double-locked path validation, never a shell.

Loop safety rests on writing the attempt to the audit log **before** stopping, so a *failed* reclaim consumes the cooldown rather than retrying every tick. If that write fails, the reclaim aborts before touching the service — refusing to act is the safe failure. The reclaim runs on its own goroutine so a slow stop/clear/start cannot stall alert evaluation, and an interrupted sequence is detected and recovered at engine start.

**Boot guard.** A sentinel in the cache dir, written at every start and cleared by the healthcheck on first success. If it survives to the next start, the previous one never became healthy — almost always a heap OOM while reloading an oversized cache — so the cache is dropped and rebuilt from live data. Adapted from `Start9Labs/mempool-startos`, with one important difference: it execs `/backend/start.sh`, not `node`, because `start.sh` renders `mempool-config.json` from the `MEMPOOL_*` env vars first.

**Settings.** Four new keys with fallback defaults, no migration: `dir_size_warning_mb` (700), `dir_size_critical_mb` (900), `dir_size_autoreclaim_enabled` (true), `dir_size_autoreclaim_min_interval_hours` (24). Bounds-validated server-side including the cross-field rule, exposed in the UI with the consequence stated plainly, and switchable off.

## Testing

Go API, Go agent and web suites all green. ~40 new tests, including a regression test that reproduces the stop/start loop and was confirmed red against the pre-fix ordering, and one that pins the boot guard's conditional sentinel removal. The rendered compose template was validated with `docker compose config`, and the healthcheck's `$$` escaping verified against a live container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)