### PR TITLE
NeedsBuild update discovery and apply

### DIFF
--- a/dockerfiles/ckpool/Dockerfile
+++ b/dockerfiles/ckpool/Dockerfile
@@ -1,6 +1,8 @@
 # ckpool v1.0.0 — multi-stage build for arm64
 FROM debian:bookworm-slim AS builder
 
+ARG SOURCE_REF=v1.0.0
+
 # retry() wraps a command in 4 attempts with 10/30/60s backoff so a transient
 # flake on deb.debian.org or bitbucket.org doesn't kill the whole build.
 RUN set -e; \
@@ -19,7 +21,7 @@ RUN set -e; \
     for delay in 0 10 30 60; do \
         [ $delay -gt 0 ] && sleep $delay; \
         rm -rf .git ./* 2>/dev/null || true; \
-        if git clone --depth 1 --branch v1.0.0 https://bitbucket.org/ckolivas/ckpool.git .; then \
+        if git clone --depth 1 --branch "${SOURCE_REF}" https://bitbucket.org/ckolivas/ckpool.git .; then \
             break; \
         fi; \
         attempt=$((attempt+1)); \
@@ -39,6 +41,9 @@ RUN set -e; \
 COPY --from=builder /build/src/ckpool /usr/local/bin/ckpool
 COPY --from=builder /build/src/ckpmsg /usr/local/bin/ckpmsg
 COPY --from=builder /build/src/notifier /usr/local/bin/notifier
+
+ARG SOURCE_REF
+LABEL org.truffels.source-ref=$SOURCE_REF
 
 USER ckpool
 ENTRYPOINT ["ckpool"]

--- a/dockerfiles/ckpool/Dockerfile
+++ b/dockerfiles/ckpool/Dockerfile
@@ -1,7 +1,9 @@
 # ckpool v1.0.0 — multi-stage build for arm64
+ARG SOURCE_REF=v1.0.0
+
 FROM debian:bookworm-slim AS builder
 
-ARG SOURCE_REF=v1.0.0
+ARG SOURCE_REF
 
 # retry() wraps a command in 4 attempts with 10/30/60s backoff so a transient
 # flake on deb.debian.org or bitbucket.org doesn't kill the whole build.

--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -34,6 +34,9 @@ RUN set -e; \
     retry apt-get install -y --no-install-recommends cron postgresql-client && \
     rm -rf /var/lib/apt/lists/*
 
+ARG SOURCE_REF=unknown
+LABEL org.truffels.source-ref=$SOURCE_REF
+
 WORKDIR /app
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules

--- a/install.sh
+++ b/install.sh
@@ -897,7 +897,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.23}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.24}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/install.sh
+++ b/install.sh
@@ -486,9 +486,12 @@ cp "$SCRIPT_DIR/dockerfiles/ckpool/Dockerfile" "$COMPOSE_DIR/ckpool/Dockerfile"
 tee "$COMPOSE_DIR/ckpool/docker-compose.yml" >/dev/null <<'CKPOOLDC'
 services:
   ckpool:
+    # Absolute paths, matching ckpoolTemplate in truffels-api: the API
+    # reconciles this file on every boot, and the agent builds through nsenter
+    # where a relative context would resolve against a different cwd.
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: /srv/truffels/compose/ckpool
+      dockerfile: /srv/truffels/compose/ckpool/Dockerfile
     image: truffels/ckpool:v1.0.0
     container_name: truffels-ckpool
     restart: unless-stopped

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1715,6 +1715,16 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 	}
 	// ref_scheme selects the validator. Absent means tag — the self-update
 	// path predates this field and must keep its stricter check.
+	//
+	// Note the asymmetry with model.UpdateSource.RefScheme in truffels-api,
+	// which documents an empty value as "commit": that is the *registry's*
+	// default for a service definition, and the API resolves it to an explicit
+	// "commit" before it ever reaches this endpoint (see applyNeedsBuild). Here,
+	// at the root boundary, an absent field is a request that predates the
+	// field, so it gets the STRICTER of the two validators — a commit hash sent
+	// without a ref_scheme is rejected with 400 rather than silently accepted.
+	// Both defaults therefore fail closed; they must not be "harmonised" by
+	// making this one accept commit hashes.
 	valid := isValidTag(req.Tag)
 	if req.RefScheme == "commit" {
 		valid = isValidCommitHash(req.Tag)
@@ -1724,7 +1734,9 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("git checkout", "repo", req.RepoDir, "tag", req.Tag)
+	// Audit line for the only endpoint that runs git checkout as root: record
+	// which validator let the ref through, not just the ref itself.
+	slog.Info("git checkout", "repo", req.RepoDir, "tag", req.Tag, "scheme", req.RefScheme)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1597,12 +1597,22 @@ func handleSystemTuningSet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"status": "ok"})
 }
 
-// allowedRepoDir is the mounted project repo path inside the container.
-const allowedRepoDir = "/repo"
+// allowedRepoDirs are the only directories git operations may touch. Exact
+// string match only — no prefix matching, no path cleaning. A cleaned path
+// would let "/repo/../etc" normalise into something that passes.
+var allowedRepoDirs = map[string]bool{
+	"/repo":                          true,
+	"/srv/truffels/data/ckpoolstats": true,
+}
+
+func isAllowedRepoDir(dir string) bool {
+	return allowedRepoDirs[dir]
+}
 
 type gitCheckoutRequest struct {
-	RepoDir string `json:"repo_dir"`
-	Tag     string `json:"tag"`
+	RepoDir   string `json:"repo_dir"`
+	Tag       string `json:"tag"`
+	RefScheme string `json:"ref_scheme,omitempty"`
 }
 
 func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
@@ -1612,8 +1622,8 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate repo_dir is the allowed path
-	if req.RepoDir != allowedRepoDir {
+	// Validate repo_dir is one of the allowed paths
+	if !isAllowedRepoDir(req.RepoDir) {
 		writeJSON(w, 403, map[string]string{"error": "repo_dir not allowed"})
 		return
 	}
@@ -1621,9 +1631,14 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]string{"error": "tag required"})
 		return
 	}
-	// Validate tag format (must start with v and contain only semver chars)
-	if !isValidTag(req.Tag) {
-		writeJSON(w, 400, map[string]string{"error": "invalid tag format"})
+	// ref_scheme selects the validator. Absent means tag — the self-update
+	// path predates this field and must keep its stricter check.
+	valid := isValidTag(req.Tag)
+	if req.RefScheme == "commit" {
+		valid = isValidCommitHash(req.Tag)
+	}
+	if !valid {
+		writeJSON(w, 400, map[string]string{"error": "invalid ref format"})
 		return
 	}
 
@@ -1661,6 +1676,21 @@ func isValidTag(tag string) bool {
 	}
 	for _, c := range tag[1:] {
 		if c != '.' && c != '-' && (c < '0' || c > '9') && (c < 'a' || c > 'z') {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidCommitHash accepts abbreviated and full git object names: lowercase
+// hex, 7 to 40 characters. Deliberately separate from isValidTag so loosening
+// one cannot weaken the other.
+func isValidCommitHash(s string) bool {
+	if len(s) < 7 || len(s) > 40 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			return false
 		}
 	}

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -574,10 +574,11 @@ type imageInspectRequest struct {
 	Container string `json:"container"`
 }
 
-type imageInspectResult struct {
-	Image   string   `json:"image"`
-	Digest  string   `json:"digest"`
-	Tags    []string `json:"tags"`
+type imageInspectResponse struct {
+	Image  string            `json:"image"`
+	Digest string            `json:"digest"`
+	Tags   []string          `json:"tags"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 func handleImageInspect(w http.ResponseWriter, r *http.Request) {
@@ -631,10 +632,21 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal(bytes.TrimSpace(tagsOut.Bytes()), &tags)
 	}
 
-	writeJSON(w, 200, imageInspectResult{
+	// Get labels — carries org.truffels.source-ref, the ref the image was built from.
+	cmd4 := exec.CommandContext(ctx, "docker", "inspect", "--format",
+		"{{json .Config.Labels}}", imageName)
+	var labelsOut bytes.Buffer
+	cmd4.Stdout = &labelsOut
+	labels := map[string]string{}
+	if cmd4.Run() == nil {
+		_ = json.Unmarshal(bytes.TrimSpace(labelsOut.Bytes()), &labels)
+	}
+
+	writeJSON(w, 200, imageInspectResponse{
 		Image:  imageName,
 		Digest: digest,
 		Tags:   tags,
+		Labels: labels,
 	})
 }
 

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -93,6 +93,8 @@ func main() {
 	mux.HandleFunc("POST /v1/inspect", handleInspect)
 	mux.HandleFunc("POST /v1/image/pull", handleImagePull)
 	mux.HandleFunc("POST /v1/image/inspect", handleImageInspect)
+	mux.HandleFunc("POST /v1/image/inspect-by-name", handleImageInspectByName)
+	mux.HandleFunc("POST /v1/image/tag", handleImageTag)
 	mux.HandleFunc("POST /v1/compose/build", handleComposeBuild)
 	mux.HandleFunc("GET /v1/stats", handleStats)
 	mux.HandleFunc("GET /v1/health", handleHealth)
@@ -607,6 +609,13 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 	}
 	imageName := strings.TrimSpace(imageOut.String())
 
+	writeJSON(w, 200, inspectImageByName(ctx, imageName))
+}
+
+// inspectImageByName reads digest, tags and labels straight off an image. Every
+// docker call here is best-effort: a missing field is reported as empty rather
+// than as a failure, which is what the digest/tag lookups have always done.
+func inspectImageByName(ctx context.Context, imageName string) imageInspectResponse {
 	// Get image digest
 	cmd2 := exec.CommandContext(ctx, "docker", "inspect", "--format",
 		"{{index .RepoDigests 0}}", imageName)
@@ -642,12 +651,85 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal(bytes.TrimSpace(labelsOut.Bytes()), &labels)
 	}
 
-	writeJSON(w, 200, imageInspectResponse{
+	return imageInspectResponse{
 		Image:  imageName,
 		Digest: digest,
 		Tags:   tags,
 		Labels: labels,
-	})
+	}
+}
+
+// isAllowedImageRef restricts image operations to images this appliance builds
+// itself. Anything else — upstream images, anything with shell metacharacters —
+// is refused; the agent runs as root against the docker socket. Exact charset
+// check, no normalising: a cleaned or lowercased ref would let something that
+// should fail slip through.
+func isAllowedImageRef(ref string) bool {
+	if !strings.HasPrefix(ref, "truffels/") {
+		return false
+	}
+	for _, c := range ref {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'z') &&
+			c != '/' && c != ':' && c != '.' && c != '-' && c != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+type imageByNameRequest struct {
+	Image string `json:"image"`
+}
+
+// handleImageInspectByName inspects an image without going through a container.
+// The container-based route cannot answer for a service that is down — which is
+// exactly the state a failed or never-started custom build leaves behind.
+func handleImageInspectByName(w http.ResponseWriter, r *http.Request) {
+	var req imageByNameRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if !isAllowedImageRef(req.Image) {
+		writeJSON(w, 403, map[string]string{"error": "image ref not allowed"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	writeJSON(w, 200, inspectImageByName(ctx, req.Image))
+}
+
+// handleImageTag retags an image, used to stage and restore the rollback
+// generation of a custom-built service.
+func handleImageTag(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Source string `json:"source"`
+		Target string `json:"target"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if !isAllowedImageRef(req.Source) || !isAllowedImageRef(req.Target) {
+		writeJSON(w, 403, map[string]string{"error": "image ref not allowed"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "tag", req.Source, req.Target)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "docker tag failed: " + err.Error(), "output": out.String()})
+		return
+	}
+	slog.Info("image tagged", "source", req.Source, "target", req.Target)
+	writeJSON(w, 200, map[string]string{"status": "ok"})
 }
 
 // --- Container Stats ---

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -996,6 +996,70 @@ func TestIsValidTag(t *testing.T) {
 	}
 }
 
+func TestIsValidCommitHash(t *testing.T) {
+	valid := []string{
+		"4bccedb",
+		"dbd39954",
+		"4bccedb1234567890abcdef1234567890abcdef1",
+	}
+	for _, s := range valid {
+		if !isValidCommitHash(s) {
+			t.Errorf("isValidCommitHash(%q) = false, want true", s)
+		}
+	}
+
+	invalid := []string{
+		"",                                          // leer
+		"4bcced",                                    // 6 Zeichen, zu kurz
+		"4bccedb1234567890abcdef1234567890abcdef12", // 41 Zeichen, zu lang
+		"4BCCEDB",                                   // Großbuchstaben
+		"v1.2.0",                                    // Tag, kein Hash
+		"4bccedb; rm -rf /",                         // Shell-Metazeichen
+		"../../../etc/passwd",                       // Pfad-Traversal
+		"4bccedb\n--upload-pack=evil",               // Newline-Injection
+		"-4bccedb",                                  // führender Bindestrich, sieht wie ein Flag aus
+	}
+	for _, s := range invalid {
+		if isValidCommitHash(s) {
+			t.Errorf("isValidCommitHash(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestAllowedRepoDirsRejectsTraversal(t *testing.T) {
+	allowed := []string{"/repo", "/srv/truffels/data/ckpoolstats"}
+	for _, d := range allowed {
+		if !isAllowedRepoDir(d) {
+			t.Errorf("isAllowedRepoDir(%q) = false, want true", d)
+		}
+	}
+
+	rejected := []string{
+		"/repo/../etc",
+		"/srv/truffels/data/ckpoolstats/../../secrets",
+		"/srv/truffels/secrets",
+		"/repo/",
+		"",
+		"/",
+	}
+	for _, d := range rejected {
+		if isAllowedRepoDir(d) {
+			t.Errorf("isAllowedRepoDir(%q) = true, want false", d)
+		}
+	}
+}
+
+func TestIsValidTagStillRejectsCommitHashes(t *testing.T) {
+	// isValidTag darf durch diese Änderung nicht aufgeweicht werden —
+	// der Self-Update-Pfad hängt daran.
+	if isValidTag("4bccedb") {
+		t.Error("isValidTag must keep rejecting bare commit hashes")
+	}
+	if !isValidTag("v0.3.1-dev.23") {
+		t.Error("isValidTag must keep accepting dev tags")
+	}
+}
+
 // --- handleComposeUpDetached ---
 
 func TestHandleComposeUpDetached_InvalidService(t *testing.T) {

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -2282,3 +2282,135 @@ func TestImageInspectResponseCarriesLabels(t *testing.T) {
 		t.Errorf("response JSON lacks the source-ref label: %s", b)
 	}
 }
+
+// --- Image retag / inspect-by-name (security boundary: agent is root) ---
+
+func TestImageTagRejectsForeignImages(t *testing.T) {
+	// Der Endpunkt darf nur Truffels-eigene Images umtaggen.
+	if isAllowedImageRef("bitcoin/bitcoin:29.0") {
+		t.Error("must reject images outside the truffels namespace")
+	}
+	if !isAllowedImageRef("truffels/ckpool:rollback") {
+		t.Error("must accept truffels images")
+	}
+	if isAllowedImageRef("truffels/ckpool:latest; rm -rf /") {
+		t.Error("must reject shell metacharacters")
+	}
+}
+
+func TestIsAllowedImageRef_Charset(t *testing.T) {
+	allowed := []string{
+		"truffels/ckpool:v1.0.0", "truffels/ckstats:latest",
+		"truffels/ckstats-cron:rollback", "truffels/api:v0.3.1-dev.23",
+		"truffels/web:sha256_abc",
+	}
+	for _, ref := range allowed {
+		if !isAllowedImageRef(ref) {
+			t.Errorf("ref %q should be allowed", ref)
+		}
+	}
+	denied := []string{
+		"", "ckpool:latest", "docker.io/truffels/ckpool:latest",
+		"Truffels/ckpool:latest", "truffels/CKPOOL:latest",
+		"truffels/ckpool:latest $(id)", "truffels/ckpool:latest`id`",
+		"truffels/ckpool:latest&&id", "truffels/ckpool:latest|id",
+		"truffels/ckpool:latest\nid", "truffels/ck pool:latest",
+		"truffels/ckpool:latest'", `truffels/ckpool:latest"`,
+		"truffels/ckpool:*", "truffels/ckpool:latest;id",
+	}
+	for _, ref := range denied {
+		if isAllowedImageRef(ref) {
+			t.Errorf("ref %q must be rejected", ref)
+		}
+	}
+}
+
+func TestHandleImageTag_RejectsForeignSource(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"source": "bitcoin/bitcoin:29.0", "target": "truffels/ckpool:latest",
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/tag", bytes.NewReader(body))
+
+	handleImageTag(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImageTag_RejectsForeignTarget(t *testing.T) {
+	// Source allowed, target not — both sides must be checked.
+	body, _ := json.Marshal(map[string]string{
+		"source": "truffels/ckpool:rollback", "target": "nginx:latest",
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/tag", bytes.NewReader(body))
+
+	handleImageTag(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImageTag_MalformedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/tag", bytes.NewReader([]byte("nope")))
+
+	handleImageTag(w, r)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleImageInspectByName_RejectsForeignImage(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"image": "mariadb:lts"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/inspect-by-name", bytes.NewReader(body))
+
+	handleImageInspectByName(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "image ref not allowed" {
+		t.Errorf("expected 'image ref not allowed', got %q", resp["error"])
+	}
+}
+
+func TestHandleImageInspectByName_MalformedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/inspect-by-name", bytes.NewReader([]byte("{")))
+
+	handleImageInspectByName(w, r)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleImageInspectByName_AllowedImageAnswersWithoutContainer(t *testing.T) {
+	// docker is not available in the test container, so the lookups inside come
+	// back empty — the point here is that an allowed ref gets past the guard and
+	// is answered with the shared inspect response shape.
+	body, _ := json.Marshal(map[string]string{"image": "truffels/ckpool:rollback"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/inspect-by-name", bytes.NewReader(body))
+
+	handleImageInspectByName(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp imageInspectResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Image != "truffels/ckpool:rollback" {
+		t.Errorf("image = %q, want the requested ref", resp.Image)
+	}
+}

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -2160,3 +2160,22 @@ func TestDirSizeCache_StaleMarkerSurfacedViaTimestamp(t *testing.T) {
 		t.Errorf("walked was %v ago, expected >1h", time.Since(walked))
 	}
 }
+
+func TestImageInspectResponseCarriesLabels(t *testing.T) {
+	// Die Response-Struktur muss ein labels-Feld serialisieren, sonst kann
+	// die API die gebaute Ref nicht zurücklesen.
+	resp := imageInspectResponse{
+		Image:  "truffels/ckpool:latest",
+		Labels: map[string]string{"org.truffels.source-ref": "v1.2.0"},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"labels"`) {
+		t.Errorf("response JSON lacks labels field: %s", b)
+	}
+	if !strings.Contains(string(b), "org.truffels.source-ref") {
+		t.Errorf("response JSON lacks the source-ref label: %s", b)
+	}
+}

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -970,6 +970,45 @@ func TestHandleGitCheckout_InvalidTagFormat(t *testing.T) {
 	}
 }
 
+func TestHandleGitCheckout_CommitHashRejectedWithoutRefScheme(t *testing.T) {
+	// A bare commit hash must NOT pass under the default (tag) validator.
+	// If it did, the scheme selection defaulted to the loose check instead
+	// of the strict one the self-update path relies on.
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: "/repo", Tag: "4bccedb"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "invalid ref format" {
+		t.Fatalf("expected 'invalid ref format', got %q", resp["error"])
+	}
+}
+
+func TestHandleGitCheckout_TagRejectedUnderCommitScheme(t *testing.T) {
+	// A tag must NOT pass when ref_scheme is explicitly "commit". If it
+	// did, the branch that picks the validator was inverted.
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: "/repo", Tag: "v0.2.0", RefScheme: "commit"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "invalid ref format" {
+		t.Fatalf("expected 'invalid ref format', got %q", resp["error"])
+	}
+}
+
 func TestHandleGitCheckout_MalformedJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader([]byte("bad")))

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -125,6 +125,16 @@ const ckpoolTemplate = `# Project Truffels — ckpool (Solo Mining Pool)
 
 services:
   ckpool:
+    # ckpool has no upstream image — it is built here from the Dockerfile the
+    # reconciler writes next to this file. Without this block a
+    # "docker compose build --build-arg SOURCE_REF=..." finds nothing to build,
+    # exits 0, and the update engine then verifies the label of the unchanged
+    # old image. Absolute paths because the agent runs compose through nsenter
+    # in PID 1's mount namespace. The context only has to carry the Dockerfile:
+    # the build clones ckpool from bitbucket itself.
+    build:
+      context: /srv/truffels/compose/ckpool
+      dockerfile: /srv/truffels/compose/ckpool/Dockerfile
     image: {{.ImageTag}}
     container_name: truffels-ckpool
     restart: unless-stopped

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -33,6 +34,37 @@ func TestRender_Ckpool(t *testing.T) {
 	assertContains(t, got, "image: truffels/ckpool:v1.0.0")
 	assertContains(t, got, "memory: 1024M")
 	assertContains(t, got, "container_name: truffels-ckpool")
+	// ckpool is built locally, and this template is what the reconciler
+	// enforces on every API start. Without a build section
+	// "docker compose build --build-arg SOURCE_REF=..." has nothing to build,
+	// exits 0, and the update engine verifies the label of the *old* image —
+	// i.e. every ckpool update silently becomes a no-op that reports success.
+	assertContains(t, got, "build:")
+	assertContains(t, got, "context: /srv/truffels/compose/ckpool")
+	assertContains(t, got, "dockerfile: /srv/truffels/compose/ckpool/Dockerfile")
+}
+
+// The installed compose file and the reconciled template must declare the same
+// build, otherwise the first API boot after an install silently rewrites the
+// build definition (or, worse, drops it).
+func TestRender_CkpoolBuildMatchesInstaller(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	got, err := Render("ckpool", CkpoolParams{ImageTag: "truffels/ckpool:v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range []string{
+		"context: /srv/truffels/compose/ckpool",
+		"dockerfile: /srv/truffels/compose/ckpool/Dockerfile",
+	} {
+		if !strings.Contains(string(installer), line) {
+			t.Errorf("install.sh does not declare %q for ckpool", line)
+		}
+		assertContains(t, got, line)
+	}
 }
 
 func TestRender_Mempool(t *testing.T) {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -317,10 +317,13 @@ func (c *ComposeClient) SystemTuningSet(action, value string) error {
 	return nil
 }
 
-// GitCheckout tells the agent to fetch tags and checkout a specific git tag.
-func (c *ComposeClient) GitCheckout(repoDir, tag string) error {
-	body, _ := json.Marshal(map[string]string{"repo_dir": repoDir, "tag": tag})
-	slog.Info("agent git checkout", "repo", repoDir, "tag", tag)
+// GitCheckout tells the agent to fetch and checkout a specific ref.
+// refScheme is "tag" or "commit"; empty means tag.
+func (c *ComposeClient) GitCheckout(repoDir, ref, refScheme string) error {
+	body, _ := json.Marshal(map[string]string{
+		"repo_dir": repoDir, "tag": ref, "ref_scheme": refScheme,
+	})
+	slog.Info("agent git checkout", "repo", repoDir, "ref", ref, "scheme", refScheme)
 
 	resp, err := c.httpClient.Post(c.agentURL+"/v1/git/checkout", "application/json", bytes.NewReader(body))
 	if err != nil {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -124,6 +124,52 @@ func (c *ComposeClient) ImageInspect(container string) (*ImageInfo, error) {
 	return &info, nil
 }
 
+// ImageInspectByName returns image info for an image reference, without going
+// through a container. Needed for custom-built services: their container may be
+// absent (never started, or removed by a failed update), and the container-based
+// lookup then reports nothing at all.
+func (c *ComposeClient) ImageInspectByName(image string) (*ImageInfo, error) {
+	body, _ := json.Marshal(map[string]string{"image": image})
+
+	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/inspect-by-name", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("agent image inspect by name: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		var ar agentResponse
+		_ = json.NewDecoder(resp.Body).Decode(&ar)
+		return nil, fmt.Errorf("agent image inspect by name: %s", ar.Error)
+	}
+
+	var info ImageInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("agent image inspect by name decode: %w", err)
+	}
+	return &info, nil
+}
+
+// ImageTag points target at the image currently behind source. Used to stage
+// and to restore the rollback generation of a custom-built service.
+func (c *ComposeClient) ImageTag(source, target string) error {
+	body, _ := json.Marshal(map[string]string{"source": source, "target": target})
+	slog.Info("agent image tag", "source", source, "target", target)
+
+	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/tag", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("agent image tag: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var ar agentResponse
+	_ = json.NewDecoder(resp.Body).Decode(&ar)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("agent image tag: %s", ar.Error)
+	}
+	return nil
+}
+
 // Build runs docker compose build for a service via the agent.
 func (c *ComposeClient) Build(serviceID string) error {
 	body, _ := json.Marshal(agentServiceReq{ServiceID: serviceID})

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -43,9 +43,10 @@ type agentResponse struct {
 }
 
 type ImageInfo struct {
-	Image  string   `json:"image"`
-	Digest string   `json:"digest"`
-	Tags   []string `json:"tags"`
+	Image  string            `json:"image"`
+	Digest string            `json:"digest"`
+	Tags   []string          `json:"tags"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 func (c *ComposeClient) Up(serviceID string) error {

--- a/truffels-api/internal/docker/docker_test.go
+++ b/truffels-api/internal/docker/docker_test.go
@@ -316,7 +316,7 @@ func TestComposeClient_GitCheckout_Success(t *testing.T) {
 	defer srv.Close()
 
 	client := NewComposeClient(srv.URL)
-	if err := client.GitCheckout("/repo", "v0.2.0"); err != nil {
+	if err := client.GitCheckout("/repo", "v0.2.0", "tag"); err != nil {
 		t.Fatalf("git checkout: %v", err)
 	}
 }
@@ -329,7 +329,7 @@ func TestComposeClient_GitCheckout_Error(t *testing.T) {
 	defer srv.Close()
 
 	client := NewComposeClient(srv.URL)
-	err := client.GitCheckout("/repo", "v0.2.0")
+	err := client.GitCheckout("/repo", "v0.2.0", "tag")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/truffels-api/internal/model/update.go
+++ b/truffels-api/internal/model/update.go
@@ -32,7 +32,17 @@ type UpdateSource struct {
 	Branch     string     `json:"branch,omitempty"`     // github/bitbucket: "main" or "master"
 	NeedsBuild bool       `json:"needs_build"`          // true for custom-built images (ckpool, ckstats)
 	TagFilter  string     `json:"tag_filter,omitempty"` // dockerhub: only consider tags matching this prefix (e.g. "2.9-alpine", "16-alpine")
+	RefScheme  string     `json:"ref_scheme,omitempty"`  // "tag" | "commit"; leer = "commit"
+	RepoDir    string     `json:"repo_dir,omitempty"`    // Arbeitskopie auf Platte, wenn das Dockerfile nicht selbst klont
 }
+
+// RefScheme bestimmt, was die Discovery für einen NeedsBuild-Service anbietet.
+// Tag: sortierte Versions-Tags des Upstreams. Commit: HEAD des Branches, für
+// Upstreams ohne Tags.
+const (
+	RefSchemeTag    = "tag"
+	RefSchemeCommit = "commit"
+)
 
 // UpdateCheck represents the latest known version info for a service.
 type UpdateCheck struct {

--- a/truffels-api/internal/service/templates/ckpool.go
+++ b/truffels-api/internal/service/templates/ckpool.go
@@ -17,6 +17,8 @@ var Ckpool = model.ServiceTemplate{
 		Repo:       "ckolivas/ckpool",
 		Branch:     "master",
 		NeedsBuild: true,
+		RefScheme:  model.RefSchemeTag,
+		TagFilter:  "v",
 	},
 	DataDirs: []model.DataDir{
 		{

--- a/truffels-api/internal/service/templates/ckstats.go
+++ b/truffels-api/internal/service/templates/ckstats.go
@@ -17,6 +17,8 @@ var Ckstats = model.ServiceTemplate{
 		Repo:       "mrv777/ckstats",
 		Branch:     "main",
 		NeedsBuild: true,
+		RefScheme:  model.RefSchemeCommit,
+		RepoDir:    "/srv/truffels/data/ckpoolstats",
 	},
 	DataDirs: []model.DataDir{
 		{

--- a/truffels-api/internal/service/templates/templates_test.go
+++ b/truffels-api/internal/service/templates/templates_test.go
@@ -1,0 +1,22 @@
+package templates
+
+import (
+	"testing"
+
+	"truffels-api/internal/model"
+)
+
+func TestNeedsBuildTemplatesDeclareRefScheme(t *testing.T) {
+	if Ckpool.UpdateSource.RefScheme != model.RefSchemeTag {
+		t.Errorf("ckpool RefScheme = %q, want %q", Ckpool.UpdateSource.RefScheme, model.RefSchemeTag)
+	}
+	if Ckpool.UpdateSource.RepoDir != "" {
+		t.Errorf("ckpool RepoDir = %q, want empty (Dockerfile clones itself)", Ckpool.UpdateSource.RepoDir)
+	}
+	if Ckstats.UpdateSource.RefScheme != model.RefSchemeCommit {
+		t.Errorf("ckstats RefScheme = %q, want %q", Ckstats.UpdateSource.RefScheme, model.RefSchemeCommit)
+	}
+	if Ckstats.UpdateSource.RepoDir != "/srv/truffels/data/ckpoolstats" {
+		t.Errorf("ckstats RepoDir = %q, want /srv/truffels/data/ckpoolstats", Ckstats.UpdateSource.RepoDir)
+	}
+}

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"truffels-api/internal/docker"
@@ -29,8 +30,36 @@ type mockAgentOpts struct {
 	buildFail   bool
 	unhealthy   bool // if true, inspect returns unhealthy containers
 	imageInspectFail bool   // if true, /v1/image/inspect returns 500
+	tagFail          bool   // if true, /v1/image/tag returns 500 (no staged rollback image)
 	composeDirs      map[string]string // service_id -> compose dir path for rewrite-tags
 	imageLabels      map[string]string // labels returned by /v1/image/inspect (NeedsBuild verification)
+	tags             *tagRecorder      // records /v1/image/tag calls when set
+}
+
+// tagCall is one /v1/image/tag request. JSON tags match the agent's wire format
+// so the recorder decodes exactly what the client sent.
+type tagCall struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+// tagRecorder collects retag calls. The engine prunes in a background goroutine
+// after a successful update, so access is behind a mutex.
+type tagRecorder struct {
+	mu    sync.Mutex
+	calls []tagCall
+}
+
+func (r *tagRecorder) record(c tagCall) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, c)
+}
+
+func (r *tagRecorder) snapshot() []tagCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]tagCall(nil), r.calls...)
 }
 
 func newMockAgent(opts mockAgentOpts) *httptest.Server {
@@ -101,6 +130,31 @@ func newMockAgent(opts mockAgentOpts) *httptest.Server {
 				Labels: opts.imageLabels,
 			}
 			_ = json.NewEncoder(w).Encode(info)
+
+		case "/v1/image/inspect-by-name":
+			var req struct {
+				Image string `json:"image"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if opts.imageInspectFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "no such image"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(docker.ImageInfo{Image: req.Image, Labels: opts.imageLabels})
+
+		case "/v1/image/tag":
+			var req tagCall
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if opts.tags != nil {
+				opts.tags.record(req)
+			}
+			if opts.tagFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "no such image"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case "/v1/inspect":
 			// AgentInspector.Inspect decodes as []model.ContainerState

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -30,6 +30,7 @@ type mockAgentOpts struct {
 	unhealthy   bool // if true, inspect returns unhealthy containers
 	imageInspectFail bool   // if true, /v1/image/inspect returns 500
 	composeDirs      map[string]string // service_id -> compose dir path for rewrite-tags
+	imageLabels      map[string]string // labels returned by /v1/image/inspect (NeedsBuild verification)
 }
 
 func newMockAgent(opts mockAgentOpts) *httptest.Server {
@@ -97,6 +98,7 @@ func newMockAgent(opts mockAgentOpts) *httptest.Server {
 			info := docker.ImageInfo{
 				Image:  "mariadb:lts",
 				Digest: "sha256:olddigest123",
+				Labels: opts.imageLabels,
 			}
 			_ = json.NewEncoder(w).Encode(info)
 
@@ -671,7 +673,11 @@ func TestApplyUpdate_AlreadyUpdating(t *testing.T) {
 }
 
 func TestApplyUpdate_BuildService(t *testing.T) {
-	agent := newMockAgent(mockAgentOpts{})
+	// The rebuilt image must report the requested ref, otherwise the engine
+	// refuses to call the update a success (see the NeedsBuild tests).
+	agent := newMockAgent(mockAgentOpts{
+		imageLabels: map[string]string{SourceRefLabel: "def789abc012"},
+	})
 	defer agent.Close()
 
 	composeDir := t.TempDir()

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -767,18 +767,30 @@ func composeImageRe(serviceID string) *regexp.Regexp {
 // tag nothing runs: the same silent no-op this rollback path exists to end. So
 // read the compose file and fall back to the convention only when it says
 // nothing.
+// Every path to the fallback warns: each one is a misconfiguration that turns
+// staging and rollback into tag moves nothing runs, and it has to be visible
+// before a rollback needs the ref, not afterwards.
 func liveImageRef(tmpl model.ServiceTemplate, serviceID string) string {
 	fallback := "truffels/" + serviceID + ":latest"
 	if tmpl.ComposeDir == "" {
+		slog.Warn("no compose dir for service, assuming conventional image ref",
+			"service", serviceID, "image", fallback)
 		return fallback
 	}
-	data, err := os.ReadFile(tmpl.ComposeDir + "/docker-compose.yml")
+	path := tmpl.ComposeDir + "/docker-compose.yml"
+	data, err := os.ReadFile(path)
 	if err != nil {
+		slog.Warn("cannot read compose file, assuming conventional image ref",
+			"service", serviceID, "path", path, "image", fallback, "err", err)
 		return fallback
 	}
 	if m := composeImageRe(serviceID).FindSubmatch(data); m != nil {
 		return string(m[1])
 	}
+	// A trailing comment ("image: truffels/ckpool:v1.0.0 # pinned") or an
+	// interpolated tag ("image: truffels/ckpool:${TAG}") both miss the pattern.
+	slog.Warn("no plain truffels image line in compose file, assuming conventional image ref",
+		"service", serviceID, "path", path, "image", fallback)
 	return fallback
 }
 
@@ -809,11 +821,22 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 	}
 
 	// Stage the running image for rollback before the build overwrites its tag.
-	// Best-effort: a first-time build has nothing to stage, and refusing to
-	// update over that would be worse than losing the rollback option.
+	// Staging itself is best-effort: a first-time build has nothing to stage,
+	// and refusing to update over that would be worse than losing the rollback
+	// option.
 	live := liveImageRef(tmpl, serviceID)
-	if err := e.compose.ImageTag(live, rollbackImageRef(serviceID)); err != nil {
+	rollbackRef := rollbackImageRef(serviceID)
+	if err := e.compose.ImageTag(live, rollbackRef); err != nil {
+		// Whatever :rollback still points at is now one generation too old —
+		// it was staged by the *previous* update. Restoring it later would
+		// install the wrong build and report a successful rollback, which is
+		// the class of lie this whole path exists to end. Drop the tag so a
+		// later rollback fails honestly instead. Removing a tag does not delete
+		// the image it shares with other tags.
 		slog.Warn("could not stage rollback image", "service", serviceID, "image", live, "err", err)
+		if rmErr := e.compose.RemoveImage(rollbackRef); rmErr != nil {
+			slog.Warn("could not drop the stale rollback tag", "service", serviceID, "image", rollbackRef, "err", rmErr)
+		}
 	}
 
 	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -734,7 +734,7 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 
 	// Step 1: Git checkout the new tag
 	_ = e.store.UpdateLogStatus(logID, model.UpdatePulling, "", "")
-	if err := e.compose.GitCheckout("/repo", check.LatestVersion); err != nil {
+	if err := e.compose.GitCheckout("/repo", check.LatestVersion, model.RefSchemeTag); err != nil {
 		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "git checkout failed: "+err.Error(), "")
 		e.alertUpdateFailed(serviceID, "git checkout failed: "+err.Error())
 		return &UpdateError{Msg: "git checkout failed: " + err.Error()}

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -651,13 +651,57 @@ func (e *Engine) RollbackService(serviceID string) error {
 	// Restore the old image
 	_ = e.store.UpdateLogStatus(logID, model.UpdatePulling, "", "")
 	if src.NeedsBuild {
+		// The truffels stack is NeedsBuild as well, but it is a github_release:
+		// ApplyUpdateToVersion routes it to applySelfUpdate before it ever gets
+		// here, and nothing is staged under a truffels/truffels:rollback tag.
+		// Without this guard the retag path below chases an image that does not
+		// exist and ends in a misleading "no rollback image available" plus an
+		// alert. Keep the honest message this path had before retag rollbacks.
+		if src.Type == model.SourceGitHubRelease {
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "rollback not supported for custom-built services", "")
+			return &UpdateError{Msg: "rollback not supported for custom-built services"}
+		}
+
 		// Nothing to pull — a custom build exists only on this box. The image
 		// running before the last update was staged under :rollback; move that
 		// tag back onto the ref the compose file runs. Fail loudly if it is
 		// gone: restarting the current image and calling it a rollback is the
 		// bug this replaces.
+		//
+		// Check the staged image *before* moving any tag: :rollback holds
+		// exactly one generation and is only ever staged by an update, never by
+		// a rollback. After one successful rollback it points at the image that
+		// is already running, so a second rollback would retag a no-op, come up
+		// healthy and then record prevVersion as the running version — the
+		// running code would be one generation older than the UI claims.
+		// Verifying first means a refusal leaves nothing half-done.
+		rollbackRef := rollbackImageRef(serviceID)
+		info, inspectErr := e.compose.ImageInspectByName(rollbackRef)
+		if inspectErr != nil {
+			msg := "cannot verify the staged rollback image: " + inspectErr.Error()
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		}
+		staged := info.Labels[SourceRefLabel]
+		switch {
+		case staged == "":
+			// Either nothing is staged (the agent answers 200 with empty fields
+			// for an unknown image) or the staged image predates source-ref
+			// labels. Both mean we cannot prove what it would restore.
+			msg := fmt.Sprintf("no rollback image available: %s carries no source ref, so it cannot be shown to hold %s", rollbackRef, prevVersion)
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		case staged != prevVersion:
+			msg := fmt.Sprintf("staged rollback image holds ref %q, not %q — only one generation is kept, so this version is gone", staged, prevVersion)
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		}
+
 		live := liveImageRef(tmpl, serviceID)
-		if err := e.compose.ImageTag(rollbackImageRef(serviceID), live); err != nil {
+		if err := e.compose.ImageTag(rollbackRef, live); err != nil {
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "no rollback image available: "+err.Error(), "")
 			e.alertUpdateFailed(serviceID, "rollback image restore failed: "+err.Error())
 			return &UpdateError{Msg: "no rollback image available: " + err.Error()}

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -490,11 +490,8 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		}
 		// No compose file rewrite needed — tag stays the same
 	} else if src.NeedsBuild {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
-		if err := e.compose.Build(serviceID); err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "build failed: "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "build failed: "+err.Error())
-			return &UpdateError{Msg: "build failed: " + err.Error()}
+		if err := e.applyNeedsBuild(serviceID, tmpl, src, check, logID); err != nil {
+			return err
 		}
 	} else {
 		_ = e.store.UpdateLogStatus(logID, model.UpdatePulling, "", "")
@@ -715,6 +712,60 @@ func (e *Engine) checkHealth(tmpl model.ServiceTemplate) bool {
 		}
 	}
 	return true
+}
+
+// applyNeedsBuild rebuilds a custom-built service at a specific upstream ref
+// and verifies the result before starting it. The ref travels into the build as
+// the SOURCE_REF build arg and comes back out of the image's source-ref label,
+// so a build that silently produced the old code can no longer be reported as a
+// successful update — which is exactly what ckpool and ckstats used to do.
+func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, src *model.UpdateSource, check *model.UpdateCheck, logID int64) error {
+	// Services whose source lives as a working copy on disk need it moved to the
+	// target ref first; ckpool clones inside its Dockerfile and has no RepoDir.
+	if src.RepoDir != "" {
+		// model.UpdateSource documents an empty RefScheme as "commit", but the
+		// agent's /v1/git/checkout treats an empty ref_scheme as "tag" and would
+		// reject a commit hash with HTTP 400. Resolve the default here so the
+		// wire value always carries the meaning the model defines.
+		refScheme := src.RefScheme
+		if refScheme == "" {
+			refScheme = model.RefSchemeCommit
+		}
+		if err := e.compose.GitCheckout(src.RepoDir, check.LatestVersion, refScheme); err != nil {
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "git checkout failed: "+err.Error(), "")
+			e.alertUpdateFailed(serviceID, "git checkout failed: "+err.Error())
+			return &UpdateError{Msg: "git checkout failed: " + err.Error()}
+		}
+	}
+
+	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
+	buildArgs := map[string]string{"SOURCE_REF": check.LatestVersion}
+	if err := e.compose.BuildWithArgs(serviceID, buildArgs); err != nil {
+		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "build failed: "+err.Error(), "")
+		e.alertUpdateFailed(serviceID, "build failed: "+err.Error())
+		return &UpdateError{Msg: "build failed: " + err.Error()}
+	}
+
+	// Verify before restarting: a mismatched image must never get to run. The
+	// agent resolves the image by the name the container references, so this
+	// reads the freshly built image even though the old one is still running.
+	if len(tmpl.ContainerNames) > 0 {
+		info, err := e.compose.ImageInspect(tmpl.ContainerNames[0])
+		if err != nil {
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "image inspect failed: "+err.Error(), "")
+			e.alertUpdateFailed(serviceID, "image inspect failed: "+err.Error())
+			return &UpdateError{Msg: "image inspect failed: " + err.Error()}
+		}
+		built := info.Labels[SourceRefLabel]
+		if built != check.LatestVersion {
+			msg := fmt.Sprintf("built ref %q does not match requested %q", built, check.LatestVersion)
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		}
+	}
+
+	return nil
 }
 
 // applySelfUpdate handles the self-update flow for truffels services (agent/api/web).

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strconv"
 	"sync"
 	"syscall"
@@ -530,7 +531,12 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 			return &UpdateError{Msg: "start failed: " + err.Error()}
 		}
 		slog.Error("update: start failed, rolling back", "service", serviceID, "err", err)
-		e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion)
+		if rbErr := e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion); rbErr != nil {
+			msg := "start failed: " + err.Error() + "; rollback incomplete: " + rbErr.Error()
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, check.CurrentVersion)
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "start failed: "+err.Error(), check.CurrentVersion)
 		e.alertUpdateFailed(serviceID, "start failed, rolled back to "+check.CurrentVersion)
 		return &UpdateError{Msg: "start failed, rolled back: " + err.Error()}
@@ -547,7 +553,12 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 			return &UpdateError{Msg: "service unhealthy after update, no rollback available for floating tag"}
 		}
 		slog.Error("update: service unhealthy after update, rolling back", "service", serviceID)
-		e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion)
+		if rbErr := e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion); rbErr != nil {
+			msg := "unhealthy after update; rollback incomplete: " + rbErr.Error()
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, check.CurrentVersion)
+			e.alertUpdateFailed(serviceID, msg)
+			return &UpdateError{Msg: msg}
+		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "unhealthy after update", check.CurrentVersion)
 		e.alertUpdateFailed(serviceID, "unhealthy after update, rolled back to "+check.CurrentVersion)
 		return &UpdateError{Msg: "service unhealthy after update, rolled back"}
@@ -633,24 +644,34 @@ func (e *Engine) RollbackService(serviceID string) error {
 		return &UpdateError{Msg: "cannot create rollback log: " + err.Error()}
 	}
 
-	// Pull old version
+	// Restore the old image
 	_ = e.store.UpdateLogStatus(logID, model.UpdatePulling, "", "")
 	if src.NeedsBuild {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "rollback not supported for custom-built services", "")
-		return &UpdateError{Msg: "rollback not supported for custom-built services"}
-	}
-	for _, img := range src.Images {
-		if _, err := e.compose.Pull(img + ":" + prevVersion); err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "pull failed: "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "rollback pull failed: "+err.Error())
-			return &UpdateError{Msg: "pull failed: " + err.Error()}
+		// Nothing to pull — a custom build exists only on this box. The image
+		// running before the last update was staged under :rollback; move that
+		// tag back onto the ref the compose file runs. Fail loudly if it is
+		// gone: restarting the current image and calling it a rollback is the
+		// bug this replaces.
+		live := liveImageRef(tmpl, serviceID)
+		if err := e.compose.ImageTag(rollbackImageRef(serviceID), live); err != nil {
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "no rollback image available: "+err.Error(), "")
+			e.alertUpdateFailed(serviceID, "rollback image restore failed: "+err.Error())
+			return &UpdateError{Msg: "no rollback image available: " + err.Error()}
 		}
-	}
-	// Rewrite compose tags
-	if err := e.compose.RewriteTags(serviceID, src.Images, currentVersion, prevVersion); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "compose rewrite failed: "+err.Error(), "")
-		e.alertUpdateFailed(serviceID, "rollback compose rewrite failed: "+err.Error())
-		return &UpdateError{Msg: "compose rewrite failed: " + err.Error()}
+	} else {
+		for _, img := range src.Images {
+			if _, err := e.compose.Pull(img + ":" + prevVersion); err != nil {
+				_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "pull failed: "+err.Error(), "")
+				e.alertUpdateFailed(serviceID, "rollback pull failed: "+err.Error())
+				return &UpdateError{Msg: "pull failed: " + err.Error()}
+			}
+		}
+		// Rewrite compose tags
+		if err := e.compose.RewriteTags(serviceID, src.Images, currentVersion, prevVersion); err != nil {
+			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "compose rewrite failed: "+err.Error(), "")
+			e.alertUpdateFailed(serviceID, "rollback compose rewrite failed: "+err.Error())
+			return &UpdateError{Msg: "compose rewrite failed: " + err.Error()}
+		}
 	}
 
 	// Restart
@@ -683,8 +704,22 @@ func (e *Engine) RollbackService(serviceID string) error {
 	return nil
 }
 
-func (e *Engine) rollback(serviceID string, tmpl model.ServiceTemplate, src *model.UpdateSource, currentVersion, newVersion string) {
-	if !src.NeedsBuild {
+// rollback returns the service to the state it was in before the update.
+// It reports an error when it could not do so — the caller must not claim a
+// rollback that did not happen.
+func (e *Engine) rollback(serviceID string, tmpl model.ServiceTemplate, src *model.UpdateSource, currentVersion, newVersion string) error {
+	var rollbackErr error
+	if src.NeedsBuild {
+		// A custom build has no registry to pull the old version back from. The
+		// previous image was staged under :rollback before the build overwrote
+		// the live tag; move it back, otherwise Down/Up would simply restart the
+		// very image that just failed while we reported a successful rollback.
+		live := liveImageRef(tmpl, serviceID)
+		if err := e.compose.ImageTag(rollbackImageRef(serviceID), live); err != nil {
+			slog.Error("rollback: retag failed", "service", serviceID, "image", live, "err", err)
+			rollbackErr = fmt.Errorf("restoring previous image failed: %w", err)
+		}
+	} else {
 		// Revert compose file to old version
 		if err := e.compose.RewriteTags(serviceID, src.Images, newVersion, currentVersion); err != nil {
 			slog.Error("rollback: compose rewrite failed", "service", serviceID, "err", err)
@@ -695,6 +730,7 @@ func (e *Engine) rollback(serviceID string, tmpl model.ServiceTemplate, src *mod
 	}
 	_ = e.compose.Down(serviceID)
 	_ = e.compose.Up(serviceID)
+	return rollbackErr
 }
 
 func (e *Engine) checkHealth(tmpl model.ServiceTemplate) bool {
@@ -719,6 +755,40 @@ func (e *Engine) checkHealth(tmpl model.ServiceTemplate) bool {
 // the SOURCE_REF build arg and comes back out of the image's source-ref label,
 // so a build that silently produced the old code can no longer be reported as a
 // successful update — which is exactly what ckpool and ckstats used to do.
+// composeImageRe matches the image line a compose file uses for a service's own
+// truffels image, e.g. "  image: truffels/ckpool:v1.0.0".
+func composeImageRe(serviceID string) *regexp.Regexp {
+	return regexp.MustCompile(`(?m)^\s*image:\s*(truffels/` + regexp.QuoteMeta(serviceID) + `:[A-Za-z0-9._-]+)\s*$`)
+}
+
+// liveImageRef is the image reference a custom-built service actually runs.
+// The convention is truffels/<id>:latest — but ckpool's compose file pins
+// truffels/ckpool:v1.0.0, and staging or restoring :latest there would move a
+// tag nothing runs: the same silent no-op this rollback path exists to end. So
+// read the compose file and fall back to the convention only when it says
+// nothing.
+func liveImageRef(tmpl model.ServiceTemplate, serviceID string) string {
+	fallback := "truffels/" + serviceID + ":latest"
+	if tmpl.ComposeDir == "" {
+		return fallback
+	}
+	data, err := os.ReadFile(tmpl.ComposeDir + "/docker-compose.yml")
+	if err != nil {
+		return fallback
+	}
+	if m := composeImageRe(serviceID).FindSubmatch(data); m != nil {
+		return string(m[1])
+	}
+	return fallback
+}
+
+// rollbackImageRef names the single retained rollback generation. Exactly one:
+// a second update overwrites it, because more generations cost disk on a device
+// that has none to spare.
+func rollbackImageRef(serviceID string) string {
+	return "truffels/" + serviceID + ":rollback"
+}
+
 func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, src *model.UpdateSource, check *model.UpdateCheck, logID int64) error {
 	// Services whose source lives as a working copy on disk need it moved to the
 	// target ref first; ckpool clones inside its Dockerfile and has no RepoDir.
@@ -738,6 +808,14 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 		}
 	}
 
+	// Stage the running image for rollback before the build overwrites its tag.
+	// Best-effort: a first-time build has nothing to stage, and refusing to
+	// update over that would be worse than losing the rollback option.
+	live := liveImageRef(tmpl, serviceID)
+	if err := e.compose.ImageTag(live, rollbackImageRef(serviceID)); err != nil {
+		slog.Warn("could not stage rollback image", "service", serviceID, "image", live, "err", err)
+	}
+
 	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
 	buildArgs := map[string]string{"SOURCE_REF": check.LatestVersion}
 	if err := e.compose.BuildWithArgs(serviceID, buildArgs); err != nil {
@@ -749,20 +827,31 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 	// Verify before restarting: a mismatched image must never get to run. The
 	// agent resolves the image by the name the container references, so this
 	// reads the freshly built image even though the old one is still running.
+	var info *docker.ImageInfo
+	err := fmt.Errorf("service %s has no container to inspect", serviceID)
 	if len(tmpl.ContainerNames) > 0 {
-		info, err := e.compose.ImageInspect(tmpl.ContainerNames[0])
-		if err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "image inspect failed: "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "image inspect failed: "+err.Error())
-			return &UpdateError{Msg: "image inspect failed: " + err.Error()}
-		}
-		built := info.Labels[SourceRefLabel]
-		if built != check.LatestVersion {
-			msg := fmt.Sprintf("built ref %q does not match requested %q", built, check.LatestVersion)
+		info, err = e.compose.ImageInspect(tmpl.ContainerNames[0])
+	}
+	if err != nil {
+		// No container to resolve through — the case checkService deliberately
+		// does not skip for git sources, i.e. ckpool and ckstats after a failed
+		// or never-completed start. Ask for the image by name instead; only a
+		// second failure means we cannot verify at all.
+		byName, nameErr := e.compose.ImageInspectByName(live)
+		if nameErr != nil {
+			msg := "image inspect failed: " + err.Error() + "; by name: " + nameErr.Error()
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
 			e.alertUpdateFailed(serviceID, msg)
 			return &UpdateError{Msg: msg}
 		}
+		info = byName
+	}
+	built := info.Labels[SourceRefLabel]
+	if built != check.LatestVersion {
+		msg := fmt.Sprintf("built ref %q does not match requested %q", built, check.LatestVersion)
+		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+		e.alertUpdateFailed(serviceID, msg)
+		return &UpdateError{Msg: msg}
 	}
 
 	return nil

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -160,7 +160,11 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 			// For digest-based checks, use the local image digest directly
 			currentVersion = info.Digest
 		} else {
-			currentVersion = ExtractCurrentVersion(src, info.Image)
+			// Labels first: for the services we build ourselves the image tag is
+			// pinned (truffels/ckpool:v1.0.0 stays put across builds), so the only
+			// statement about what is actually running is the ref stamped into the
+			// image at build time. Everything else still reads the tag.
+			currentVersion = ExtractCurrentVersionFromLabels(src, info.Image, info.Labels)
 		}
 	}
 

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"truffels-api/internal/docker"
 	"truffels-api/internal/model"
 )
 
@@ -1023,6 +1025,254 @@ func TestPruneOldImages_RespectsSetting(t *testing.T) {
 	// Should NOT remove anything when setting is true
 	if len(removedImages) != 0 {
 		t.Fatalf("expected 0 images removed when keep_old_images=true, got %d: %v", len(removedImages), removedImages)
+	}
+}
+
+// --- NeedsBuild apply path (ckpool / ckstats) ---
+
+// needsBuildRecorder captures what the engine asked the agent to do on the
+// NeedsBuild path and serves the image label the engine verifies against.
+// The engine prunes in a background goroutine after a successful update, so
+// every field is behind a mutex.
+type needsBuildRecorder struct {
+	mu             sync.Mutex
+	imageLabels    map[string]string
+	buildArgs      map[string]string
+	checkoutDir    string
+	checkoutRef    string
+	checkoutScheme string
+	checkoutCalls  int
+	upCalls        int
+}
+
+func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return needsBuildRecorder{
+		buildArgs:      r.buildArgs,
+		checkoutDir:    r.checkoutDir,
+		checkoutRef:    r.checkoutRef,
+		checkoutScheme: r.checkoutScheme,
+		checkoutCalls:  r.checkoutCalls,
+		upCalls:        r.upCalls,
+	}
+}
+
+func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/git/checkout":
+			var req struct {
+				RepoDir   string `json:"repo_dir"`
+				Tag       string `json:"tag"`
+				RefScheme string `json:"ref_scheme"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.checkoutDir, rec.checkoutRef, rec.checkoutScheme = req.RepoDir, req.Tag, req.RefScheme
+			rec.checkoutCalls++
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		case "/v1/compose/build":
+			var req struct {
+				ServiceID string            `json:"service_id"`
+				BuildArgs map[string]string `json:"build_args"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.buildArgs = req.BuildArgs
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		case "/v1/image/inspect":
+			rec.mu.Lock()
+			labels := rec.imageLabels
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(docker.ImageInfo{Image: "truffels/built:local", Labels: labels})
+
+		case "/v1/compose/up":
+			rec.mu.Lock()
+			rec.upCalls++
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		case "/v1/inspect":
+			var req struct {
+				Containers []string `json:"containers"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			var states []map[string]interface{}
+			for _, name := range req.Containers {
+				states = append(states, map[string]interface{}{
+					"name": name, "status": "running", "health": "healthy",
+				})
+			}
+			_ = json.NewEncoder(w).Encode(states)
+
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		}
+	}))
+}
+
+func ckpoolBuildTemplate(composeDir string) model.ServiceTemplate {
+	return model.ServiceTemplate{
+		ID:             "ckpool",
+		DisplayName:    "ckpool",
+		ComposeDir:     composeDir,
+		ContainerNames: []string{"truffels-ckpool"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceBitbucket,
+			Repo:       "ckolivas/ckpool",
+			Branch:     "master",
+			NeedsBuild: true,
+			RefScheme:  model.RefSchemeTag,
+			TagFilter:  "v",
+		},
+	}
+}
+
+func ckstatsBuildTemplate(composeDir, refScheme string) model.ServiceTemplate {
+	return model.ServiceTemplate{
+		ID:             "ckstats",
+		DisplayName:    "ckstats",
+		ComposeDir:     composeDir,
+		ContainerNames: []string{"truffels-ckstats", "truffels-ckstats-cron"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceGitHub,
+			Repo:       "mrv777/ckstats",
+			Branch:     "main",
+			NeedsBuild: true,
+			RefScheme:  refScheme,
+			RepoDir:    "/srv/truffels/data/ckpoolstats",
+		},
+	}
+}
+
+// A build whose image carries a different ref than the one requested must not
+// count as an update — this is exactly the failure that used to be invisible.
+func TestApplyUpdate_NeedsBuild_LabelMismatchFails(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "v1.0.0"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected error on label mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("expected a ref mismatch error, got: %v", err)
+	}
+
+	got := rec.snapshot()
+	if got.upCalls != 0 {
+		t.Errorf("service must not be started when the built ref does not match (up calls=%d)", got.upCalls)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 {
+		t.Fatal("expected an update log")
+	}
+	if logs[0].Status != model.UpdateFailed {
+		t.Errorf("log status = %v, want %v", logs[0].Status, model.UpdateFailed)
+	}
+}
+
+func TestApplyUpdate_NeedsBuild_PassesSourceRefBuildArg(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "v1.2.0"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if got.buildArgs["SOURCE_REF"] != "v1.2.0" {
+		t.Errorf("SOURCE_REF = %q, want v1.2.0", got.buildArgs["SOURCE_REF"])
+	}
+	// ckpool clones inside its Dockerfile — there is no working copy to move.
+	if got.checkoutCalls != 0 {
+		t.Errorf("expected no git checkout without RepoDir, got %d calls", got.checkoutCalls)
+	}
+}
+
+func TestApplyUpdate_NeedsBuild_ChecksOutRepoDirForCommitScheme(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "dbd39954"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckstatsBuildTemplate(t.TempDir(), model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "4bccedb",
+		LatestVersion:  "dbd39954",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckstats"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if got.checkoutDir != "/srv/truffels/data/ckpoolstats" {
+		t.Errorf("checkout dir = %q, want the ckstats repo dir", got.checkoutDir)
+	}
+	if got.checkoutRef != "dbd39954" {
+		t.Errorf("checkout ref = %q, want dbd39954", got.checkoutRef)
+	}
+	if got.checkoutScheme != model.RefSchemeCommit {
+		t.Errorf("checkout scheme = %q, want %q", got.checkoutScheme, model.RefSchemeCommit)
+	}
+}
+
+// An empty RefScheme means "commit" per model.UpdateSource, but the agent reads
+// an empty ref_scheme as "tag" and rejects commit hashes. The engine must send
+// the model's meaning explicitly rather than pass the blank through.
+func TestApplyUpdate_NeedsBuild_EmptyRefSchemeCheckedOutAsCommit(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "dbd39954"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckstatsBuildTemplate(t.TempDir(), "")
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "4bccedb",
+		LatestVersion:  "dbd39954",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckstats"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rec.snapshot().checkoutScheme; got != model.RefSchemeCommit {
+		t.Errorf("checkout scheme = %q, want %q for an empty RefScheme", got, model.RefSchemeCommit)
 	}
 }
 

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -1,7 +1,9 @@
 package updates
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1113,6 +1115,8 @@ type needsBuildRecorder struct {
 	byNameCalls    int
 	tagFail        bool // /v1/image/tag 500s — nothing staged to restore
 	tags           []tagCall
+	removed        []string // images dropped via /v1/image/remove
+	unhealthy      bool     // /v1/inspect reports the containers unhealthy
 	buildArgs      map[string]string
 	checkoutDir    string
 	checkoutRef    string
@@ -1128,6 +1132,7 @@ func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
 		byNameImage:    r.byNameImage,
 		byNameCalls:    r.byNameCalls,
 		tags:           append([]tagCall(nil), r.tags...),
+		removed:        append([]string(nil), r.removed...),
 		buildArgs:      r.buildArgs,
 		checkoutDir:    r.checkoutDir,
 		checkoutRef:    r.checkoutRef,
@@ -1212,15 +1217,31 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 			rec.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
+		case "/v1/image/remove":
+			var req struct {
+				Image string `json:"image"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.removed = append(rec.removed, req.Image)
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
 		case "/v1/inspect":
 			var req struct {
 				Containers []string `json:"containers"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			health := "healthy"
+			if rec.unhealthy {
+				health = "unhealthy"
+			}
+			rec.mu.Unlock()
 			var states []map[string]interface{}
 			for _, name := range req.Containers {
 				states = append(states, map[string]interface{}{
-					"name": name, "status": "running", "health": "healthy",
+					"name": name, "status": "running", "health": health,
 				})
 			}
 			_ = json.NewEncoder(w).Encode(states)
@@ -1493,6 +1514,136 @@ func TestApplyUpdate_NeedsBuild_StagesRollbackImageBeforeBuild(t *testing.T) {
 	}
 	if got.tags[0].Source != "truffels/ckpool:latest" || got.tags[0].Target != "truffels/ckpool:rollback" {
 		t.Errorf("staged %q -> %q, want the live tag onto :rollback", got.tags[0].Source, got.tags[0].Target)
+	}
+}
+
+// A failed staging must not leave the previous update's :rollback tag in place:
+// restoring that later would install a two-generations-old image and report a
+// successful rollback.
+func TestApplyUpdate_NeedsBuild_FailedStagingDropsStaleRollbackTag(t *testing.T) {
+	rec := &needsBuildRecorder{
+		tagFail:     true, // staging retag fails; :rollback still points at N-2
+		imageLabels: map[string]string{SourceRefLabel: "v1.2.0"},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	// Staging is best-effort — a failure there must not block the update.
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("failed staging must not block the update: %v", err)
+	}
+
+	got := rec.snapshot()
+	found := false
+	for _, img := range got.removed {
+		if img == "truffels/ckpool:rollback" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("stale rollback tag was not dropped, removed = %v", got.removed)
+	}
+}
+
+// The same run end to end: staging fails, the service comes up unhealthy, and
+// the rollback has nothing valid to restore. It must say so — the old code
+// logged rolled_back while the failed build kept running.
+func TestApplyUpdate_NeedsBuild_StaleStagingRollbackFailsHonestly(t *testing.T) {
+	rec := &needsBuildRecorder{
+		tagFail:     true,
+		unhealthy:   true,
+		imageLabels: map[string]string{SourceRefLabel: "v1.2.0"},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected an error when the service is unhealthy and cannot be rolled back")
+	}
+	if !strings.Contains(err.Error(), "rollback incomplete") {
+		t.Errorf("expected an honest 'rollback incomplete' error, got: %v", err)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 {
+		t.Fatal("expected an update log")
+	}
+	if logs[0].Status == model.UpdateRolledBack {
+		t.Error("log claims rolled_back although nothing was restored")
+	}
+	if logs[0].Status != model.UpdateFailed {
+		t.Errorf("log status = %v, want %v", logs[0].Status, model.UpdateFailed)
+	}
+
+	got := rec.snapshot()
+	found := false
+	for _, img := range got.removed {
+		if img == "truffels/ckpool:rollback" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("stale rollback tag was not dropped, removed = %v", got.removed)
+	}
+}
+
+// The :latest fallback is a misconfiguration, not a normal case — it must leave
+// a trace, otherwise a wrong live ref only surfaces when a rollback needs it.
+func TestLiveImageRef_FallbackIsLogged(t *testing.T) {
+	cases := []struct {
+		name    string
+		compose string // empty means: write no compose file at all
+		wantLog string
+	}{
+		{"interpolated tag", "services:\n  ckpool:\n    image: truffels/ckpool:${TAG}\n", "no plain truffels image line"},
+		{"trailing comment", "services:\n  ckpool:\n    image: truffels/ckpool:v1.0.0 # pinned\n", "no plain truffels image line"},
+		{"unreadable compose file", "", "cannot read compose file"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			dir := t.TempDir()
+			if tc.compose != "" {
+				_ = os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(tc.compose), 0644)
+			}
+
+			got := liveImageRef(ckpoolBuildTemplate(dir), "ckpool")
+			if got != "truffels/ckpool:latest" {
+				t.Errorf("live ref = %q, want the conventional fallback", got)
+			}
+			if !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("expected a warning containing %q, got: %s", tc.wantLog, buf.String())
+			}
+			if !strings.Contains(buf.String(), "ckpool") {
+				t.Errorf("warning does not name the service: %s", buf.String())
+			}
+		})
 	}
 }
 

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -944,6 +944,66 @@ func TestCheckService_DoesNotSkipGitHubSource(t *testing.T) {
 	}
 }
 
+// A freshly installed ckpool runs the image install.sh built at the Dockerfile's
+// default ref, and its compose tag never changes across builds. The image label
+// is the only truthful source for "what is running" — reading the tag instead
+// left currentVersion empty, and the empty-current branch below then declared
+// the newest upstream tag to be the running one ("v1.2.0, up to date" on a box
+// running v1.0.0).
+func TestCheckService_NeedsBuildUsesImageLabel(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{
+		imageLabels: map[string]string{SourceRefLabel: "v1.0.0"},
+	})
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	// No update_checks row — the state of a device that was just installed.
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("ckpool")
+	if check == nil {
+		t.Fatal("expected an update check row for ckpool")
+	}
+	if check.CurrentVersion != "v1.0.0" {
+		t.Errorf("current version = %q, want v1.0.0 from the image label", check.CurrentVersion)
+	}
+}
+
+// The self-update stack is NeedsBuild too, but carries no source-ref label —
+// its version must keep coming from the image tag.
+func TestCheckService_SelfUpdateKeepsTagVersion(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{})
+	defer agent.Close()
+
+	tmpl := model.ServiceTemplate{
+		ID:             "truffels",
+		DisplayName:    "Truffels",
+		ComposeDir:     t.TempDir(),
+		ContainerNames: []string{"truffels-agent"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceGitHubRelease,
+			Repo:       "bandrewk/truffels",
+			Images:     []string{"truffels/agent", "truffels/api", "truffels/web"},
+			NeedsBuild: true,
+		},
+	}
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("truffels")
+	if check == nil {
+		t.Fatal("expected an update check row for truffels (the mock image inspect answers with a tag)")
+	}
+	// The mock's /v1/image/inspect answers "mariadb:lts"; what matters is that
+	// the tag is used at all instead of an absent label blanking the row.
+	if check.CurrentVersion != "lts" {
+		t.Errorf("current version = %q, want the image tag", check.CurrentVersion)
+	}
+}
+
 func TestRunPreflight_UpdateAvailable_SetsVersions(t *testing.T) {
 	agent := newMockAgent(mockAgentOpts{})
 	defer agent.Close()

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -376,7 +376,11 @@ func TestRollbackService_AlreadyAtPreviousVersion(t *testing.T) {
 // registry to pull an old build from.
 func TestRollbackService_CustomBuildRetagsPreviousImage(t *testing.T) {
 	tags := &tagRecorder{}
-	agent := newMockAgent(mockAgentOpts{tags: tags})
+	// The staged image must prove it carries the version we are rolling back to.
+	agent := newMockAgent(mockAgentOpts{
+		tags:        tags,
+		imageLabels: map[string]string{SourceRefLabel: "abc123"},
+	})
 	defer agent.Close()
 
 	tmpl := model.ServiceTemplate{
@@ -436,7 +440,12 @@ func TestRollbackService_CustomBuildRetagsPreviousImage(t *testing.T) {
 // Without a staged image there is nothing to roll back to. Reporting success
 // here is exactly the old bug: Down/Up would restart the broken build.
 func TestRollbackService_CustomBuildFailsWithoutStagedImage(t *testing.T) {
-	agent := newMockAgent(mockAgentOpts{tagFail: true})
+	// Staged and labelled, but the retag itself fails (e.g. the image was
+	// pruned between inspect and tag).
+	agent := newMockAgent(mockAgentOpts{
+		tagFail:     true,
+		imageLabels: map[string]string{SourceRefLabel: "abc123"},
+	})
 	defer agent.Close()
 
 	tmpl := model.ServiceTemplate{
@@ -478,6 +487,139 @@ func TestRollbackService_CustomBuildFailsWithoutStagedImage(t *testing.T) {
 	logs, _ := st.GetUpdateLogs("ckpool", 5)
 	if len(logs) == 0 || logs[0].Status != model.UpdateFailed {
 		t.Errorf("expected a failed rollback log, got %+v", logs)
+	}
+}
+
+// An image staged before source-ref labels existed (or no image at all — the
+// agent answers 200 with empty fields for an unknown image) cannot prove what
+// it would restore. Refuse before touching a tag.
+func TestRollbackService_RefusesUnverifiableStagedImage(t *testing.T) {
+	tags := &tagRecorder{}
+	agent := newMockAgent(mockAgentOpts{tags: tags})
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckpool", FromVersion: "v1.0.0", ToVersion: "v1.2.0", Status: model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "v1.2.0", LatestVersion: "v1.2.0",
+	})
+
+	err := eng.RollbackService("ckpool")
+	if err == nil {
+		t.Fatal("expected a refusal for an unlabelled rollback image")
+	}
+	if !strings.Contains(err.Error(), "no rollback image available") {
+		t.Errorf("expected 'no rollback image available', got: %v", err)
+	}
+	if calls := tags.snapshot(); len(calls) != 0 {
+		t.Errorf("nothing may be retagged before the staged image is verified, got %+v", calls)
+	}
+	if check, _ := st.GetLatestUpdateCheck("ckpool"); check == nil || check.CurrentVersion != "v1.2.0" {
+		t.Errorf("version bookkeeping must be untouched, got %+v", check)
+	}
+}
+
+// :rollback keeps exactly one generation and is only staged by an update. After
+// one successful rollback it points at the image that is already running, so a
+// second rollback used to retag a no-op, come up healthy and record the version
+// it did NOT restore.
+func TestRollbackService_SecondRollbackRefusesStaleStagedImage(t *testing.T) {
+	tags := &tagRecorder{}
+	agent := newMockAgent(mockAgentOpts{
+		tags: tags,
+		// Still the image staged by the update that ran before the first
+		// rollback — i.e. v1.0.0, the version already running.
+		imageLabels: map[string]string{SourceRefLabel: "v1.0.0"},
+	})
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	// The update, then the rollback that followed it — both successful.
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckpool", FromVersion: "v1.0.0", ToVersion: "v1.2.0", Status: model.UpdateDone,
+	})
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckpool", FromVersion: "v1.2.0", ToVersion: "v1.0.0", Status: model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "v1.0.0", LatestVersion: "v1.2.0", HasUpdate: true,
+	})
+
+	err := eng.RollbackService("ckpool")
+	if err == nil {
+		t.Fatal("expected the second rollback to be refused")
+	}
+	if !strings.Contains(err.Error(), "v1.0.0") || !strings.Contains(err.Error(), "v1.2.0") {
+		t.Errorf("error should name both the staged and the requested ref, got: %v", err)
+	}
+	if calls := tags.snapshot(); len(calls) != 0 {
+		t.Errorf("a no-op retag must not happen, got %+v", calls)
+	}
+	check, _ := st.GetLatestUpdateCheck("ckpool")
+	if check == nil || check.CurrentVersion != "v1.0.0" {
+		t.Errorf("current version must stay v1.0.0 — that is what runs, got %+v", check)
+	}
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateFailed {
+		t.Errorf("expected a failed rollback log, got %+v", logs)
+	}
+}
+
+// The truffels stack is NeedsBuild but a github_release: it has no staged
+// :rollback image and its live image ref cannot be found in its own compose
+// file. It must say so instead of failing deep inside the retag path.
+func TestRollbackService_SelfUpdateIsRefusedHonestly(t *testing.T) {
+	tags := &tagRecorder{}
+	agent := newMockAgent(mockAgentOpts{tags: tags})
+	defer agent.Close()
+
+	tmpl := model.ServiceTemplate{
+		ID:             "truffels",
+		DisplayName:    "Truffels",
+		ComposeDir:     t.TempDir(),
+		ContainerNames: []string{"truffels-agent", "truffels-api", "truffels-web"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceGitHubRelease,
+			Repo:       "bandrewk/truffels",
+			Images:     []string{"truffels/agent", "truffels/api", "truffels/web"},
+			NeedsBuild: true,
+		},
+	}
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID:   "truffels",
+		FromVersion: "v0.3.1-dev.23",
+		ToVersion:   "v0.3.1-dev.24",
+		Status:      model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "truffels",
+		CurrentVersion: "v0.3.1-dev.24",
+		LatestVersion:  "v0.3.1-dev.24",
+	})
+
+	err := eng.RollbackService("truffels")
+	if err == nil {
+		t.Fatal("expected rollback of the truffels stack to be refused")
+	}
+	if !strings.Contains(err.Error(), "rollback not supported for custom-built services") {
+		t.Errorf("expected the honest custom-build message, got: %v", err)
+	}
+	if calls := tags.snapshot(); len(calls) != 0 {
+		t.Errorf("the self-update stack must not enter the retag path, got %+v", calls)
+	}
+	alerts, _ := st.GetActiveAlerts()
+	for _, a := range alerts {
+		if a.Type == "update_failed" && a.ServiceID == "truffels" {
+			t.Errorf("a refused, never-started rollback must not raise an update_failed alert: %+v", a)
+		}
 	}
 }
 

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -368,8 +368,73 @@ func TestRollbackService_AlreadyAtPreviousVersion(t *testing.T) {
 	}
 }
 
-func TestRollbackService_CustomBuildBlocked(t *testing.T) {
-	agent := newMockAgent(mockAgentOpts{})
+// Custom-built services used to be refused outright here ("rollback not
+// supported for custom-built services"). They now roll back by moving the
+// staged :rollback tag back onto the ref the compose file runs — there is no
+// registry to pull an old build from.
+func TestRollbackService_CustomBuildRetagsPreviousImage(t *testing.T) {
+	tags := &tagRecorder{}
+	agent := newMockAgent(mockAgentOpts{tags: tags})
+	defer agent.Close()
+
+	tmpl := model.ServiceTemplate{
+		ID:             "ckpool",
+		DisplayName:    "ckpool",
+		ComposeDir:     t.TempDir(),
+		ContainerNames: []string{"truffels-ckpool"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceBitbucket,
+			Repo:       "ckolivas/ckpool",
+			Branch:     "master",
+			NeedsBuild: true,
+		},
+	}
+
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID:   "ckpool",
+		FromVersion: "abc123",
+		ToVersion:   "def456",
+		Status:      model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "def456",
+		LatestVersion:  "def456",
+		HasUpdate:      false,
+	})
+
+	if err := eng.RollbackService("ckpool"); err != nil {
+		t.Fatalf("rollback of a custom-built service should now succeed: %v", err)
+	}
+
+	calls := tags.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one retag, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Source != "truffels/ckpool:rollback" {
+		t.Errorf("tag source = %q, want the staged rollback image", calls[0].Source)
+	}
+	if calls[0].Target != "truffels/ckpool:latest" {
+		t.Errorf("tag target = %q, want the live tag", calls[0].Target)
+	}
+
+	// The version bookkeeping must follow, same as for registry services.
+	check, _ := st.GetLatestUpdateCheck("ckpool")
+	if check == nil || check.CurrentVersion != "abc123" {
+		t.Errorf("expected current version abc123 after rollback, got %+v", check)
+	}
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateDone {
+		t.Errorf("expected a done rollback log, got %+v", logs)
+	}
+}
+
+// Without a staged image there is nothing to roll back to. Reporting success
+// here is exactly the old bug: Down/Up would restart the broken build.
+func TestRollbackService_CustomBuildFailsWithoutStagedImage(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{tagFail: true})
 	defer agent.Close()
 
 	tmpl := model.ServiceTemplate{
@@ -402,10 +467,15 @@ func TestRollbackService_CustomBuildBlocked(t *testing.T) {
 
 	err := eng.RollbackService("ckpool")
 	if err == nil {
-		t.Fatal("expected error for custom-built service rollback")
+		t.Fatal("expected an error when no rollback image is staged")
 	}
-	if !strings.Contains(err.Error(), "custom-built") {
-		t.Errorf("expected 'custom-built' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "no rollback image available") {
+		t.Errorf("expected 'no rollback image available', got: %v", err)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateFailed {
+		t.Errorf("expected a failed rollback log, got %+v", logs)
 	}
 }
 
@@ -1037,6 +1107,12 @@ func TestPruneOldImages_RespectsSetting(t *testing.T) {
 type needsBuildRecorder struct {
 	mu             sync.Mutex
 	imageLabels    map[string]string
+	inspectFail    bool              // /v1/image/inspect 500s — container gone
+	byNameLabels   map[string]string // labels served by /v1/image/inspect-by-name
+	byNameImage    string            // ref the engine asked for by name
+	byNameCalls    int
+	tagFail        bool // /v1/image/tag 500s — nothing staged to restore
+	tags           []tagCall
 	buildArgs      map[string]string
 	checkoutDir    string
 	checkoutRef    string
@@ -1049,6 +1125,9 @@ func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return needsBuildRecorder{
+		byNameImage:    r.byNameImage,
+		byNameCalls:    r.byNameCalls,
+		tags:           append([]tagCall(nil), r.tags...),
 		buildArgs:      r.buildArgs,
 		checkoutDir:    r.checkoutDir,
 		checkoutRef:    r.checkoutRef,
@@ -1087,9 +1166,45 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 
 		case "/v1/image/inspect":
 			rec.mu.Lock()
-			labels := rec.imageLabels
+			labels, fail := rec.imageLabels, rec.inspectFail
 			rec.mu.Unlock()
+			if fail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "cannot inspect container: no such container"})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(docker.ImageInfo{Image: "truffels/built:local", Labels: labels})
+
+		case "/v1/image/inspect-by-name":
+			var req struct {
+				Image string `json:"image"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.byNameImage = req.Image
+			rec.byNameCalls++
+			labels := rec.byNameLabels
+			rec.mu.Unlock()
+			if labels == nil {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "no such image"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(docker.ImageInfo{Image: req.Image, Labels: labels})
+
+		case "/v1/image/tag":
+			var req tagCall
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.tags = append(rec.tags, req)
+			fail := rec.tagFail
+			rec.mu.Unlock()
+			if fail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "no such image"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case "/v1/compose/up":
 			rec.mu.Lock()
@@ -1273,6 +1388,212 @@ func TestApplyUpdate_NeedsBuild_EmptyRefSchemeCheckedOutAsCommit(t *testing.T) {
 
 	if got := rec.snapshot().checkoutScheme; got != model.RefSchemeCommit {
 		t.Errorf("checkout scheme = %q, want %q for an empty RefScheme", got, model.RefSchemeCommit)
+	}
+}
+
+// Before this change rollback() only did Down/Up for NeedsBuild services: it
+// restarted the very image that had just failed, then reported a rollback.
+func TestRollbackRestoresPreviousImage(t *testing.T) {
+	rec := &needsBuildRecorder{}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, _ := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	if err := eng.rollback("ckpool", tmpl, tmpl.UpdateSource, "v1.0.0", "v1.2.0"); err != nil {
+		t.Fatalf("unexpected rollback error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if len(got.tags) != 1 {
+		t.Fatalf("expected exactly one retag, got %d: %+v", len(got.tags), got.tags)
+	}
+	if got.tags[0].Source != "truffels/ckpool:rollback" {
+		t.Errorf("tag source = %q, want the rollback image", got.tags[0].Source)
+	}
+	if got.tags[0].Target != "truffels/ckpool:latest" {
+		t.Errorf("tag target = %q, want the live tag", got.tags[0].Target)
+	}
+	if got.upCalls != 1 {
+		t.Errorf("service should be started again after the retag, up calls = %d", got.upCalls)
+	}
+}
+
+// ckpool's compose file pins truffels/ckpool:v1.0.0. Retagging :latest there
+// would move a tag nothing runs — the rollback has to target the pinned ref.
+func TestRollbackRestoresPinnedComposeTag(t *testing.T) {
+	rec := &needsBuildRecorder{}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	composeDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(`services:
+  ckpool:
+    build: .
+    image: truffels/ckpool:v1.0.0
+`), 0644)
+
+	tmpl := ckpoolBuildTemplate(composeDir)
+	eng, _ := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	if err := eng.rollback("ckpool", tmpl, tmpl.UpdateSource, "v1.0.0", "v1.2.0"); err != nil {
+		t.Fatalf("unexpected rollback error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if len(got.tags) != 1 || got.tags[0].Target != "truffels/ckpool:v1.0.0" {
+		t.Fatalf("expected retag onto the pinned compose ref, got %+v", got.tags)
+	}
+}
+
+// A rollback that could not restore anything must be reported as such, not
+// logged as rolled_back while the broken build keeps running.
+func TestRollbackReportsFailureWhenNothingStaged(t *testing.T) {
+	rec := &needsBuildRecorder{tagFail: true}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, _ := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	err := eng.rollback("ckpool", tmpl, tmpl.UpdateSource, "v1.0.0", "v1.2.0")
+	if err == nil {
+		t.Fatal("expected an error when the rollback image cannot be restored")
+	}
+	if !strings.Contains(err.Error(), "restoring previous image failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// The running image has to be staged before the build overwrites its tag —
+// afterwards it is gone.
+func TestApplyUpdate_NeedsBuild_StagesRollbackImageBeforeBuild(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "v1.2.0"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if len(got.tags) != 1 {
+		t.Fatalf("expected one staging retag, got %d: %+v", len(got.tags), got.tags)
+	}
+	if got.tags[0].Source != "truffels/ckpool:latest" || got.tags[0].Target != "truffels/ckpool:rollback" {
+		t.Errorf("staged %q -> %q, want the live tag onto :rollback", got.tags[0].Source, got.tags[0].Target)
+	}
+}
+
+// checkService does not skip git sources when the container is missing, so the
+// apply path has to cope with it too: verification falls back to asking for the
+// image by name instead of failing the update outright.
+func TestApplyUpdate_NeedsBuild_VerifiesByImageNameWhenContainerMissing(t *testing.T) {
+	rec := &needsBuildRecorder{
+		inspectFail:  true, // no container to resolve the image through
+		byNameLabels: map[string]string{SourceRefLabel: "v1.2.0"},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("verification should fall back to the image name: %v", err)
+	}
+
+	got := rec.snapshot()
+	if got.byNameCalls != 1 {
+		t.Errorf("expected one inspect-by-name call, got %d", got.byNameCalls)
+	}
+	if got.byNameImage != "truffels/ckpool:latest" {
+		t.Errorf("inspect-by-name asked for %q, want the service's own image", got.byNameImage)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateDone {
+		t.Errorf("expected a done update log, got %+v", logs)
+	}
+}
+
+// The fallback must not become a hole in the verification: a wrong label found
+// by name still fails the update.
+func TestApplyUpdate_NeedsBuild_ByNameLabelMismatchFails(t *testing.T) {
+	rec := &needsBuildRecorder{
+		inspectFail:  true,
+		byNameLabels: map[string]string{SourceRefLabel: "v1.0.0"},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected a mismatch error from the by-name verification")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("expected a ref mismatch error, got: %v", err)
+	}
+
+	got := rec.snapshot()
+	if got.upCalls != 0 {
+		t.Errorf("service must not start on a mismatch (up calls=%d)", got.upCalls)
+	}
+}
+
+// Both lookups failing is a real failure — never a silent pass.
+func TestApplyUpdate_NeedsBuild_BothInspectRoutesFail(t *testing.T) {
+	rec := &needsBuildRecorder{inspectFail: true} // byNameLabels nil -> 500
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckpoolBuildTemplate(t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected an error when neither inspect route answers")
+	}
+	if !strings.Contains(err.Error(), "image inspect failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got := rec.snapshot(); got.upCalls != 0 {
+		t.Errorf("service must not start unverified (up calls=%d)", got.upCalls)
 	}
 }
 

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -697,12 +697,21 @@ func ExtractCurrentVersion(src *model.UpdateSource, imageName string) string {
 const SourceRefLabel = "org.truffels.source-ref"
 
 // ExtractCurrentVersionFromLabels resolves the running version, preferring the
-// build label for custom-built services. Returns "" when a NeedsBuild image
-// carries no label; that means it predates label support and its version is
-// genuinely unknown, which must not be reported as up to date.
+// build label for the git sources we build ourselves (ckpool, ckstats).
+// Returns "" when such an image carries no label; that means it predates label
+// support and its version is genuinely unknown, which must not be reported as
+// up to date.
+//
+// The switch is on src.Type, not on src.NeedsBuild: the truffels stack is
+// NeedsBuild too, but it is a github_release whose version legitimately lives
+// in the image tag (truffels/api:v0.3.1-dev.24) — its Dockerfiles stamp no
+// org.truffels.source-ref, so keying on NeedsBuild would blank out the
+// self-update's own version detection.
 func ExtractCurrentVersionFromLabels(src *model.UpdateSource, imageName string, labels map[string]string) string {
-	if src.NeedsBuild {
+	switch src.Type {
+	case model.SourceGitHub, model.SourceBitbucket:
 		return labels[SourceRefLabel]
+	default:
+		return ExtractCurrentVersion(src, imageName)
 	}
-	return ExtractCurrentVersion(src, imageName)
 }

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -3,6 +3,7 @@ package updates
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -35,8 +36,14 @@ func CheckLatestVersion(src *model.UpdateSource, channel string) (string, error)
 		}
 		return checkDockerDigest(src.Images[0], tag)
 	case model.SourceGitHub:
+		if src.RefScheme == model.RefSchemeTag {
+			return checkGitTag(model.SourceGitHub, src.Repo, src.TagFilter, "")
+		}
 		return checkGitHub(src.Repo, src.Branch)
 	case model.SourceBitbucket:
+		if src.RefScheme == model.RefSchemeTag {
+			return checkGitTag(model.SourceBitbucket, src.Repo, src.TagFilter, "")
+		}
 		return checkBitbucket(src.Repo, src.Branch)
 	case model.SourceGitHubRelease:
 		return checkGitHubRelease(src.Repo, channel)
@@ -437,6 +444,84 @@ func checkBitbucket(repo, branch string) (string, error) {
 		hash = hash[:12]
 	}
 	return hash, nil
+}
+
+// checkGitTag returns the highest version tag in a git repo's tag list.
+// Non-version tags are discarded by extractVersion — ckpool for instance
+// carries M21/MP4/S1 tags alongside its vX.Y.Z releases.
+// apiBase overrides the API host; empty means the real upstream host.
+func checkGitTag(srcType model.SourceType, repo, filter, apiBase string) (string, error) {
+	var url string
+	switch srcType {
+	case model.SourceBitbucket:
+		base := apiBase
+		if base == "" {
+			base = "https://api.bitbucket.org"
+		}
+		url = fmt.Sprintf("%s/2.0/repositories/%s/refs/tags?pagelen=100", base, repo)
+	case model.SourceGitHub:
+		base := apiBase
+		if base == "" {
+			base = "https://api.github.com"
+		}
+		url = fmt.Sprintf("%s/repos/%s/tags?per_page=100", base, repo)
+	default:
+		return "", fmt.Errorf("checkGitTag: unsupported source type %s", srcType)
+	}
+
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("git tags request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("git tags: HTTP %d for %s", resp.StatusCode, repo)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("git tags read: %w", err)
+	}
+
+	// Bitbucket wraps the list in {"values":[...]}, GitHub returns a bare array.
+	type tagEntry struct {
+		Name string `json:"name"`
+	}
+	var names []tagEntry
+	if srcType == model.SourceBitbucket {
+		var wrapped struct {
+			Values []tagEntry `json:"values"`
+		}
+		if err := json.Unmarshal(body, &wrapped); err != nil {
+			return "", fmt.Errorf("git tags decode: %w", err)
+		}
+		names = wrapped.Values
+	} else {
+		if err := json.Unmarshal(body, &names); err != nil {
+			return "", fmt.Errorf("git tags decode: %w", err)
+		}
+	}
+
+	best := ""
+	var bestVer []int
+	for _, t := range names {
+		if filter != "" && !strings.HasPrefix(t.Name, filter) {
+			continue
+		}
+		ver, ok := extractVersion(t.Name, "")
+		if !ok {
+			continue
+		}
+		if best == "" || compareVersions(ver, bestVer) > 0 {
+			best, bestVer = t.Name, ver
+		}
+	}
+
+	if best == "" {
+		return "", fmt.Errorf("git tags: no version tags found for %s", repo)
+	}
+	return best, nil
 }
 
 // checkGitHubRelease returns the latest release tag name from GitHub.

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -690,3 +690,19 @@ func ExtractCurrentVersion(src *model.UpdateSource, imageName string) string {
 		return "unknown"
 	}
 }
+
+// SourceRefLabel carries the git ref an image was built from. It is the only
+// trustworthy statement about what a NeedsBuild service is actually running —
+// the update_checks row merely records what the engine intended to build.
+const SourceRefLabel = "org.truffels.source-ref"
+
+// ExtractCurrentVersionFromLabels resolves the running version, preferring the
+// build label for custom-built services. Returns "" when a NeedsBuild image
+// carries no label; that means it predates label support and its version is
+// genuinely unknown, which must not be reported as up to date.
+func ExtractCurrentVersionFromLabels(src *model.UpdateSource, imageName string, labels map[string]string) string {
+	if src.NeedsBuild {
+		return labels[SourceRefLabel]
+	}
+	return ExtractCurrentVersion(src, imageName)
+}

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -854,3 +854,88 @@ func TestListDockerHubVersions_PrefersPlainTagOnVersionTie(t *testing.T) {
 		}
 	}
 }
+
+// ---------- checkGitTag ----------
+
+func TestCheckGitTagBitbucket(t *testing.T) {
+	// Echte ckpool-Tag-Formen: Versions-Tags neben M/MP/S-Tags, die
+	// keine Versionen sind und niemals gewinnen dürfen.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"values":[
+			{"name":"M21"},{"name":"MP4"},{"name":"S1"},
+			{"name":"v0.9.9"},{"name":"v1.0.0"},{"name":"v1.1.1"},{"name":"v1.2.0"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	got, err := checkGitTag(model.SourceBitbucket, "ckolivas/ckpool", "v", srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1.2.0" {
+		t.Errorf("got %q, want v1.2.0", got)
+	}
+}
+
+func TestCheckGitTagNumericNotLexicographic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"values":[{"name":"v0.9.9"},{"name":"v0.10.0"}]}`))
+	}))
+	defer srv.Close()
+
+	got, err := checkGitTag(model.SourceBitbucket, "x/y", "v", srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v0.10.0" {
+		t.Errorf("got %q, want v0.10.0 (numeric compare, not lexicographic)", got)
+	}
+}
+
+func TestCheckGitTagGitHubShape(t *testing.T) {
+	// GitHub liefert ein Array statt eines Objekts mit "values".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"v2.0.0"},{"name":"v1.9.0"}]`))
+	}))
+	defer srv.Close()
+
+	got, err := checkGitTag(model.SourceGitHub, "x/y", "v", srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v2.0.0" {
+		t.Errorf("got %q, want v2.0.0", got)
+	}
+}
+
+func TestCheckGitTagNoVersionTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"values":[{"name":"M21"},{"name":"S1"}]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := checkGitTag(model.SourceBitbucket, "x/y", "v", srv.URL); err == nil {
+		t.Error("expected error when no version tags exist, got nil")
+	}
+}
+
+func TestCheckGitTagHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	if _, err := checkGitTag(model.SourceBitbucket, "x/y", "v", srv.URL); err == nil {
+		t.Error("expected error on HTTP 500, got nil")
+	}
+}
+
+func TestCheckLatestVersionCommitSchemeUnchanged(t *testing.T) {
+	// Leeres RefScheme muss weiterhin den Commit-Pfad wählen. Wir prüfen das
+	// ohne Netzwerk, indem wir einen unbekannten Source-Type ausschließen und
+	// nur die Verzweigung selbst betrachten.
+	src := &model.UpdateSource{Type: model.SourceBitbucket, Repo: "x/y", Branch: "master"}
+	if src.RefScheme == model.RefSchemeTag {
+		t.Fatal("empty RefScheme must not be treated as tag scheme")
+	}
+}

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -967,3 +967,19 @@ func TestExtractCurrentVersionFromLabelsPullSourceUnaffected(t *testing.T) {
 		t.Errorf("got %q, want 29.0 (tag wins for pull sources)", got)
 	}
 }
+
+// The truffels stack is NeedsBuild as well, but its version lives in the image
+// tag and its Dockerfiles stamp no source-ref label. Keying the label lookup on
+// NeedsBuild instead of the source type would blank the self-update's version.
+func TestExtractCurrentVersionFromLabelsSelfUpdateUsesTag(t *testing.T) {
+	src := &model.UpdateSource{
+		Type:       model.SourceGitHubRelease,
+		Repo:       "bandrewk/truffels",
+		Images:     []string{"truffels/agent", "truffels/api", "truffels/web"},
+		NeedsBuild: true,
+	}
+
+	if got := ExtractCurrentVersionFromLabels(src, "truffels/api:v0.3.1-dev.24", nil); got != "v0.3.1-dev.24" {
+		t.Errorf("got %q, want v0.3.1-dev.24 from the image tag", got)
+	}
+}

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -939,3 +939,31 @@ func TestCheckLatestVersionCommitSchemeUnchanged(t *testing.T) {
 		t.Fatal("empty RefScheme must not be treated as tag scheme")
 	}
 }
+
+func TestExtractCurrentVersionFromLabels(t *testing.T) {
+	src := &model.UpdateSource{Type: model.SourceBitbucket, NeedsBuild: true}
+	labels := map[string]string{"org.truffels.source-ref": "v1.2.0"}
+
+	if got := ExtractCurrentVersionFromLabels(src, "truffels/ckpool:latest", labels); got != "v1.2.0" {
+		t.Errorf("got %q, want v1.2.0", got)
+	}
+}
+
+func TestExtractCurrentVersionFromLabelsMissing(t *testing.T) {
+	src := &model.UpdateSource{Type: model.SourceBitbucket, NeedsBuild: true}
+
+	// Ein Image ohne Label stammt aus einem Build vor dieser Änderung.
+	// Es darf nicht als "aktuell" durchgehen.
+	if got := ExtractCurrentVersionFromLabels(src, "truffels/ckpool:latest", nil); got != "" {
+		t.Errorf("got %q, want empty for unlabelled image", got)
+	}
+}
+
+func TestExtractCurrentVersionFromLabelsPullSourceUnaffected(t *testing.T) {
+	src := &model.UpdateSource{Type: model.SourceDockerHub}
+	labels := map[string]string{"org.truffels.source-ref": "ignored"}
+
+	if got := ExtractCurrentVersionFromLabels(src, "btcpayserver/bitcoin:29.0", labels); got != "29.0" {
+		t.Errorf("got %q, want 29.0 (tag wins for pull sources)", got)
+	}
+}


### PR DESCRIPTION
ckpool and ckstats reported updates they never performed. Discovery read the
upstream `master` HEAD while the build stayed pinned to a frozen ref, apply only
rebuilt without rewriting anything, and rollback restarted the same failed image
while logging a successful revert.

## What changed

- Tag-based discovery for ckpool, commit-based for ckstats — its upstream has no tags
- The target ref travels into the build as `SOURCE_REF` and returns as the image
  label `org.truffels.source-ref`
- The engine verifies the built ref before the service starts, so a mismatched
  image never runs
- `checkService` derives the running version of built services from that label
  instead of trusting the stored row
- Rollback restores the previous image by retag, and refuses honestly when the
  staged image is stale or missing
- The reconciled ckpool template gained the `build:` section it never had, kept
  in sync with `install.sh`

## Notes

- The reconciler restarts ckpool once on the first boot after this update, since
  the build block is new in the template. Miners reconnect once.
- Images built before this branch carry no source ref. For those, the first
  manual rollback after the first update is refused with a stated reason rather
  than restoring an unverifiable image; this self-heals after one update cycle,
  and `apply` with an explicit `target_version` rebuilds an older ref in the
  meantime.

Lint clean on both modules, 486 + 128 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)