### PR TITLE
Fix the repo mount and stop claiming unprovable versions

### DIFF
--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -34,7 +34,13 @@ RUN set -e; \
     retry apt-get install -y --no-install-recommends cron postgresql-client && \
     rm -rf /var/lib/apt/lists/*
 
-ARG SOURCE_REF=unknown
+# Empty default on purpose. Unlike ckpool's, this arg drives no checkout — the
+# source is bind-mounted from the working copy, so SOURCE_REF is purely a stamp.
+# A default like "unknown" would therefore label the image with a version that
+# does not exist, and the engine treats any non-empty label as proof of what is
+# running. Empty means "not stated", which is the truth for a build that was not
+# told its ref.
+ARG SOURCE_REF=
 LABEL org.truffels.source-ref=$SOURCE_REF
 
 WORKDIR /app

--- a/install.sh
+++ b/install.sh
@@ -863,7 +863,20 @@ log "Building ckpool image..."
 cd "$COMPOSE_DIR/ckpool" && docker compose build --quiet
 
 log "Building ckstats image..."
-cd "$COMPOSE_DIR/ckstats" && docker compose build --quiet
+# Stamp the commit we are actually building. ckstats' SOURCE_REF drives no
+# checkout — the source is the working copy cloned above — so without this the
+# image carries no ref and the update engine correctly refuses to claim it knows
+# what is running. Short to 12 chars: the engine compares against GitHub's
+# commit SHA truncated to the same length, and a 40-char hash would never match.
+CKSTATS_REF="$(git -C "$DATA_DIR/ckpoolstats" rev-parse --short=12 HEAD 2>/dev/null || true)"
+if [[ -n "$CKSTATS_REF" ]]; then
+    cd "$COMPOSE_DIR/ckstats" && docker compose build --quiet --build-arg SOURCE_REF="$CKSTATS_REF"
+else
+    # An empty label is the acceptable fallback — the engine then offers a
+    # rebuild that stamps a real ref. A made-up one is not.
+    warn "Cannot determine the ckstats commit; building without a source ref (an update will be offered to stamp one)."
+    cd "$COMPOSE_DIR/ckstats" && docker compose build --quiet
+fi
 
 # --- Step 9: Start services in order ------------------------------------------
 log "Starting bitcoind..."

--- a/install.sh
+++ b/install.sh
@@ -913,7 +913,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.24}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.25}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/install.sh
+++ b/install.sh
@@ -975,6 +975,10 @@ services:
       - /srv/truffels/backups:/srv/truffels/backups
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
+      # The Dockerfile reconciler runs here and reads the expected Dockerfiles
+      # from /repo before writing them into the deployed compose dirs. Read-only:
+      # only the agent's self-update checkout writes to the working copy.
+      - $TRUFFELS_REPO_SRC:/repo:ro
     environment:
       TRUFFELS_LISTEN: ":8080"
       TRUFFELS_DB_PATH: "/data/truffels.db"

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -532,6 +532,10 @@ services:
       - /srv/truffels/backups:/srv/truffels/backups
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
+      # The Dockerfile reconciler runs here and reads the expected Dockerfiles
+      # from /repo before writing them into the deployed compose dirs. Read-only:
+      # only the agent's self-update checkout writes to the working copy.
+      - {{.RepoSrc}}:/repo:ro
     environment:
       TRUFFELS_LISTEN: ":8080"
       TRUFFELS_DB_PATH: "/data/truffels.db"

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -196,6 +196,73 @@ func TestRender_Truffels(t *testing.T) {
 	assertContains(t, got, "container_name: truffels-web")
 }
 
+// The Dockerfile reconciler runs in the *API* container: it reads the expected
+// Dockerfile from /repo and writes it into the deployed compose dir. Without
+// this mount every reconcile logged "open /repo/dockerfiles/ckpool/Dockerfile:
+// no such file or directory" and the deployed Dockerfiles silently stayed on
+// whatever the installer wrote months earlier. That is how ckpool got rebuilt
+// from a Dockerfile with no ARG SOURCE_REF and no source-ref LABEL, producing
+// an unlabelled image that the update engine then correctly rejected with
+// `built ref "" does not match requested "v1.2.0"`. Read-only is enough — the
+// reconciler only reads; only the agent's self-update checkout writes.
+func TestRender_TruffelsAPIMountsRepoReadOnly(t *testing.T) {
+	got, err := Render("truffels", TruffelsParams{
+		AgentTag: "truffels/agent:v0.3.1-dev.25",
+		APITag:   "truffels/api:v0.3.1-dev.25",
+		WebTag:   "truffels/web:v0.3.1-dev.25",
+		RepoSrc:  "/home/truffel/Project-Truffels",
+		Version:  "v0.3.1-dev.25",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContains(t, serviceBlock(t, got, "api"), "- /home/truffel/Project-Truffels:/repo:ro")
+	// And the agent keeps write access — its self-update checkout needs it.
+	assertContains(t, serviceBlock(t, got, "agent"), "- /home/truffel/Project-Truffels:/repo:rw")
+}
+
+// The installed compose file and the reconciled template must agree, otherwise
+// the first API boot after an install rewrites what the installer just wrote —
+// or a fresh install runs for a whole release cycle without the mount.
+func TestInstaller_TruffelsAPIMountsRepoReadOnly(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	assertContains(t, serviceBlock(t, string(installer), "api"), "- $TRUFFELS_REPO_SRC:/repo:ro")
+	assertContains(t, serviceBlock(t, string(installer), "agent"), "- $TRUFFELS_REPO_SRC:/repo:rw")
+}
+
+// serviceBlock returns just the given service's block from a compose document.
+// Asserting against the whole document would let one service's mount satisfy
+// an assertion about another's — exactly the mistake that hid the missing api
+// /repo mount, since the agent block carries a matching line.
+func serviceBlock(t *testing.T, doc, name string) string {
+	t.Helper()
+	lines := strings.Split(doc, "\n")
+	start := -1
+	for i, l := range lines {
+		if l == "  "+name+":" {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("no %q service block found in:\n%s", name, doc)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		if len(lines[i])-len(strings.TrimLeft(lines[i], " ")) <= 2 {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
 func assertContains(t *testing.T, s, substr string) {
 	t.Helper()
 	if !strings.Contains(s, substr) {

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -233,6 +233,57 @@ func TestInstaller_TruffelsAPIMountsRepoReadOnly(t *testing.T) {
 	assertContains(t, serviceBlock(t, string(installer), "agent"), "- $TRUFFELS_REPO_SRC:/repo:rw")
 }
 
+// ckstats' SOURCE_REF is a pure stamp — unlike ckpool's, it drives no
+// git clone --branch. A default of "unknown" therefore produced an image
+// labelled with the literal string "unknown", and the installer built it
+// without passing the arg at all. That is a fabricated version, and it
+// defeats the rule that an unprovable build must report an empty version.
+// Empty default plus an explicit ref from the installer, or nothing.
+func TestCkstatsDockerfile_DoesNotDefaultToAPlaceholderRef(t *testing.T) {
+	data, err := os.ReadFile("../../../dockerfiles/ckstats/Dockerfile")
+	if err != nil {
+		t.Skipf("dockerfile not readable from this checkout: %v", err)
+	}
+	df := string(data)
+	if !strings.Contains(df, "ARG SOURCE_REF=\n") {
+		t.Errorf("ckstats Dockerfile must default SOURCE_REF to empty; got:\n%s",
+			grepLines(df, "SOURCE_REF"))
+	}
+	for _, bad := range []string{"ARG SOURCE_REF=unknown", "ARG SOURCE_REF=none", "ARG SOURCE_REF=latest"} {
+		if strings.Contains(df, bad) {
+			t.Errorf("ckstats Dockerfile stamps a placeholder ref: %q", bad)
+		}
+	}
+	// The label itself must still be emitted, otherwise a build stamps nothing
+	// at all and no update can ever prove itself.
+	assertContains(t, df, "LABEL org.truffels.source-ref=$SOURCE_REF")
+}
+
+// A fresh install must stamp the commit it actually built, so a new device is
+// honest from the first check rather than merely "not wrong".
+func TestInstaller_BuildsCkstatsWithItsRealRef(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	sh := string(installer)
+	assertContains(t, sh, "--build-arg SOURCE_REF=")
+	// The engine compares against a 12-char short SHA (checkGitHub truncates to
+	// SHA[:12]). Stamping a full 40-char hash would mismatch forever.
+	assertContains(t, sh, "rev-parse --short=12 HEAD")
+}
+
+// grepLines returns the lines of s containing substr, for readable failures.
+func grepLines(s, substr string) string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.Contains(l, substr) {
+			out = append(out, l)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
 // serviceBlock returns just the given service's block from a compose document.
 // Asserting against the whole document would let one service's mount satisfy
 // an assertion about another's — exactly the mistake that hid the missing api

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -738,10 +738,15 @@ func (e *Engine) RollbackService(serviceID string) error {
 		}
 		staged := info.Labels[SourceRefLabel]
 		switch {
-		case staged == "":
+		case isPlaceholderRef(staged):
 			// Either nothing is staged (the agent answers 200 with empty fields
-			// for an unknown image) or the staged image predates source-ref
-			// labels. Both mean we cannot prove what it would restore.
+			// for an unknown image), or the staged image predates source-ref
+			// labels, or it was built with the old ARG SOURCE_REF=unknown
+			// default. All three mean we cannot prove what it would restore —
+			// and the last one is the dangerous shape: a device installed under
+			// dev.24 also has "unknown" in update_log.from_version, so a raw
+			// comparison found staged == prevVersion and restored an
+			// unidentifiable image while reporting the version it went back to.
 			msg := fmt.Sprintf("no rollback image available: %s carries no source ref, so it cannot be shown to hold %s", rollbackRef, prevVersion)
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
 			e.alertUpdateFailed(serviceID, msg)

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -243,6 +243,18 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 	}
 }
 
+// versionLabel renders a version for a human-readable message. An empty
+// version is a deliberate statement — checkService leaves it empty when the
+// running image carries no source ref — so name that state instead of letting
+// the sentence break off mid-clause ("rolled back to " with nothing after it,
+// or "pre-update snapshot ( → v1.2.0)").
+func versionLabel(v string) string {
+	if v == "" {
+		return "an unidentified build (no source ref)"
+	}
+	return v
+}
+
 // RunPreflight checks whether a service is safe to update and returns detailed results.
 func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) {
 	result := &model.PreflightResult{
@@ -507,7 +519,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		_ = e.store.CreateConfigRevision(&model.ConfigRevision{
 			ServiceID:        serviceID,
 			Actor:            "update_engine",
-			Diff:             fmt.Sprintf("pre-update snapshot (%s → %s)", check.CurrentVersion, check.LatestVersion),
+			Diff:             fmt.Sprintf("pre-update snapshot (%s → %s)", versionLabel(check.CurrentVersion), versionLabel(check.LatestVersion)),
 			ConfigSnapshot:   string(snapshot),
 			ValidationResult: "ok",
 		})
@@ -574,7 +586,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 			return &UpdateError{Msg: msg}
 		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "start failed: "+err.Error(), check.CurrentVersion)
-		e.alertUpdateFailed(serviceID, "start failed, rolled back to "+check.CurrentVersion)
+		e.alertUpdateFailed(serviceID, "start failed, rolled back to "+versionLabel(check.CurrentVersion))
 		return &UpdateError{Msg: "start failed, rolled back: " + err.Error()}
 	}
 
@@ -596,7 +608,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 			return &UpdateError{Msg: msg}
 		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "unhealthy after update", check.CurrentVersion)
-		e.alertUpdateFailed(serviceID, "unhealthy after update, rolled back to "+check.CurrentVersion)
+		e.alertUpdateFailed(serviceID, "unhealthy after update, rolled back to "+versionLabel(check.CurrentVersion))
 		return &UpdateError{Msg: "service unhealthy after update, rolled back"}
 	}
 
@@ -662,6 +674,15 @@ func (e *Engine) RollbackService(serviceID string) error {
 	currentVersion := ""
 	if check != nil {
 		currentVersion = check.CurrentVersion
+	}
+	// A rollback needs a known starting point on both ends. An empty
+	// CurrentVersion is checkService's deliberate "this build carries no source
+	// ref, so we cannot prove what runs" — restoring one unidentified image over
+	// another and reporting the version it supposedly went back to is exactly
+	// the lie the source-ref check exists to end. The UI hides the button in
+	// this state; this is the guard for everyone who calls the endpoint directly.
+	if currentVersion == "" {
+		return &UpdateError{Msg: "cannot roll back: the running version is unknown (the image carries no source ref) — rebuild first so it can be identified"}
 	}
 	if currentVersion == prevVersion {
 		return &UpdateError{Msg: "already at the previous version"}
@@ -777,7 +798,12 @@ func (e *Engine) RollbackService(serviceID string) error {
 		ServiceID:      serviceID,
 		CurrentVersion: prevVersion,
 		LatestVersion:  currentVersion,
-		HasUpdate:      true,
+		// Never advertise an update without a target: the UI would render
+		// "update available" with nothing to go to, and its button would call
+		// ApplyUpdate with an empty SOURCE_REF. The guard above already rules
+		// out an empty currentVersion; this keeps the invariant local to the
+		// write, where it can be read off the row itself.
+		HasUpdate: currentVersion != "" && currentVersion != prevVersion,
 	})
 
 	slog.Info("rollback complete", "service", serviceID, "from", currentVersion, "to", prevVersion)

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -168,8 +168,16 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 		}
 	}
 
+	// For a service we build ourselves from a git source, the source-ref label is
+	// the only authority on what is running: the compose tag is pinned and never
+	// moves across builds. No label means the running version is unknown, and an
+	// unknown version must not be papered over — not with the stored row (which
+	// the initialisation below used to poison), and not with latestVersion.
+	labelIsAuthority := src.NeedsBuild && (src.Type == model.SourceGitHub || src.Type == model.SourceBitbucket)
+
 	// For commit-based sources, use stored version if we can't derive it
-	if currentVersion == "" && (src.Type == model.SourceGitHub || src.Type == model.SourceBitbucket) {
+	if currentVersion == "" && !labelIsAuthority &&
+		(src.Type == model.SourceGitHub || src.Type == model.SourceBitbucket) {
 		prev, _ := e.store.GetLatestUpdateCheck(tmpl.ID)
 		if prev != nil && prev.CurrentVersion != "" {
 			currentVersion = prev.CurrentVersion
@@ -202,6 +210,21 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 	if err != nil {
 		check.Error = err.Error()
 		slog.Warn("update check failed", "service", tmpl.ID, "err", err)
+	} else if labelIsAuthority && currentVersion == "" {
+		// Unknown running version. Offering the rebuild is the only way out: it
+		// stamps the label and the next check reads a real version. Reporting
+		// "up to date" instead was a dead end — the label needs an update, and
+		// the update was never offered because everything looked current.
+		//
+		// CurrentVersion stays empty on purpose. It becomes prevVersion in
+		// RollbackService and FromVersion in the update log, so a stand-in like
+		// "unknown" would be recorded as a version that exists and could be
+		// rolled back to. Empty is the honest answer.
+		check.HasUpdate = latestVersion != ""
+		if check.HasUpdate {
+			slog.Info("update offered: running build carries no source ref",
+				"service", tmpl.ID, "latest", latestVersion)
+		}
 	} else {
 		// For commit-based sources: first check initializes current to latest (no update)
 		if currentVersion == "" && latestVersion != "" &&

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -280,9 +280,18 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 	} else {
 		result.FromVersion = check.CurrentVersion
 		result.ToVersion = check.LatestVersion
+		// An empty CurrentVersion is a deliberate statement, not a gap:
+		// checkService leaves it empty when the running image carries no
+		// source-ref label. Say so, rather than rendering it as a blank on the
+		// left of the arrow ("update available:  → 8f2e7c2f"), which reads like
+		// a formatting bug and tells the user nothing about why.
+		msg := fmt.Sprintf("update available: %s → %s", check.CurrentVersion, check.LatestVersion)
+		if check.CurrentVersion == "" {
+			msg = fmt.Sprintf("update available: running version unknown (the image carries no source ref) → %s; rebuilding stamps it", check.LatestVersion)
+		}
 		result.Checks = append(result.Checks, model.PreflightCheck{
 			Name: "update_available", Status: "pass",
-			Message:  fmt.Sprintf("update available: %s → %s", check.CurrentVersion, check.LatestVersion),
+			Message:  msg,
 			Blocking: true,
 		})
 	}

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -1411,6 +1411,11 @@ func TestExtractCurrentVersionFromLabels_PlaceholderIsNotARef(t *testing.T) {
 		{},
 		{SourceRefLabel: ""},
 		{SourceRefLabel: "unknown"},
+		// Our own Dockerfiles only ever emit lowercase, but a label is just a
+		// string someone can set — casing must not be a way past the check.
+		{SourceRefLabel: "Unknown"},
+		{SourceRefLabel: "UNKNOWN"},
+		{SourceRefLabel: "  unknown  "},
 	} {
 		if got := ExtractCurrentVersionFromLabels(src, "truffels/ckstats:latest", labels); got != "" {
 			t.Errorf("labels %v: current version = %q, want empty", labels, got)
@@ -1420,6 +1425,70 @@ func TestExtractCurrentVersionFromLabels_PlaceholderIsNotARef(t *testing.T) {
 	real := map[string]string{SourceRefLabel: "8f2e7c2f1a2b"}
 	if got := ExtractCurrentVersionFromLabels(src, "truffels/ckstats:latest", real); got != "8f2e7c2f1a2b" {
 		t.Errorf("current version = %q, want 8f2e7c2f1a2b", got)
+	}
+	// ...and a padded one comes back trimmed. The placeholder check already
+	// trims before comparing, so returning the raw value would let a ref
+	// survive with whitespace that can never equal latestVersion.
+	padded := map[string]string{SourceRefLabel: "  8f2e7c2f1a2b\n"}
+	if got := ExtractCurrentVersionFromLabels(src, "truffels/ckstats:latest", padded); got != "8f2e7c2f1a2b" {
+		t.Errorf("current version = %q, want it trimmed to 8f2e7c2f1a2b", got)
+	}
+}
+
+// The staged :rollback image is the other place a source-ref label is read. A
+// device installed under dev.24 that then took a ckstats update has "unknown"
+// in update_log.from_version *and* on the staged image, so staged ==
+// prevVersion matched and the rollback ran — writing "unknown" back out as
+// to_version and current_version. The restore is physically correct and the
+// next check cycle corrects the row, but it is the same lie in the same class,
+// and the whole point of this branch is that an unidentifiable image is never
+// accepted as proof of a version.
+func TestRollbackService_RefusesPlaceholderStagedImage(t *testing.T) {
+	rec := &needsBuildRecorder{
+		byNameLabels: map[string]string{SourceRefLabel: "unknown"},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	composeDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(`services:
+  ckstats:
+    image: truffels/ckstats:latest
+`), 0644)
+
+	tmpl := ckstatsBuildTemplate(composeDir, model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	// The device history: an update ran from the placeholder-labelled build.
+	logID, _ := st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckstats", FromVersion: "unknown", ToVersion: "8f2e7c2f1a2b",
+		Status: model.UpdatePending,
+	})
+	_ = st.UpdateLogStatus(logID, model.UpdateDone, "", "")
+	// Current version is known, so the empty-version guard is not what fires here.
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "8f2e7c2f1a2b",
+		LatestVersion:  "8f2e7c2f1a2b",
+		HasUpdate:      false,
+	})
+
+	err := eng.RollbackService("ckstats")
+	if err == nil {
+		t.Fatal("expected a refusal: a placeholder label proves nothing about the staged image")
+	}
+	if !strings.Contains(err.Error(), "no source ref") {
+		t.Errorf("error = %q, want it to say the staged image carries no source ref", err.Error())
+	}
+
+	// The retag must not have happened — that is the difference between
+	// refusing and restoring an image we cannot identify.
+	snap := rec.snapshot()
+	if len(snap.tags) != 0 {
+		t.Errorf("rollback retagged %v despite the placeholder label", snap.tags)
+	}
+	if snap.upCalls != 0 {
+		t.Errorf("rollback restarted the service %d times despite refusing", snap.upCalls)
 	}
 }
 

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -1146,6 +1146,151 @@ func TestCheckService_SelfUpdateKeepsTagVersion(t *testing.T) {
 	}
 }
 
+// newCommitServer answers the GitHub commits API with a fixed SHA so a
+// checkService test can pin latestVersion without touching the network.
+func newCommitServer(sha string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": sha})
+	}))
+}
+
+// A service we build ourselves from a git source states what it is running
+// only through org.truffels.source-ref. An image built before label support
+// carries none — and the old code then declared the newest upstream commit to
+// be the running one. On the device that made ckstats report "up to date"
+// while sitting 84 commits (and several security fixes) behind.
+func TestCheckService_UnprovableBuildIsNotReportedCurrent(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{}) // no source-ref label on the image
+	defer agent.Close()
+
+	srv := newCommitServer("8f2e7c2f1a2b3c4d5e6f")
+	defer srv.Close()
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	tmpl := ckstatsBuildTemplate(t.TempDir(), model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("ckstats")
+	if check == nil {
+		t.Fatal("expected an update check row for ckstats")
+	}
+	if check.CurrentVersion != "" {
+		t.Errorf("current version = %q, want empty: without the label the running build is unknown", check.CurrentVersion)
+	}
+	if !check.HasUpdate {
+		t.Error("has_update = false; an unprovable build must be offered the rebuild that stamps the label")
+	}
+	if check.LatestVersion != "8f2e7c2f1a2b" {
+		t.Errorf("latest version = %q, want 8f2e7c2f1a2b", check.LatestVersion)
+	}
+}
+
+// The stored row is the other half of the trap: it was written by the very
+// initialisation this change removes, so falling back to it re-reads the lie.
+// Nothing else can correct it — the label only appears after an update, and no
+// update was ever offered. This is the test that proves the dead end is open.
+func TestCheckService_UnprovableBuildIgnoresPoisonedStoredRow(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{}) // still no source-ref label
+	defer agent.Close()
+
+	srv := newCommitServer("8f2e7c2f1a2b3c4d5e6f")
+	defer srv.Close()
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	tmpl := ckstatsBuildTemplate(t.TempDir(), model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	// Exactly the row measured on the device: current == latest, no update,
+	// while the working copy actually sat on an old commit.
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "8f2e7c2f1a2b",
+		LatestVersion:  "8f2e7c2f1a2b",
+		HasUpdate:      false,
+	})
+
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("ckstats")
+	if check == nil {
+		t.Fatal("expected an update check row for ckstats")
+	}
+	if check.CurrentVersion != "" {
+		t.Errorf("current version = %q, want empty: the stored row is not evidence of what runs", check.CurrentVersion)
+	}
+	if !check.HasUpdate {
+		t.Error("has_update = false; the poisoned row must not keep the service pinned as up to date")
+	}
+}
+
+// CurrentVersion travels into RollbackService as prevVersion and into the
+// update log's FromVersion. A stand-in like "unknown" would be recorded as a
+// version that exists and could later be "rolled back to" — so the unknown
+// state must stay literally empty, all the way through an apply.
+func TestCheckService_UnprovableBuildRecordsNoPlaceholderVersion(t *testing.T) {
+	rec := &needsBuildRecorder{} // imageLabels nil: nothing proves what runs
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	srv := newCommitServer("8f2e7c2f1a2b3c4d5e6f")
+	defer srv.Close()
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	composeDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(`services:
+  ckstats:
+    image: truffels/ckstats:latest
+`), 0644)
+	tmpl := ckstatsBuildTemplate(composeDir, model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("ckstats")
+	if check == nil {
+		t.Fatal("expected an update check row for ckstats")
+	}
+	for _, banned := range []string{"unknown", "none", "n/a", "-", "8f2e7c2f1a2b"} {
+		if check.CurrentVersion == banned {
+			t.Fatalf("current version = %q; an unprovable running version must stay empty, not be stood in for", banned)
+		}
+	}
+
+	// The rebuild the check now offers stamps the label; from here the state heals.
+	rec.mu.Lock()
+	rec.imageLabels = map[string]string{SourceRefLabel: "8f2e7c2f1a2b"}
+	rec.mu.Unlock()
+
+	if err := eng.ApplyUpdate("ckstats"); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+
+	logs, err := st.GetUpdateLogs("ckstats", 10)
+	if err != nil || len(logs) == 0 {
+		t.Fatalf("expected an update log, got %v (err %v)", logs, err)
+	}
+	if logs[0].FromVersion != "" {
+		t.Errorf("update log from_version = %q, want empty: no invented version may be recorded", logs[0].FromVersion)
+	}
+	if logs[0].ToVersion != "8f2e7c2f1a2b" {
+		t.Errorf("update log to_version = %q, want 8f2e7c2f1a2b", logs[0].ToVersion)
+	}
+
+	healed, _ := st.GetLatestUpdateCheck("ckstats")
+	if healed.CurrentVersion != "8f2e7c2f1a2b" || healed.HasUpdate {
+		t.Errorf("after the update: current = %q has_update = %v, want 8f2e7c2f1a2b / false",
+			healed.CurrentVersion, healed.HasUpdate)
+	}
+}
+
 func TestRunPreflight_UpdateAvailable_SetsVersions(t *testing.T) {
 	agent := newMockAgent(mockAgentOpts{})
 	defer agent.Close()

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -1343,6 +1343,59 @@ func TestRunPreflight_UpdateAvailable_SetsVersions(t *testing.T) {
 	}
 }
 
+// checkService now leaves CurrentVersion empty for a build whose image carries
+// no source ref. The preflight message must name that state, not render it as
+// an empty side of an arrow ("update available:  → 8f2e7c2f"), which reads like
+// a formatting bug rather than the deliberate "we do not know" it is.
+func TestRunPreflight_UnknownCurrentVersionIsNamed(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{})
+	defer agent.Close()
+
+	composeDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(`services:
+  ckstats:
+    image: truffels/ckstats:latest
+`), 0644)
+
+	tmpl := ckstatsBuildTemplate(composeDir, model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "",
+		LatestVersion:  "8f2e7c2f1a2b",
+		HasUpdate:      true,
+	})
+
+	result, err := eng.RunPreflight("ckstats")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// FromVersion stays empty — it is the honest value and the UI renders its
+	// own placeholder. Only the human-readable message changes.
+	if result.FromVersion != "" {
+		t.Errorf("FromVersion = %q, want empty", result.FromVersion)
+	}
+	var msg string
+	for _, c := range result.Checks {
+		if c.Name == "update_available" {
+			msg = c.Message
+		}
+	}
+	if msg == "" {
+		t.Fatal("no update_available check found")
+	}
+	if strings.Contains(msg, "available:  ") || strings.Contains(msg, ": →") {
+		t.Errorf("message renders the unknown version as a blank: %q", msg)
+	}
+	if !strings.Contains(msg, "unknown") || !strings.Contains(msg, "source ref") {
+		t.Errorf("message = %q, want it to say the running version is unknown and why", msg)
+	}
+	if !strings.Contains(msg, "8f2e7c2f1a2b") {
+		t.Errorf("message = %q, want it to name the target version", msg)
+	}
+}
+
 // --- pruneOldImages tests ---
 
 func TestPruneOldImages_KeepsCurrentAndN1(t *testing.T) {

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -3,6 +3,7 @@ package updates
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1393,6 +1394,145 @@ func TestRunPreflight_UnknownCurrentVersionIsNamed(t *testing.T) {
 	}
 	if !strings.Contains(msg, "8f2e7c2f1a2b") {
 		t.Errorf("message = %q, want it to name the target version", msg)
+	}
+}
+
+// A build-arg default like ARG SOURCE_REF=unknown stamps the literal string
+// "unknown" into the label. That is not a ref — it is the absence of one,
+// wearing a name. Letting it through made CurrentVersion non-empty, which
+// switched off the honest path entirely: it reached update logs, the preflight
+// message, the UI and finally the rollback verification, where staged
+// "unknown" == prevVersion "unknown" would have approved restoring an image
+// nobody can identify.
+func TestExtractCurrentVersionFromLabels_PlaceholderIsNotARef(t *testing.T) {
+	src := &model.UpdateSource{Type: model.SourceGitHub, Repo: "mrv777/ckstats", NeedsBuild: true}
+	for _, labels := range []map[string]string{
+		nil,
+		{},
+		{SourceRefLabel: ""},
+		{SourceRefLabel: "unknown"},
+	} {
+		if got := ExtractCurrentVersionFromLabels(src, "truffels/ckstats:latest", labels); got != "" {
+			t.Errorf("labels %v: current version = %q, want empty", labels, got)
+		}
+	}
+	// A real ref still comes through untouched.
+	real := map[string]string{SourceRefLabel: "8f2e7c2f1a2b"}
+	if got := ExtractCurrentVersionFromLabels(src, "truffels/ckstats:latest", real); got != "8f2e7c2f1a2b" {
+		t.Errorf("current version = %q, want 8f2e7c2f1a2b", got)
+	}
+}
+
+// End to end through checkService: the placeholder must land in the same
+// honest state as a missing label, not be stored as a version.
+func TestCheckService_PlaceholderLabelIsTreatedAsUnknown(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{
+		imageLabels: map[string]string{SourceRefLabel: "unknown"},
+	})
+	defer agent.Close()
+
+	srv := newCommitServer("8f2e7c2f1a2b3c4d5e6f")
+	defer srv.Close()
+	original := httpClient
+	httpClient = newRedirectClient(srv)
+	defer func() { httpClient = original }()
+
+	tmpl := ckstatsBuildTemplate(t.TempDir(), model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	eng.checkService(tmpl)
+
+	check, _ := st.GetLatestUpdateCheck("ckstats")
+	if check == nil {
+		t.Fatal("expected an update check row for ckstats")
+	}
+	if check.CurrentVersion != "" {
+		t.Errorf("current version = %q, want empty: %q is a placeholder, not a ref", check.CurrentVersion, check.CurrentVersion)
+	}
+	if !check.HasUpdate {
+		t.Error("has_update = false; a placeholder label must still offer the rebuild")
+	}
+}
+
+// The UI hides the rollback button when the running version is unknown, but the
+// REST endpoint is reachable directly. Without a server-side guard the function
+// ran on ("" != prevVersion), and on success stored LatestVersion:"" with
+// HasUpdate:true — which the UI renders as an update with no target and whose
+// button then calls ApplyUpdate with an empty SOURCE_REF.
+func TestRollbackService_RefusesWhenCurrentVersionUnknown(t *testing.T) {
+	rec := &needsBuildRecorder{imageLabels: map[string]string{SourceRefLabel: "8f2e7c2f1a2b"}}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	composeDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(`services:
+  ckstats:
+    image: truffels/ckstats:latest
+`), 0644)
+
+	tmpl := ckstatsBuildTemplate(composeDir, model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	// A completed update exists, so prevVersion resolves...
+	logID, _ := st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckstats", FromVersion: "4bccedb01234", ToVersion: "8f2e7c2f1a2b",
+		Status: model.UpdatePending,
+	})
+	_ = st.UpdateLogStatus(logID, model.UpdateDone, "", "")
+	// ...but what runs now cannot be proven.
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "",
+		LatestVersion:  "8f2e7c2f1a2b",
+		HasUpdate:      true,
+	})
+
+	err := eng.RollbackService("ckstats")
+	if err == nil {
+		t.Fatal("expected a refusal: rolling back from an unknown version is a guess")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error = %q, want it to name the unknown running version", err.Error())
+	}
+
+	// Nothing may have been done: no retag, no restart.
+	snap := rec.snapshot()
+	if len(snap.tags) != 0 {
+		t.Errorf("rollback retagged %v despite refusing", snap.tags)
+	}
+	if snap.upCalls != 0 {
+		t.Errorf("rollback restarted the service %d times despite refusing", snap.upCalls)
+	}
+
+	// And the stored row must not have become an update with no target.
+	check, _ := st.GetLatestUpdateCheck("ckstats")
+	if check.HasUpdate && check.LatestVersion == "" {
+		t.Error("stored an update with no target version")
+	}
+}
+
+// Messages that concatenate a version must not break off mid-sentence when the
+// version is the deliberate empty "we cannot prove this" state.
+func TestVersionLabel_NamesTheUnknownState(t *testing.T) {
+	if got := versionLabel("v1.2.0"); got != "v1.2.0" {
+		t.Errorf("versionLabel(%q) = %q, want it unchanged", "v1.2.0", got)
+	}
+	got := versionLabel("")
+	if got == "" {
+		t.Fatal("versionLabel(\"\") returned empty: the sentence would break off")
+	}
+	if !strings.Contains(got, "unidentified") && !strings.Contains(got, "unknown") {
+		t.Errorf("versionLabel(\"\") = %q, want it to name the unknown state", got)
+	}
+	// The three call sites that used to trail off.
+	for _, msg := range []string{
+		"start failed, rolled back to " + versionLabel(""),
+		"unhealthy after update, rolled back to " + versionLabel(""),
+		fmt.Sprintf("pre-update snapshot (%s → %s)", versionLabel(""), versionLabel("v1.2.0")),
+	} {
+		if strings.HasSuffix(msg, "to ") || strings.Contains(msg, "( →") {
+			t.Errorf("message breaks off mid-clause: %q", msg)
+		}
 	}
 }
 

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -710,8 +710,29 @@ const SourceRefLabel = "org.truffels.source-ref"
 func ExtractCurrentVersionFromLabels(src *model.UpdateSource, imageName string, labels map[string]string) string {
 	switch src.Type {
 	case model.SourceGitHub, model.SourceBitbucket:
-		return labels[SourceRefLabel]
+		ref := labels[SourceRefLabel]
+		if isPlaceholderRef(ref) {
+			return ""
+		}
+		return ref
 	default:
 		return ExtractCurrentVersion(src, imageName)
+	}
+}
+
+// isPlaceholderRef reports whether a source-ref label says nothing about what
+// was built. ckstats' Dockerfile used to default the build arg to the literal
+// string "unknown", and the installer built without passing the arg — so the
+// image was labelled "unknown" and, being non-empty, was treated as a real
+// version all the way into rollback verification, where "unknown" == "unknown"
+// would have approved restoring an unidentifiable image. Images built that way
+// still exist on installed devices, so recognising the placeholder is what
+// heals them, not just fixing the Dockerfile.
+func isPlaceholderRef(ref string) bool {
+	switch strings.TrimSpace(ref) {
+	case "", "unknown", "none", "null", "latest":
+		return true
+	default:
+		return false
 	}
 }

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -710,10 +710,13 @@ const SourceRefLabel = "org.truffels.source-ref"
 func ExtractCurrentVersionFromLabels(src *model.UpdateSource, imageName string, labels map[string]string) string {
 	switch src.Type {
 	case model.SourceGitHub, model.SourceBitbucket:
-		ref := labels[SourceRefLabel]
+		ref := strings.TrimSpace(labels[SourceRefLabel])
 		if isPlaceholderRef(ref) {
 			return ""
 		}
+		// Trimmed, not raw: the placeholder check above compares the trimmed
+		// value, so returning the raw one would let a padded ref through and it
+		// could then never equal latestVersion — a permanent phantom update.
 		return ref
 	default:
 		return ExtractCurrentVersion(src, imageName)
@@ -728,8 +731,10 @@ func ExtractCurrentVersionFromLabels(src *model.UpdateSource, imageName string, 
 // would have approved restoring an unidentifiable image. Images built that way
 // still exist on installed devices, so recognising the placeholder is what
 // heals them, not just fixing the Dockerfile.
+// Matching is case-insensitive: our own Dockerfiles only ever emit lowercase,
+// but a label is just a string, and casing must not be a way past the check.
 func isPlaceholderRef(ref string) bool {
-	switch strings.TrimSpace(ref) {
+	switch strings.ToLower(strings.TrimSpace(ref)) {
 	case "", "unknown", "none", "null", "latest":
 		return true
 	default:

--- a/truffels-web/src/lib/updates.test.ts
+++ b/truffels-web/src/lib/updates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { truncDigest, formatTime, logStatusMap, parseVersion, compareVersion } from './updates'
+import { truncDigest, displayVersion, canRollback, formatTime, logStatusMap, parseVersion, compareVersion } from './updates'
 
 describe('truncDigest', () => {
   it('returns em-dash for empty string', () => {
@@ -136,5 +136,60 @@ describe('compareVersion', () => {
 
   it('treats v-prefix as equivalent', () => {
     expect(compareVersion('v31.0', '31.0')).toBe(0)
+  })
+})
+
+describe('displayVersion', () => {
+  it('returns em-dash for an unknown version', () => {
+    // dev.25: checkService leaves current_version empty for a build whose
+    // image carries no source ref. Rendering it raw left the arrow with
+    // nothing on its left side.
+    expect(displayVersion('')).toBe('—')
+    expect(displayVersion(undefined)).toBe('—')
+    expect(displayVersion(null)).toBe('—')
+  })
+
+  it('passes a known version through unchanged', () => {
+    expect(displayVersion('8f2e7c2f1a2b')).toBe('8f2e7c2f1a2b')
+    expect(displayVersion('v1.2.0')).toBe('v1.2.0')
+  })
+})
+
+describe('canRollback', () => {
+  it('offers a rollback when the running version is known and differs', () => {
+    expect(canRollback({ floatingTag: false, fromVersion: 'v1.0.0', currentVersion: 'v1.2.0' })).toBe(true)
+  })
+
+  it('refuses when the running version is unknown', () => {
+    // dev.25: the whole point of leaving current_version empty is that we
+    // cannot prove what runs. A rollback whose starting point is unknown is
+    // exactly the guess the source-ref label check exists to prevent — and
+    // the old `from_version !== current_version` compared truthy against '',
+    // so the button appeared for every unlabelled ckpool/ckstats build.
+    expect(canRollback({ floatingTag: false, fromVersion: 'v1.0.0', currentVersion: '' })).toBe(false)
+    expect(canRollback({ floatingTag: false, fromVersion: 'v1.0.0', currentVersion: undefined })).toBe(false)
+    expect(canRollback({ floatingTag: false, fromVersion: 'v1.0.0', currentVersion: null })).toBe(false)
+  })
+
+  it('refuses when there is nothing to roll back to', () => {
+    expect(canRollback({ floatingTag: false, fromVersion: '', currentVersion: 'v1.2.0' })).toBe(false)
+    expect(canRollback({ floatingTag: false, fromVersion: undefined, currentVersion: 'v1.2.0' })).toBe(false)
+  })
+
+  it('refuses when the service already runs that version', () => {
+    expect(canRollback({ floatingTag: false, fromVersion: 'v1.0.0', currentVersion: 'v1.0.0' })).toBe(false)
+  })
+
+  it('refuses for floating-tag services', () => {
+    // The old image is overwritten in place — there is nothing to restore.
+    expect(canRollback({ floatingTag: true, fromVersion: 'v1.0.0', currentVersion: 'v1.2.0' })).toBe(false)
+  })
+})
+
+describe('canRollback with an absent floating_tag', () => {
+  it('treats a missing flag as not floating', () => {
+    // ServiceTemplate.floating_tag is optional in the API type, so the guard
+    // must not turn `undefined` into a refusal.
+    expect(canRollback({ fromVersion: 'v1.0.0', currentVersion: 'v1.2.0' })).toBe(true)
   })
 })

--- a/truffels-web/src/lib/updates.ts
+++ b/truffels-web/src/lib/updates.ts
@@ -5,6 +5,40 @@ export function truncDigest(v: string): string {
   return v
 }
 
+/**
+ * Render a version string, or an em-dash when it is unknown.
+ *
+ * The API deliberately reports an empty current_version for a service we build
+ * ourselves whose image carries no org.truffels.source-ref label: the running
+ * build cannot be proven, and inventing a version string would put a fiction
+ * into rollback targets and update logs. The UI's job is to show that as a
+ * placeholder rather than as a blank next to an arrow.
+ */
+export function displayVersion(v?: string | null): string {
+  return v ? v : '—'
+}
+
+/**
+ * Whether a rollback may be offered for a service.
+ *
+ * A rollback restores the version the last successful update came *from*, so
+ * it needs a known starting point on both ends. An empty currentVersion means
+ * we cannot prove what is running — offering to roll back from an unknown
+ * state is exactly the guess the source-ref label check exists to prevent.
+ * The previous `fromVersion !== currentVersion` test compared truthy against
+ * '', so the button appeared for every unlabelled ckpool/ckstats build.
+ */
+export function canRollback(args: {
+  floatingTag?: boolean | null
+  fromVersion?: string | null
+  currentVersion?: string | null
+}): boolean {
+  if (args.floatingTag) return false
+  if (!args.fromVersion) return false
+  if (!args.currentVersion) return false
+  return args.fromVersion !== args.currentVersion
+}
+
 /** Format an ISO timestamp for display. */
 export function formatTime(iso: string): string {
   if (!iso) return ''

--- a/truffels-web/src/pages/ServiceDetailPage.tsx
+++ b/truffels-web/src/pages/ServiceDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'recharts'
 import { api, ServiceInstance, UpdateCheck, UpdateLog, ContainerSnapshot } from '@/lib/api'
+import { canRollback } from '@/lib/updates'
 import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
@@ -415,8 +416,11 @@ function OverviewTab({ svc, updateCheck, serviceId }: { svc: ServiceInstance; up
 
   // Find previous version from last successful update log
   const lastDoneLog = updateLogs?.find((l: UpdateLog) => l.status === 'done')
-  const canRollback = !svc.template.floating_tag && !!lastDoneLog?.from_version
-    && lastDoneLog.from_version !== updateCheck?.current_version
+  const rollbackAvailable = canRollback({
+    floatingTag: svc.template.floating_tag,
+    fromVersion: lastDoneLog?.from_version,
+    currentVersion: updateCheck?.current_version,
+  })
 
   const doRollback = async () => {
     setRollbackLoading(true)
@@ -511,7 +515,7 @@ function OverviewTab({ svc, updateCheck, serviceId }: { svc: ServiceInstance; up
                   </span>
                 )}
               </dd>
-              {canRollback && (
+              {rollbackAvailable && (
                 <>
                   <dt className="text-gray-500">Rollback</dt>
                   <dd>

--- a/truffels-web/src/pages/UpdatesPage.tsx
+++ b/truffels-web/src/pages/UpdatesPage.tsx
@@ -4,7 +4,7 @@ import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import ConfirmDialog from '@/components/ConfirmDialog'
-import { truncDigest, formatTime, logStatusMap, phaseLabel, formatElapsed, compareVersion } from '@/lib/updates'
+import { truncDigest, displayVersion, formatTime, logStatusMap, phaseLabel, formatElapsed, compareVersion } from '@/lib/updates'
 
 function DockerIcon() {
   return (
@@ -560,9 +560,9 @@ export default function UpdatesPage() {
         {preflightResult && (
           <div className="space-y-4">
             <div className="text-sm text-gray-400">
-              <span className="font-mono text-gray-200">{preflightResult.from_version}</span>
+              <span className="font-mono text-gray-200">{displayVersion(preflightResult.from_version)}</span>
               <span className="text-gray-600 mx-2">&rarr;</span>
-              <span className="font-mono text-gray-200">{preflightResult.to_version}</span>
+              <span className="font-mono text-gray-200">{displayVersion(preflightResult.to_version)}</span>
             </div>
 
             <div className="space-y-2">
@@ -604,9 +604,9 @@ export default function UpdatesPage() {
                       <StatusBadge status={logStatusMap(l.status)} />
                     </div>
                     <div className="flex items-center gap-2 mt-1 text-xs text-gray-400 flex-wrap">
-                      <span className="font-mono">{l.from_version}</span>
+                      <span className="font-mono">{displayVersion(l.from_version)}</span>
                       <span className="text-gray-600">&rarr;</span>
-                      <span className="font-mono">{l.to_version}</span>
+                      <span className="font-mono">{displayVersion(l.to_version)}</span>
                     </div>
                     {l.error && (
                       <p className="text-xs text-red-400 mt-1">{l.error}</p>


### PR DESCRIPTION
Follow-up to v0.3.1-dev.24. The first real ckpool update surfaced two older
faults that the new label verification made visible instead of silent.

## The repo mount

`reconcileDockerfile` reads `/repo/dockerfiles/...` and runs in the api
container, which has no `/repo` mount — only the agent does. Dockerfile
reconciliation has therefore never worked, and the deployed Dockerfiles were
months old. The ckpool update to v1.2.0 failed on exactly this: it built with
the old Dockerfile, which has no `ARG SOURCE_REF` and no `LABEL`, so the image
carried no ref and verification refused it before the container started.

The api container now gets the same repo mount as the agent, read-only, in both
the template and `install.sh`.

## An unprovable version is not "current"

`checkService` wrote the latest version into the current-version field whenever
the running version was unknown, which made `has_update` false. That is a dead
end: only the image label can correct the row, only an update stamps a label,
and no update is offered while everything looks current. One device had ckstats
84 commits behind, including security fixes, reporting as up to date.

For built services from a git source the label is now the only authority. When
it is absent the current version stays empty and an update is offered, which is
what stamps the label and heals the state. Placeholder refs — `unknown`, `none`,
`null`, `latest` — are treated as absent, so devices already carrying the
`unknown` label that dev.24 stamped are covered too. `install.sh` builds ckstats
with its real ref instead of a placeholder.

Rollback refuses, on the server and in the UI, while the running version cannot
be proven, and the staged rollback image is checked the same way.

## Notes

- After this update ckpool and ckstats both show as update-available with an
  empty current version and no rollback button. That is the honest state; the
  first rebuild stamps the label and a proven version returns.
- Two known gaps left open, both failing honestly: an installer run as real root
  rather than through sudo cannot read the ckstats ref and builds unstamped, and
  the agent's config mount differs between installer and template.

Lint clean on both Go modules, full suites green, Vitest 82/82, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)