### PR TITLE
Make the ckstats source updatable and fix the installer drift

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -49,7 +49,24 @@ environment:
 
 ## ckstats blank page
 
-ckstats requires `basePath: '/ckstats'` in `next.config.js`. Without this, assets load from the wrong path. The Caddy proxy must **not** use `uri strip_prefix /ckstats` — Next.js handles the prefix internally.
+ckstats requires `basePath: '/ckstats'` in `next.config.js` — without it, assets load
+from `/_next/...` instead of `/ckstats/_next/...` and get swallowed by the Caddy
+catch-all that fronts mempool.
+
+Since v0.3.1-dev.26 this is applied automatically at build time by
+`dockerfiles/ckstats/Dockerfile`, alongside the existing `fetch()` prefix
+rewrites. **Do not edit `next.config.js` in
+`/srv/truffels/data/ckpoolstats` by hand.** That tree must stay a pristine
+upstream checkout; a local edit makes it dirty and blocks every later
+`git checkout <commit>`, which is how ckstats updates used to fail with
+`git checkout failed: exit status 1`.
+
+If a page is still blank, rebuild the image (an update, or
+`docker compose build` in `/srv/truffels/compose/ckstats`) rather than patching
+the source tree.
+
+The Caddy proxy must **not** use `uri strip_prefix /ckstats` — Next.js handles
+the prefix internally.
 
 ## electrs index incompatibility
 

--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -19,6 +19,39 @@ RUN sed -i "s|fetch('/api/|fetch('/ckstats/api/|g" components/Header.tsx && \
     sed -i "s|fetch(\`/api/|fetch(\`/ckstats/api/|g" components/UserResetButton.tsx components/PrivacyToggle.tsx && \
     npx prettier --write components/Header.tsx components/UserResetButton.tsx components/PrivacyToggle.tsx
 
+# Patch: serve the whole app under /ckstats.
+#
+# Caddy routes /ckstats to this container WITHOUT `uri strip_prefix`, so Next.js
+# has to own the prefix itself. Without basePath the assets are emitted at
+# /_next/... , fall through Caddy's mempool catch-all, and every page renders
+# blank.
+#
+# This lived as a hand edit in the working copy until v0.3.1-dev.26, which meant
+# (a) every fresh install shipped a broken ckstats, because install.sh clones a
+# pristine upstream tree and nothing ever added the line, and (b) the hand edit
+# made the working copy dirty, so `git checkout <commit>` refused and no ckstats
+# update could ever apply. The working copy must stay an untouched upstream
+# checkout; all Truffels changes belong here, at build time.
+#
+# The grep guard makes the patch idempotent — it re-runs on every build, and a
+# second injection would produce a duplicate key. The anchor `const nextConfig
+# = {` is stable across the upstream revisions we support (verified against the
+# pre-Next-15 config and against 8f2e7c2f8403, which renamed
+# experimental.serverComponentsExternalPackages to serverExternalPackages but
+# kept the declaration line). If upstream ever drops that line the build fails
+# loudly here rather than silently producing a blank dashboard.
+#
+# truffels-patch:basePath:begin
+RUN if ! grep -q "basePath:" next.config.js; then \
+      sed -i "s|const nextConfig = {|const nextConfig = {\n  basePath: '/ckstats',|" next.config.js; \
+    fi; \
+    grep -q "basePath: '/ckstats'" next.config.js || { \
+      echo "FATAL: could not inject basePath into next.config.js (upstream layout changed)" >&2; \
+      cat next.config.js >&2; \
+      exit 1; \
+    }
+# truffels-patch:basePath:end
+
 RUN pnpm build
 
 FROM node:22-slim

--- a/install.sh
+++ b/install.sh
@@ -955,12 +955,19 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /srv/truffels/compose:/srv/truffels/compose:rw
-      - /srv/truffels/config:/srv/truffels/config:ro
+      # rw, not ro: handleFileReconcile writes service configuration under
+      # configRoot (the proxy Caddyfile among them). Mounted read-only, a fresh
+      # install could not write any service config until the API's first
+      # reconcile rewrote this file from the template — which is also what made
+      # the drift invisible. templates.go has always said rw; the installer was
+      # the side that was wrong.
+      - /srv/truffels/config:/srv/truffels/config:rw
       - /srv/truffels/secrets:/srv/truffels/secrets:ro
       - /srv/truffels/data:/srv/truffels/data:rw
       - $TRUFFELS_REPO_SRC:/repo:rw
     environment:
       TRUFFELS_COMPOSE_ROOT: "/srv/truffels/compose"
+      TRUFFELS_CONFIG_ROOT: "/srv/truffels/config"
       TRUFFELS_DATA_ROOT: "/srv/truffels/data"
       TRUFFELS_AGENT_LISTEN: ":9090"
     deploy:

--- a/install.sh
+++ b/install.sh
@@ -929,7 +929,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.25}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.26}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/install.sh
+++ b/install.sh
@@ -853,7 +853,13 @@ fi
 # ckpoolstats source (needed for ckstats Docker build)
 if [[ ! -d "$DATA_DIR/ckpoolstats/.git" ]]; then
     log "Cloning ckpoolstats (ckstats dashboard)..."
-    git clone --depth 1 https://github.com/mrv777/ckstats.git "$DATA_DIR/ckpoolstats"
+    # NOT --depth 1. The update engine checks this tree out at an arbitrary
+    # upstream commit later on; a shallow clone has no history to check out, so
+    # every ckstats update on a freshly installed device would fail. This device
+    # only survived because its clone happened to be full.
+    # --filter=blob:none keeps the transfer small the correct way: full history
+    # (refs and trees), blobs fetched on demand, so any commit stays reachable.
+    git clone --filter=blob:none https://github.com/mrv777/ckstats.git "$DATA_DIR/ckpoolstats"
     chown -R 1000:1000 "$DATA_DIR/ckpoolstats"
 else
     log "ckpoolstats source already present, skipping clone."
@@ -868,7 +874,17 @@ log "Building ckstats image..."
 # image carries no ref and the update engine correctly refuses to claim it knows
 # what is running. Short to 12 chars: the engine compares against GitHub's
 # commit SHA truncated to the same length, and a 40-char hash would never match.
-CKSTATS_REF="$(git -C "$DATA_DIR/ckpoolstats" rev-parse --short=12 HEAD 2>/dev/null || true)"
+#
+# -c safe.directory=... is required, not cosmetic: this script runs as root and
+# the tree is chowned to 1000:1000 just above, so git refuses it as "dubious
+# ownership". Under `sudo` git reads SUDO_UID and lets it pass, which is why the
+# omission went unnoticed — from a root shell or a systemd unit the rev-parse
+# returned empty and the install stamped no ref at all.
+# Passed with -c rather than persisted into root's global git config: the
+# exemption is scoped to this one command instead of being appended to
+# /root/.gitconfig forever, where it would keep granting access long after the
+# install finished and would accumulate a duplicate entry on every re-run.
+CKSTATS_REF="$(git -c safe.directory="$DATA_DIR/ckpoolstats" -C "$DATA_DIR/ckpoolstats" rev-parse --short=12 HEAD 2>/dev/null || true)"
 if [[ -n "$CKSTATS_REF" ]]; then
     cd "$COMPOSE_DIR/ckstats" && docker compose build --quiet --build-arg SOURCE_REF="$CKSTATS_REF"
 else

--- a/truffels-agent/gitprepare_test.go
+++ b/truffels-agent/gitprepare_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- prepareBuildSourceForCheckout ---
+//
+// Background: the ckstats build source at /srv/truffels/data/ckpoolstats was
+// stuck. `git checkout <commit>` refused because the tree carried 62 files
+// whose mode had flipped 100644 -> 100755, a pnpm-lock.yaml left over from a
+// local `pnpm install`, and a hand-added basePath in next.config.js. Every
+// ckstats update failed with "git checkout failed: exit status 1".
+//
+// These tests exercise the real git commands against real repositories built
+// in t.TempDir(). The load-bearing property is not that the tree ends up clean
+// — it is *what survives*: untracked files must never be removed, because the
+// same handler is reachable for /repo, which is the user's own checkout.
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.invalid",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.invalid",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// newSourceRepo builds a two-commit repo standing in for the ckstats upstream
+// checkout, and returns the repo path plus the first commit's hash.
+func newSourceRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	git(t, dir, "init", "-q", "-b", "main")
+	git(t, dir, "config", "user.email", "t@example.invalid")
+	git(t, dir, "config", "user.name", "t")
+
+	write(t, dir, "next.config.js", "const nextConfig = {}\n")
+	write(t, dir, "pnpm-lock.yaml", "lockfileVersion: 9\n")
+	git(t, dir, "add", "next.config.js", "pnpm-lock.yaml")
+	git(t, dir, "commit", "-q", "-m", "first")
+	first := strings.TrimSpace(git(t, dir, "rev-parse", "HEAD"))
+
+	write(t, dir, "next.config.js", "const nextConfig = { v: 2 }\n")
+	git(t, dir, "add", "next.config.js")
+	git(t, dir, "commit", "-q", "-m", "second")
+
+	return dir, first
+}
+
+// The bug itself: a tree dirtied the way the device's was must become
+// checkout-able.
+func TestPrepareBuildSource_UnblocksCheckout(t *testing.T) {
+	dir, first := newSourceRepo(t)
+
+	// Reproduce the device's state: a hand edit and a regenerated lockfile.
+	write(t, dir, "next.config.js", "const nextConfig = {\n  basePath: '/ckstats',\n}\n")
+	write(t, dir, "pnpm-lock.yaml", "lockfileVersion: 9\nchanged: true\n")
+
+	// Baseline: checkout must fail, or this test proves nothing.
+	if err := exec.Command("git", "-C", dir, "checkout", first).Run(); err == nil {
+		t.Fatal("baseline broken: checkout succeeded on a dirty tree")
+	}
+
+	if out, err := prepareBuildSourceForCheckout(context.Background(), dir); err != nil {
+		t.Fatalf("prepare failed: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "checkout", first).CombinedOutput(); err != nil {
+		t.Fatalf("checkout still blocked after prepare: %v\n%s", err, out)
+	}
+}
+
+// The 62 phantom modifications. core.fileMode=false must make them invisible,
+// which is the non-destructive answer — no command has to "clean" anything.
+func TestPrepareBuildSource_SilencesModeOnlyChanges(t *testing.T) {
+	dir, _ := newSourceRepo(t)
+
+	if err := os.Chmod(filepath.Join(dir, "next.config.js"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if status := git(t, dir, "status", "--porcelain"); !strings.Contains(status, "next.config.js") {
+		t.Skipf("filesystem does not report exec bits to git; nothing to silence (status=%q)", status)
+	}
+
+	if out, err := prepareBuildSourceForCheckout(context.Background(), dir); err != nil {
+		t.Fatalf("prepare failed: %v\n%s", err, out)
+	}
+
+	if got := strings.TrimSpace(git(t, dir, "config", "core.fileMode")); got != "false" {
+		t.Errorf("core.fileMode = %q, want \"false\"", got)
+	}
+	// And the file keeps its exec bit — nothing was rewritten to achieve this.
+	info, err := os.Stat(filepath.Join(dir, "next.config.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Error("prepare stripped the exec bit instead of telling git to ignore it")
+	}
+	if status := strings.TrimSpace(git(t, dir, "status", "--porcelain")); status != "" {
+		t.Errorf("mode noise still reported after prepare: %q", status)
+	}
+}
+
+// The rule with teeth. `git clean` is banned outright, so untracked files
+// survive even in a tree we are allowed to reset. This is the property that
+// protects CLAUDE.md, FUTURE_WORK.md and docs/superpowers/ if this code is ever
+// pointed somewhere it should not be.
+func TestPrepareBuildSource_NeverRemovesUntrackedFiles(t *testing.T) {
+	dir, _ := newSourceRepo(t)
+
+	untracked := []string{"CLAUDE.md", "FUTURE_WORK.md", "docs/superpowers/skill.md", ".superpowers/state.json"}
+	for _, name := range untracked {
+		write(t, dir, name, "irreplaceable\n")
+	}
+	// Also dirty a tracked file, so the reset actually has work to do.
+	write(t, dir, "pnpm-lock.yaml", "lockfileVersion: 9\nchanged: true\n")
+
+	if out, err := prepareBuildSourceForCheckout(context.Background(), dir); err != nil {
+		t.Fatalf("prepare failed: %v\n%s", err, out)
+	}
+
+	for _, name := range untracked {
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("untracked file %s was destroyed: %v", name, err)
+			continue
+		}
+		if string(body) != "irreplaceable\n" {
+			t.Errorf("untracked file %s was modified: %q", name, body)
+		}
+	}
+}
+
+// Tracked content is what the reset is for: the local basePath edit and the
+// regenerated lockfile go away, because the only correct content of a build
+// source tree is whatever the requested commit says.
+func TestPrepareBuildSource_DiscardsTrackedEdits(t *testing.T) {
+	dir, _ := newSourceRepo(t)
+	want := git(t, dir, "show", "HEAD:next.config.js")
+
+	write(t, dir, "next.config.js", "const nextConfig = {\n  basePath: '/ckstats',\n}\n")
+	if out, err := prepareBuildSourceForCheckout(context.Background(), dir); err != nil {
+		t.Fatalf("prepare failed: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "next.config.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("tracked edit survived the reset:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+// --- the allowlist that keeps this away from /repo ---
+
+// /repo is the user's own project checkout, bind-mounted from
+// /home/truffel/Project-Truffels. Resetting it would discard uncommitted work.
+// This assertion is the whole safety argument, so it is asserted directly
+// rather than inferred.
+func TestResettableRepoDirs_ExcludesTheUsersRepo(t *testing.T) {
+	if isResettableRepoDir("/repo") {
+		t.Fatal("/repo is resettable; a checkout would discard the user's uncommitted work")
+	}
+	if !isAllowedRepoDir("/repo") {
+		t.Fatal("baseline broken: /repo should still be a valid checkout target")
+	}
+}
+
+// Only build source trees may be reset, and the list must stay explicit —
+// adding an entry has to be a deliberate act, not a side effect of extending
+// allowedRepoDirs.
+func TestResettableRepoDirs_OnlyBuildSources(t *testing.T) {
+	want := map[string]bool{"/srv/truffels/data/ckpoolstats": true}
+	for dir := range resettableRepoDirs {
+		if !want[dir] {
+			t.Errorf("unexpected resettable dir %q: adding one destroys tracked local\n"+
+				"changes there on every update; confirm it is a throwaway build source", dir)
+		}
+		if !isAllowedRepoDir(dir) {
+			t.Errorf("resettable dir %q is not an allowed repo dir; the lists have drifted", dir)
+		}
+	}
+	for dir := range want {
+		if !isResettableRepoDir(dir) {
+			t.Errorf("build source %q is not resettable; ckstats updates stay blocked", dir)
+		}
+	}
+}
+
+// No `git clean` may reach the source, in any form. Grepping the source is
+// crude, but this is a rule about what the program is allowed to contain, and
+// a behavioural test cannot prove the absence of a call on an untested path.
+func TestAgentSource_ContainsNoGitClean(t *testing.T) {
+	data, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Skipf("source not readable: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		if strings.Contains(line, `"clean"`) && strings.Contains(line, "git") {
+			t.Errorf("git clean found in agent source; untracked files must never be\n"+
+				"removed, in any directory: %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/truffels-agent/gitprepare_test.go
+++ b/truffels-agent/gitprepare_test.go
@@ -48,11 +48,26 @@ func write(t *testing.T, dir, name, content string) {
 	}
 }
 
+// registerResettable makes a temp repo eligible for prepareBuildSourceForCheckout
+// for the duration of one test.
+//
+// The behaviour tests below cannot use the real path — that is the user's live
+// ckstats tree, and running `reset --hard` against it is precisely the damage
+// this code guards. So the temp dir is added to the allowlist and removed again
+// on cleanup. The production list is unchanged outside the test, which
+// TestResettableRepoDirs_OnlyBuildSources verifies independently.
+func registerResettable(t *testing.T, dir string) {
+	t.Helper()
+	resettableRepoDirs[dir] = true
+	t.Cleanup(func() { delete(resettableRepoDirs, dir) })
+}
+
 // newSourceRepo builds a two-commit repo standing in for the ckstats upstream
 // checkout, and returns the repo path plus the first commit's hash.
 func newSourceRepo(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()
+	registerResettable(t, dir)
 	git(t, dir, "init", "-q", "-b", "main")
 	git(t, dir, "config", "user.email", "t@example.invalid")
 	git(t, dir, "config", "user.name", "t")
@@ -187,6 +202,59 @@ func TestResettableRepoDirs_ExcludesTheUsersRepo(t *testing.T) {
 	}
 	if !isAllowedRepoDir("/repo") {
 		t.Fatal("baseline broken: /repo should still be a valid checkout target")
+	}
+}
+
+// The guard has to live inside prepareBuildSourceForCheckout, not only at its
+// call site in handleGitCheckout. The call site is correct today, but a
+// function that discards tracked changes must not be safe merely because its
+// single caller happens to be wired right — the cost of a future caller getting
+// it wrong is the user's uncommitted work in /repo.
+//
+// Proving "it returned an error" is not enough: it must refuse *before*
+// executing anything. So PATH is pointed at a fake `git` that records having
+// been invoked, and the test asserts that record never appears. A real git can
+// never run here, which is deliberate — the resettable path is the user's live
+// ckstats tree and an accidental `reset --hard` against it would be exactly the
+// damage this guard exists to prevent.
+func TestPrepareBuildSource_RefusesNonBuildSourceWithoutRunningGit(t *testing.T) {
+	shimDir := t.TempDir()
+	canary := filepath.Join(shimDir, "git-was-invoked")
+	shim := "#!/bin/sh\necho \"$@\" >> " + canary + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir)
+
+	// Control: the shim really is what `git` resolves to, so a missing canary
+	// below means "not executed", not "shim broken".
+	if err := exec.Command("git", "--version").Run(); err != nil {
+		t.Fatalf("shim not reachable on PATH: %v", err)
+	}
+	if _, err := os.Stat(canary); err != nil {
+		t.Fatalf("control failed: shim ran but left no canary: %v", err)
+	}
+	if err := os.Remove(canary); err != nil {
+		t.Fatal(err)
+	}
+
+	// /repo is the user's own checkout. Anything not on the resettable list
+	// must be refused identically.
+	for _, dir := range []string{"/repo", "/", "/srv/truffels/data", "/home/truffel/Project-Truffels", ""} {
+		out, err := prepareBuildSourceForCheckout(context.Background(), dir)
+		if err == nil {
+			t.Errorf("prepare accepted %q; it may only ever touch build source trees", dir)
+		}
+		if out != "" {
+			t.Errorf("prepare returned output for %q, so it did work before refusing: %q", dir, out)
+		}
+		if err != nil && !strings.Contains(err.Error(), dir) {
+			t.Errorf("error for %q does not name the directory: %v", dir, err)
+		}
+		if _, statErr := os.Stat(canary); statErr == nil {
+			body, _ := os.ReadFile(canary)
+			t.Fatalf("prepare executed git for %q before refusing: %s", dir, body)
+		}
 	}
 }
 

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1691,6 +1691,81 @@ func isAllowedRepoDir(dir string) bool {
 	return allowedRepoDirs[dir]
 }
 
+// resettableRepoDirs is deliberately a SECOND, strictly narrower list rather
+// than a flag on allowedRepoDirs or a field on the request.
+//
+// "/repo" is the user's own project checkout, bind-mounted from
+// /home/truffel/Project-Truffels. It holds untracked files they intend to keep
+// — CLAUDE.md, FUTURE_WORK.md, docs/superpowers/, .superpowers/ — and, during
+// development, uncommitted work in tracked files. Discarding anything there
+// destroys work that no update can recreate. It must never appear in this map.
+//
+// Only build source trees belong here: throwaway upstream checkouts whose sole
+// purpose is to be fed to `docker build`, where the only correct content is
+// whatever the requested commit says. Nothing in them is authored locally, so
+// nothing in them is worth preserving.
+//
+// The decision is made here, server-side, on the path itself. A request field
+// would put it in the caller's hands, and a caller that sends the wrong value
+// once deletes the user's files permanently.
+var resettableRepoDirs = map[string]bool{
+	"/srv/truffels/data/ckpoolstats": true,
+}
+
+func isResettableRepoDir(dir string) bool {
+	return resettableRepoDirs[dir]
+}
+
+// prepareBuildSourceForCheckout makes a build source tree checkout-able again.
+//
+// `git checkout <commit>` aborts when local changes would be overwritten, which
+// left ckstats permanently unupdatable: 62 files reported as modified purely
+// because their mode flipped 100644 -> 100755 (the tree is written by a
+// container that does not preserve the mode), plus pnpm-lock.yaml left over
+// from a local `pnpm install`, plus the hand-added basePath in next.config.js
+// that v0.3.1-dev.26 moved into the Docker build.
+//
+// Two narrowly-scoped steps, in order:
+//
+//   - core.fileMode=false in that repo's own .git/config. This is the correct
+//     answer to permission-bit noise: it stops git from *reporting* the 62
+//     phantom modifications at all, structurally and permanently, instead of
+//     repeatedly papering over them with a destructive command.
+//   - reset --hard, which discards tracked content changes only.
+//
+// There is deliberately no `git clean` anywhere in this function. Untracked
+// files are never touched, in any directory. `git clean -fdx` is the command
+// that would delete a user's unversioned work, and the blast radius of getting
+// its directory wrong is unrecoverable; the mode noise it might have swept up
+// is handled by core.fileMode instead.
+//
+// Failures are returned, not swallowed: if the tree cannot be made clean the
+// checkout will fail anyway, and the operator deserves the cause rather than
+// the symptom.
+func prepareBuildSourceForCheckout(ctx context.Context, repoDir string) (string, error) {
+	steps := [][]string{
+		// Phantom mode changes: make them invisible rather than "fix" them.
+		{"config", "core.fileMode", "false"},
+		// Tracked content only. Untracked files survive.
+		{"reset", "--hard"},
+	}
+	var log bytes.Buffer
+	for _, args := range steps {
+		full := append([]string{"-c", "safe.directory=*", "-C", repoDir}, args...)
+		cmd := exec.CommandContext(ctx, "git", full...)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		log.WriteString(out.String())
+		if err != nil {
+			return log.String(), fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		}
+	}
+	slog.Info("prepared build source for checkout", "repo", repoDir)
+	return log.String(), nil
+}
+
 type gitCheckoutRequest struct {
 	RepoDir   string `json:"repo_dir"`
 	Tag       string `json:"tag"`
@@ -1741,6 +1816,19 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
+	// Build source trees get made checkout-able first; /repo never does. See
+	// resettableRepoDirs for why that list is separate and why nothing here
+	// touches untracked files.
+	var prepOut string
+	if isResettableRepoDir(req.RepoDir) {
+		out, err := prepareBuildSourceForCheckout(ctx, req.RepoDir)
+		prepOut = out
+		if err != nil {
+			writeJSON(w, 500, map[string]string{"error": "git prepare failed: " + err.Error(), "output": out})
+			return
+		}
+	}
+
 	// Fetch tags (safe.directory needed: agent runs as root, repo owned by uid 1000)
 	fetchCmd := exec.CommandContext(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "fetch", "--tags", "--force")
 	var fetchOut bytes.Buffer
@@ -1761,7 +1849,7 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, 200, map[string]string{"status": "ok", "output": fetchOut.String() + checkoutOut.String()})
+	writeJSON(w, 200, map[string]string{"status": "ok", "output": prepOut + fetchOut.String() + checkoutOut.String()})
 }
 
 func isValidTag(tag string) bool {

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1743,6 +1743,17 @@ func isResettableRepoDir(dir string) bool {
 // checkout will fail anyway, and the operator deserves the cause rather than
 // the symptom.
 func prepareBuildSourceForCheckout(ctx context.Context, repoDir string) (string, error) {
+	// Re-check the allowlist here, not only at the call site. The caller in
+	// handleGitCheckout already gates on isResettableRepoDir, and that guard
+	// stays — but a function that discards tracked changes must not be safe
+	// merely because today's single caller is wired correctly. The cost of a
+	// future caller getting it wrong is the user's uncommitted work in /repo,
+	// which no update can recreate, so the check belongs where it cannot be
+	// bypassed. This returns before any git command is executed.
+	if !isResettableRepoDir(repoDir) {
+		return "", fmt.Errorf("refusing to reset %q: not a build source directory", repoDir)
+	}
+
 	steps := [][]string{
 		// Phantom mode changes: make them invisible rather than "fix" them.
 		{"config", "core.fileMode", "false"},

--- a/truffels-api/internal/compose/ckstats_basepath_test.go
+++ b/truffels-api/internal/compose/ckstats_basepath_test.go
@@ -1,0 +1,199 @@
+package compose
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ckstats is served under /ckstats by Caddy *without* `uri strip_prefix`, so
+// Next.js must carry the prefix itself via basePath. Until v0.3.1-dev.26 that
+// line existed only as a hand edit in the working copy at
+// /srv/truffels/data/ckpoolstats — it appeared in no file in this repo. Two
+// things followed:
+//
+//  1. Every fresh install shipped a broken ckstats. install.sh clones a
+//     pristine upstream tree; nothing added basePath; assets were emitted at
+//     /_next/... and swallowed by Caddy's mempool catch-all.
+//  2. The hand edit left the working copy dirty, so `git checkout <commit>`
+//     refused and no ckstats update could ever apply — the
+//     "git checkout failed: exit status 1" the update engine reported.
+//
+// The fix moves the patch into the build, next to the fetch() rewrites that
+// were already there. These tests execute the *actual* RUN command from the
+// Dockerfile against real upstream next.config.js snapshots, so they fail if
+// the patch stops applying — not merely if its text changes.
+const ckstatsPatchBeginMarker = "# truffels-patch:basePath:begin"
+const ckstatsPatchEndMarker = "# truffels-patch:basePath:end"
+
+// extractCkstatsBasePathPatch pulls the shell body of the marked RUN
+// instruction out of the ckstats Dockerfile, unfolding backslash
+// continuations, so a test can run it verbatim under /bin/sh.
+func extractCkstatsBasePathPatch(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("../../../dockerfiles/ckstats/Dockerfile")
+	if err != nil {
+		t.Skipf("dockerfile not readable from this checkout: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == ckstatsPatchBeginMarker {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("ckstats Dockerfile has no %q marker; the basePath patch must stay\n"+
+			"machine-locatable so this test exercises the real command", ckstatsPatchBeginMarker)
+	}
+
+	var body []string
+	sawRun := false
+	for i := start + 1; i < len(lines); i++ {
+		l := lines[i]
+		if strings.TrimSpace(l) == ckstatsPatchEndMarker {
+			break
+		}
+		if !sawRun {
+			if !strings.HasPrefix(l, "RUN ") {
+				t.Fatalf("expected a RUN instruction after %q, got %q", ckstatsPatchBeginMarker, l)
+			}
+			sawRun = true
+			l = strings.TrimPrefix(l, "RUN ")
+		}
+		body = append(body, strings.TrimSuffix(strings.TrimRight(l, " "), "\\"))
+	}
+	if !sawRun {
+		t.Fatalf("no RUN instruction between the basePath patch markers")
+	}
+	return strings.Join(body, "\n")
+}
+
+// runCkstatsBasePathPatch executes the extracted patch in dir, the way the
+// builder does inside /app.
+func runCkstatsBasePathPatch(t *testing.T, dir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", extractCkstatsBasePathPatch(t))
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// ckstatsFixtures are verbatim upstream next.config.js snapshots. The
+// pre-next15 one is what the device was built from; 8f2e7c2f8403 is the
+// upstream head the pending update targets, which renamed
+// experimental.serverComponentsExternalPackages to serverExternalPackages.
+// The patch must land on both — a fix that only works against the revision we
+// happen to be sitting on is exactly the bug being fixed here.
+var ckstatsFixtures = []string{
+	"next.config.pre-next15.js",
+	"next.config.8f2e7c2f8403.js",
+}
+
+func seedCkstatsFixture(t *testing.T, fixture string) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", "ckstats", fixture))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixture, err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "next.config.js"), src, 0o644); err != nil {
+		t.Fatalf("seed fixture %s: %v", fixture, err)
+	}
+	return dir
+}
+
+func readCkstatsConfig(t *testing.T, dir string) string {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(dir, "next.config.js"))
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	return string(got)
+}
+
+// The core guarantee: a pristine upstream checkout comes out of the build step
+// with basePath set, for every upstream revision we support.
+func TestCkstatsDockerfile_InjectsBasePath(t *testing.T) {
+	for _, fixture := range ckstatsFixtures {
+		t.Run(fixture, func(t *testing.T) {
+			dir := seedCkstatsFixture(t, fixture)
+			if out, err := runCkstatsBasePathPatch(t, dir); err != nil {
+				t.Fatalf("patch failed on %s: %v\n%s", fixture, err, out)
+			}
+			got := readCkstatsConfig(t, dir)
+			if !strings.Contains(got, "basePath: '/ckstats',") {
+				t.Errorf("patched %s has no basePath:\n%s", fixture, got)
+			}
+			// It has to sit inside the config object, not merely somewhere in
+			// the file — a line appended after `module.exports` would satisfy a
+			// naive grep and change nothing at runtime.
+			idx := strings.Index(got, "const nextConfig = {")
+			bp := strings.Index(got, "basePath:")
+			exp := strings.Index(got, "module.exports")
+			if idx < 0 || bp < idx || (exp >= 0 && bp > exp) {
+				t.Errorf("basePath is not inside the nextConfig object in %s:\n%s", fixture, got)
+			}
+		})
+	}
+}
+
+// The build re-runs on every image rebuild against a working copy that may
+// already carry the previous run's output (the source is bind-mounted, not
+// copied fresh). A second injection would produce a duplicate object key.
+func TestCkstatsDockerfile_BasePathPatchIsIdempotent(t *testing.T) {
+	for _, fixture := range ckstatsFixtures {
+		t.Run(fixture, func(t *testing.T) {
+			dir := seedCkstatsFixture(t, fixture)
+			for pass := 1; pass <= 3; pass++ {
+				if out, err := runCkstatsBasePathPatch(t, dir); err != nil {
+					t.Fatalf("pass %d failed on %s: %v\n%s", pass, fixture, err, out)
+				}
+			}
+			if n := strings.Count(readCkstatsConfig(t, dir), "basePath:"); n != 1 {
+				t.Errorf("basePath appears %d times after 3 passes on %s, want exactly 1:\n%s",
+					n, fixture, readCkstatsConfig(t, dir))
+			}
+		})
+	}
+}
+
+// If upstream ever restructures next.config.js past the anchor, the build must
+// stop with a diagnosable error. Silently building a prefix-less bundle is the
+// failure mode that produced a blank dashboard on every fresh install and went
+// unnoticed for months.
+func TestCkstatsDockerfile_BasePathPatchFailsLoudlyOnUnknownLayout(t *testing.T) {
+	dir := t.TempDir()
+	unknown := "export default { webpack: (c) => c }\n"
+	if err := os.WriteFile(filepath.Join(dir, "next.config.js"), []byte(unknown), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCkstatsBasePathPatch(t, dir)
+	if err == nil {
+		t.Fatalf("patch reported success on an unrecognised next.config.js; the build\n"+
+			"would ship a prefix-less bundle. output:\n%s", out)
+	}
+	if !strings.Contains(out, "basePath") {
+		t.Errorf("failure message should name basePath so the cause is obvious, got:\n%s", out)
+	}
+}
+
+// Belt and braces: the working copy must stay a pristine upstream checkout, so
+// no part of the repo may hand the operator a next.config.js to drop in.
+// TROUBLESHOOTING.md is allowed to *mention* basePath (it documents the
+// requirement) — what must not exist is a second place that applies it.
+func TestCkstatsBasePath_IsAppliedOnlyAtBuildTime(t *testing.T) {
+	data, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	if strings.Contains(string(data), "basePath") {
+		t.Errorf("install.sh writes basePath into the working copy; that makes the\n"+
+			"checkout dirty and blocks every later `git checkout <commit>`:\n%s",
+			grepLines(string(data), "basePath"))
+	}
+}

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -233,6 +233,47 @@ func TestInstaller_TruffelsAPIMountsRepoReadOnly(t *testing.T) {
 	assertContains(t, serviceBlock(t, string(installer), "agent"), "- $TRUFFELS_REPO_SRC:/repo:rw")
 }
 
+// handleFileReconcile writes service configuration under the agent's
+// configRoot, so that mount must be writable. install.sh had it as :ro while
+// templates.go had :rw — meaning a fresh install could not write any service
+// config until the API's first reconcile rewrote the compose file from the
+// template, which is also what kept the drift out of sight. Same shape as the
+// /repo parity test above: both sides of every agent mount must agree.
+func TestInstaller_AgentConfigMountMatchesTemplate(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	got, err := Render("truffels", TruffelsParams{
+		AgentTag: "truffels/agent:v0.3.1-dev.26",
+		APITag:   "truffels/api:v0.3.1-dev.26",
+		WebTag:   "truffels/web:v0.3.1-dev.26",
+		RepoSrc:  "/home/truffel/Project-Truffels",
+		Version:  "v0.3.1-dev.26",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installerAgent := serviceBlock(t, string(installer), "agent")
+	templateAgent := serviceBlock(t, got, "agent")
+
+	assertContains(t, templateAgent, "- /srv/truffels/config:/srv/truffels/config:rw")
+	assertContains(t, installerAgent, "- /srv/truffels/config:/srv/truffels/config:rw")
+	if strings.Contains(installerAgent, "/srv/truffels/config:/srv/truffels/config:ro") {
+		t.Error("installer mounts the agent's config root read-only; handleFileReconcile\n" +
+			"cannot write service configuration until the first reconcile")
+	}
+	// configRoot has to be stated too, not left to the binary's default, or the
+	// two sides drift again the moment that default changes.
+	assertContains(t, installerAgent, `TRUFFELS_CONFIG_ROOT: "/srv/truffels/config"`)
+	assertContains(t, templateAgent, "TRUFFELS_CONFIG_ROOT")
+
+	// The API stays read-only on the same path — it only reads config.
+	assertContains(t, serviceBlock(t, string(installer), "api"), "- /srv/truffels/config:/srv/truffels/config:ro")
+	assertContains(t, serviceBlock(t, got, "api"), "- /srv/truffels/config:/srv/truffels/config:ro")
+}
+
 // ckstats' SOURCE_REF is a pure stamp — unlike ckpool's, it drives no
 // git clone --branch. A default of "unknown" therefore produced an image
 // labelled with the literal string "unknown", and the installer built it

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -273,6 +273,54 @@ func TestInstaller_BuildsCkstatsWithItsRealRef(t *testing.T) {
 	assertContains(t, sh, "rev-parse --short=12 HEAD")
 }
 
+// A shallow clone has no history to check out, so `git checkout <upstream
+// commit>` — which is exactly what a ckstats update does — cannot work on a
+// device installed with --depth 1. This device only ever updated because its
+// clone happened to be full. --filter=blob:none is the correct way to keep the
+// transfer small: full refs and trees, blobs on demand.
+func TestInstaller_ClonesCkstatsSourceDeepEnoughToUpdate(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	clone := grepLines(string(installer), "github.com/mrv777/ckstats.git")
+	if clone == "" {
+		t.Fatal("no ckstats clone found in install.sh")
+	}
+	if strings.Contains(clone, "--depth") {
+		t.Errorf("ckstats is cloned shallow; no update could ever check out a\n"+
+			"different commit on a fresh install:\n%s", clone)
+	}
+	if !strings.Contains(clone, "--filter=blob:none") {
+		t.Errorf("expected a blobless partial clone, got:\n%s", clone)
+	}
+}
+
+// install.sh runs as root and chowns the ckstats tree to 1000:1000, so git
+// rejects it with "dubious ownership" unless told otherwise. Under sudo git
+// reads SUDO_UID and lets it through, which hid the bug — from a root shell or
+// a systemd unit the rev-parse returned empty and the install stamped no source
+// ref at all. Scoped with -c rather than `git config --global`, so the
+// exemption does not outlive the command in /root/.gitconfig.
+func TestInstaller_ReadsCkstatsRefAsRealRoot(t *testing.T) {
+	installer, err := os.ReadFile("../../../install.sh")
+	if err != nil {
+		t.Skipf("installer not readable from this checkout: %v", err)
+	}
+	revParse := grepLines(string(installer), "rev-parse --short=12 HEAD")
+	if revParse == "" {
+		t.Fatal("no ckstats rev-parse found in install.sh")
+	}
+	if !strings.Contains(revParse, "safe.directory") {
+		t.Errorf("ckstats rev-parse runs as root against a 1000:1000 tree without a\n"+
+			"safe.directory exemption; it returns empty outside sudo:\n%s", revParse)
+	}
+	if strings.Contains(string(installer), "config --global --add safe.directory") {
+		t.Errorf("safe.directory must not be written to /root/.gitconfig; it would\n" +
+			"outlive the install and accumulate on every re-run")
+	}
+}
+
 // grepLines returns the lines of s containing substr, for readable failures.
 func grepLines(s, substr string) string {
 	var out []string

--- a/truffels-api/internal/compose/testdata/ckstats/next.config.8f2e7c2f8403.js
+++ b/truffels-api/internal/compose/testdata/ckstats/next.config.8f2e7c2f8403.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  webpack: (config) => {
+    config.externals.push({
+      'utf-8-validate': 'commonjs utf-8-validate',
+      'bufferutil': 'commonjs bufferutil',
+    });
+    return config;
+  },
+  serverExternalPackages: ['typeorm'],
+  staticPageGenerationTimeout: 300,
+}
+
+module.exports = nextConfig

--- a/truffels-api/internal/compose/testdata/ckstats/next.config.pre-next15.js
+++ b/truffels-api/internal/compose/testdata/ckstats/next.config.pre-next15.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  webpack: (config) => {
+    config.externals.push({
+      'utf-8-validate': 'commonjs utf-8-validate',
+      'bufferutil': 'commonjs bufferutil',
+    });
+    return config;
+  },
+  experimental: {
+    serverComponentsExternalPackages: ['typeorm'],
+  },
+}
+
+module.exports = nextConfig

--- a/truffels-web/src/pages/SettingsPage.tsx
+++ b/truffels-web/src/pages/SettingsPage.tsx
@@ -445,7 +445,9 @@ function AlertsTab({ settings, saving, onSave }: {
           about 60 seconds, during which the statistics charts have a gap. Without
           it the cache keeps growing until the backend runs out of heap.
         </p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-lg">
+        {/* items-end keeps the inputs on one line even if a label wraps on a
+            narrow viewport — otherwise the taller cell drags the row apart. */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-lg items-end">
           <div>
             <label className="block text-sm text-gray-300 mb-1">Warning threshold</label>
             <div className="flex items-center gap-2">
@@ -471,7 +473,7 @@ function AlertsTab({ settings, saving, onSave }: {
             </div>
           </div>
           <div>
-            <label className="block text-sm text-gray-300 mb-1">Min interval between reclaims</label>
+            <label className="block text-sm text-gray-300 mb-1">Min. interval</label>
             <div className="flex items-center gap-2">
               <input
                 type="number" min={1} step={1}


### PR DESCRIPTION
The ckstats update under v0.3.1-dev.25 failed with `git checkout failed: exit
status 1`. Tracing it showed the ckstats source was never prepared for
automatic updates at all.

## basePath was a hand edit, so fresh installs shipped a broken ckstats

`next.config.js` on the running device carries `basePath: '/ckstats'`. That line
exists nowhere in this repo — not in `install.sh`, not in the Dockerfile, not in
any template. `TROUBLESHOOTING.md` documented it as a requirement, which means
the symptom was written down instead of the cause being fixed.

Every fresh install therefore clones a clean upstream, never sets basePath, and
serves its assets from `/_next/...` straight into the proxy's mempool catch-all.
The hand edit also made the working copy dirty, which is what `git checkout`
refused to overwrite.

The patch now happens at build time, next to the `fetch()` patches that were
already there. It is grep-guarded so it stays idempotent, it is verified against
both the old and the current upstream shape, and it fails the build rather than
silently producing a prefix-less bundle. The working copy can now be what it
should always have been: an untouched upstream checkout.

## The rest of the update path

- `install.sh` cloned with `--depth 1`, so a fresh install could never check out
  another commit. Now a blobless clone instead of a shallow one.
- A dirty working copy blocked the checkout permanently. The agent now makes
  build source trees checkout-able first: `core.fileMode false` for the phantom
  mode changes, `reset --hard` for tracked content. Untracked files are never
  touched and there is no `git clean` anywhere.
- That reset is gated by a second, strictly narrower allowlist that contains
  only the ckstats source. `/repo` is the user's own checkout with untracked
  work in it and must never be reset; the guard sits inside the reset function
  itself, not only at the call site, and a test proves it refuses before running
  any git command.

## Installer drift

- The ckstats ref was read with plain `git rev-parse` while the installer runs
  as root against a tree owned by uid 1000. Without `sudo` that hits "dubious
  ownership" and the install starts unstamped. Scoped `safe.directory` on the
  single invocation, leaving no global state behind.
- The agent's config root was mounted read-only by the installer and read-write
  by the template. `handleFileReconcile` writes there, so the template was
  right. Also adds the `TRUFFELS_CONFIG_ROOT` the installer was missing.

## Also

The "Min interval between reclaims" label needed more width than its grid column
had, wrapped, and dragged the settings row apart.

Lint clean on both Go modules, full suites green, Vitest 82/82, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)