### PR TITLE
Let a checkout replace untracked files the target commit tracks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -929,7 +929,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.26}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.27}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-agent/gitprepare_test.go
+++ b/truffels-agent/gitprepare_test.go
@@ -190,6 +190,164 @@ func TestPrepareBuildSource_DiscardsTrackedEdits(t *testing.T) {
 	}
 }
 
+// --- removeUntrackedCollisionsForCheckout ---
+//
+// The second half of the same outage. With the tree reset, `git checkout` still
+// aborted:
+//
+//	error: The following untracked working tree files would be overwritten by checkout:
+//		pnpm-workspace.yaml
+//
+// The target commit tracks pnpm-workspace.yaml, the current HEAD does not, and
+// a local `pnpm install` had left an untracked copy in the way. reset --hard
+// cannot help — the file is untracked, so it is not the reset's business — and
+// the update was stuck with no way out.
+
+// newCollisionRepo builds a repo where the target commit tracks a file that
+// HEAD does not, standing in for the ckstats tree at the moment it jammed.
+// Returns the repo dir and the target commit.
+//
+// t.TempDir() is resolved through EvalSymlinks first: the removal path runs
+// every candidate through validateUnderRoot, which rejects a root reached via a
+// symlinked ancestor. On a host where /tmp is a symlink an unresolved temp dir
+// would fail the check for reasons that have nothing to do with the behaviour
+// under test.
+func newCollisionRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	registerResettable(t, dir)
+	git(t, dir, "init", "-q", "-b", "main")
+	git(t, dir, "config", "user.email", "t@example.invalid")
+	git(t, dir, "config", "user.name", "t")
+
+	// Commit A: no pnpm-workspace.yaml.
+	write(t, dir, "next.config.js", "const nextConfig = {}\n")
+	git(t, dir, "add", "next.config.js")
+	git(t, dir, "commit", "-q", "-m", "A")
+	first := strings.TrimSpace(git(t, dir, "rev-parse", "HEAD"))
+
+	// Commit B: pnpm-workspace.yaml is tracked from here on.
+	write(t, dir, "pnpm-workspace.yaml", "packages:\n  - upstream\n")
+	git(t, dir, "add", "pnpm-workspace.yaml")
+	git(t, dir, "commit", "-q", "-m", "B")
+	target := strings.TrimSpace(git(t, dir, "rev-parse", "HEAD"))
+
+	// Back to A, so the file is absent from the index and from HEAD.
+	git(t, dir, "checkout", "-q", first)
+	return dir, target
+}
+
+// The bug: an untracked file that the target commit tracks blocks the checkout
+// permanently. It must be removed — and only it.
+func TestRemoveUntrackedCollisions_UnblocksCheckout(t *testing.T) {
+	dir, target := newCollisionRepo(t)
+
+	// The leftover from a local `pnpm install`, and a second untracked entry
+	// that the target does NOT track and therefore must survive untouched.
+	write(t, dir, "pnpm-workspace.yaml", "packages:\n  - local-junk\n")
+	write(t, dir, ".pnpm-store/v3/files/00/abc", "cached tarball\n")
+
+	// Baseline: without the fix the checkout fails, or this test proves nothing.
+	out, err := exec.Command("git", "-C", dir, "checkout", target).CombinedOutput()
+	if err == nil {
+		t.Fatal("baseline broken: checkout succeeded despite the untracked collision")
+	}
+	if !strings.Contains(string(out), "untracked working tree files") {
+		t.Fatalf("baseline broken: checkout failed for the wrong reason:\n%s", out)
+	}
+
+	if log, err := removeUntrackedCollisionsForCheckout(context.Background(), dir, target); err != nil {
+		t.Fatalf("remove failed: %v\n%s", err, log)
+	} else if !strings.Contains(log, "pnpm-workspace.yaml") {
+		t.Errorf("removal was not logged with its path: %q", log)
+	}
+
+	if out, err := exec.Command("git", "-C", dir, "checkout", target).CombinedOutput(); err != nil {
+		t.Fatalf("checkout still blocked: %v\n%s", err, out)
+	}
+
+	// The collision now carries the target commit's content, not the local one.
+	body, err := os.ReadFile(filepath.Join(dir, "pnpm-workspace.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "packages:\n  - upstream\n" {
+		t.Errorf("pnpm-workspace.yaml = %q, want the target commit's content", body)
+	}
+
+	// The untracked file the target does not track is untouched. This is the
+	// difference between the intersection and `git clean`.
+	body, err = os.ReadFile(filepath.Join(dir, ".pnpm-store/v3/files/00/abc"))
+	if err != nil {
+		t.Fatalf("untracked non-colliding file was destroyed: %v", err)
+	}
+	if string(body) != "cached tarball\n" {
+		t.Errorf("untracked non-colliding file was modified: %q", body)
+	}
+}
+
+// Ignored files are excluded from the candidate list on purpose:
+// --exclude-standard matches what git itself does, and git overwrites ignored
+// files during checkout without complaining. Listing them would widen the blast
+// radius for no benefit.
+func TestRemoveUntrackedCollisions_LeavesIgnoredFilesToGit(t *testing.T) {
+	dir, target := newCollisionRepo(t)
+	write(t, dir, ".gitignore", "*.log\n")
+	write(t, dir, "build.log", "local build output\n")
+	write(t, dir, "pnpm-workspace.yaml", "packages:\n  - local-junk\n")
+
+	if log, err := removeUntrackedCollisionsForCheckout(context.Background(), dir, target); err != nil {
+		t.Fatalf("remove failed: %v\n%s", err, log)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "build.log")); err != nil {
+		t.Errorf("ignored file was removed: %v", err)
+	}
+}
+
+// Same guard, same reasoning as prepareBuildSourceForCheckout: this function
+// deletes files, so it must refuse anything outside the build-source allowlist
+// *before* executing git, not merely because its one caller is wired correctly.
+// The shim records every invocation; the canary must never appear.
+func TestRemoveUntrackedCollisions_RefusesNonBuildSourceWithoutRunningGit(t *testing.T) {
+	shimDir := t.TempDir()
+	canary := filepath.Join(shimDir, "git-was-invoked")
+	shim := "#!/bin/sh\necho \"$@\" >> " + canary + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir)
+
+	if err := exec.Command("git", "--version").Run(); err != nil {
+		t.Fatalf("shim not reachable on PATH: %v", err)
+	}
+	if _, err := os.Stat(canary); err != nil {
+		t.Fatalf("control failed: shim ran but left no canary: %v", err)
+	}
+	if err := os.Remove(canary); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range []string{"/repo", "/", "/srv/truffels/data", "/home/truffel/Project-Truffels", ""} {
+		out, err := removeUntrackedCollisionsForCheckout(context.Background(), dir, "8f2e7c2f8403")
+		if err == nil {
+			t.Errorf("remove accepted %q; it may only ever touch build source trees", dir)
+		}
+		if out != "" {
+			t.Errorf("remove returned output for %q, so it did work before refusing: %q", dir, out)
+		}
+		if err != nil && !strings.Contains(err.Error(), dir) {
+			t.Errorf("error for %q does not name the directory: %v", dir, err)
+		}
+		if _, statErr := os.Stat(canary); statErr == nil {
+			body, _ := os.ReadFile(canary)
+			t.Fatalf("remove executed git for %q before refusing: %s", dir, body)
+		}
+	}
+}
+
 // --- the allowlist that keeps this away from /repo ---
 
 // /repo is the user's own project checkout, bind-mounted from

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1777,6 +1777,124 @@ func prepareBuildSourceForCheckout(ctx context.Context, repoDir string) (string,
 	return log.String(), nil
 }
 
+// gitPathList runs a git command that emits NUL-separated pathnames and returns
+// them. -z is mandatory in the caller's args: without it git quotes and escapes
+// names containing spaces or non-ASCII bytes, and a quoted name would not match
+// the file on disk — the intersection below would silently miss a collision, or
+// worse, name a path that does not exist.
+func gitPathList(ctx context.Context, repoDir string, args ...string) ([]string, error) {
+	full := append([]string{"-c", "safe.directory=*", "-C", repoDir}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(errOut.String()))
+	}
+	var paths []string
+	for _, p := range strings.Split(out.String(), "\x00") {
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+
+// removeUntrackedCollisionsForCheckout removes the untracked files in a build
+// source tree that the target commit tracks — and nothing else.
+//
+// The second half of the ckstats outage. With the tree reset, `git checkout`
+// still refused:
+//
+//	error: The following untracked working tree files would be overwritten by checkout:
+//		pnpm-workspace.yaml
+//
+// The target commit tracks that file, the current HEAD does not, and a local
+// `pnpm install` had left an untracked copy in the way. `reset --hard` cannot
+// help — an untracked file is not the reset's business — so the update was
+// stuck with no way out.
+//
+// Why this exact intersection is safe, and why `git clean` is not:
+//
+// A file that is untracked here AND tracked in the target commit is a file git
+// is about to own. Seconds from now `checkout` writes the committed version
+// over that path; whatever is there is discarded either way. Keeping the local
+// copy is not an option the operator has — it only decides between "checkout
+// overwrites it" and "checkout refuses forever". So the set of files this can
+// destroy is exactly the set the checkout would have destroyed anyway, and it
+// is computed from the target commit, not from a pattern.
+//
+// `git clean -fd` answers a different question: "what is not tracked *now*". It
+// would take .pnpm-store/, any local notes, any file the operator put there —
+// its blast radius is decided by git's idea of untracked, not by us, and it
+// cannot be reasoned about ahead of time from the call site. `-x` would widen
+// it again to ignored files. Neither belongs in a program that can be pointed
+// at a repository holding work nothing can recreate.
+//
+// --exclude-standard is load-bearing for the same reason it is in git itself:
+// ignored files are absent from the candidate list because `checkout`
+// overwrites them without complaining. They are never a reason for the failure,
+// so they are never a reason to delete anything.
+//
+// Must run after `fetch` (the target commit has to be local for ls-tree) and
+// before `checkout`.
+func removeUntrackedCollisionsForCheckout(ctx context.Context, repoDir, ref string) (string, error) {
+	// Re-check the allowlist here, not only at the call site — same argument as
+	// in prepareBuildSourceForCheckout, with a sharper edge: this function calls
+	// os.Remove. It returns before any git command is executed.
+	if !isResettableRepoDir(repoDir) {
+		return "", fmt.Errorf("refusing to remove untracked files in %q: not a build source directory", repoDir)
+	}
+
+	untracked, err := gitPathList(ctx, repoDir, "ls-files", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return "", err
+	}
+	if len(untracked) == 0 {
+		return "", nil
+	}
+
+	inTarget, err := gitPathList(ctx, repoDir, "ls-tree", "-r", "--name-only", "-z", ref)
+	if err != nil {
+		return "", err
+	}
+	tracked := make(map[string]bool, len(inTarget))
+	for _, p := range inTarget {
+		tracked[p] = true
+	}
+
+	var log bytes.Buffer
+	for _, rel := range untracked {
+		if !tracked[rel] {
+			continue
+		}
+		// The paths come from git and are repo-relative, but that is an
+		// assumption about another program's output, and this one deletes files.
+		// Verify independently that the joined path still lies under repoDir.
+		// A path that fails aborts the whole operation: a candidate outside the
+		// build source means the premise is broken, and continuing past it would
+		// mean deleting the remaining entries on a premise already known false.
+		full, err := validateUnderRoot(filepath.Join(repoDir, rel), repoDir)
+		if err != nil {
+			return log.String(), fmt.Errorf("refusing to remove %q in %q: %w", rel, repoDir, err)
+		}
+		// os.Remove, never os.RemoveAll: ls-files --others lists files, so every
+		// candidate is a file. If one is somehow a non-empty directory, os.Remove
+		// fails and this aborts — which is the correct outcome. A recursive
+		// delete here would turn one wrong path into an unbounded one.
+		if err := os.Remove(full); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return log.String(), fmt.Errorf("remove %q: %w", full, err)
+		}
+		slog.Info("removed untracked file that the target commit tracks",
+			"repo", repoDir, "path", full, "ref", ref)
+		fmt.Fprintf(&log, "removed untracked file that %s tracks: %s\n", ref, rel)
+	}
+	return log.String(), nil
+}
+
 type gitCheckoutRequest struct {
 	RepoDir   string `json:"repo_dir"`
 	Tag       string `json:"tag"`
@@ -1850,17 +1968,37 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Untracked files that the target commit tracks abort the checkout, and no
+	// reset can clear them. Build source trees get exactly those removed; /repo
+	// never does. This has to sit after the fetch — the ref must be local for
+	// ls-tree to resolve it — and before the checkout.
+	var collisionOut string
+	if isResettableRepoDir(req.RepoDir) {
+		out, err := removeUntrackedCollisionsForCheckout(ctx, req.RepoDir, req.Tag)
+		collisionOut = out
+		if err != nil {
+			writeJSON(w, 500, map[string]string{
+				"error":  "git prepare failed: " + err.Error(),
+				"output": prepOut + fetchOut.String() + out,
+			})
+			return
+		}
+	}
+
 	// Checkout tag
 	checkoutCmd := exec.CommandContext(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "checkout", req.Tag)
 	var checkoutOut bytes.Buffer
 	checkoutCmd.Stdout = &checkoutOut
 	checkoutCmd.Stderr = &checkoutOut
 	if err := checkoutCmd.Run(); err != nil {
-		writeJSON(w, 500, map[string]string{"error": "git checkout failed: " + err.Error(), "output": checkoutOut.String()})
+		writeJSON(w, 500, map[string]string{
+			"error":  "git checkout failed: " + err.Error(),
+			"output": prepOut + fetchOut.String() + collisionOut + checkoutOut.String(),
+		})
 		return
 	}
 
-	writeJSON(w, 200, map[string]string{"status": "ok", "output": prepOut + fetchOut.String() + checkoutOut.String()})
+	writeJSON(w, 200, map[string]string{"status": "ok", "output": prepOut + fetchOut.String() + collisionOut + checkoutOut.String()})
 }
 
 func isValidTag(tag string) bool {

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -380,7 +380,21 @@ func (c *ComposeClient) GitCheckout(repoDir, ref, refScheme string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent git checkout: %s", ar.Error)
+		msg := ar.Error
+		// ar.Error is only the exit status ("git checkout failed: exit status
+		// 1"); git's own message — which untracked files are in the way, which
+		// ref could not be resolved — is in ar.Output. Dropping it made two
+		// consecutive failed updates indistinguishable in the UI and the cause
+		// had to be fetched off the device by hand. Same tail-truncation as
+		// BuildWithArgs: git prints the interesting lines last.
+		if ar.Output != "" {
+			out := ar.Output
+			if len(out) > 500 {
+				out = "..." + out[len(out)-500:]
+			}
+			msg += "\n" + out
+		}
+		return fmt.Errorf("agent git checkout: %s", msg)
 	}
 	return nil
 }

--- a/truffels-api/internal/docker/docker_test.go
+++ b/truffels-api/internal/docker/docker_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"truffels-api/internal/model"
@@ -332,6 +333,61 @@ func TestComposeClient_GitCheckout_Error(t *testing.T) {
 	err := client.GitCheckout("/repo", "v0.2.0", "tag")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// The agent puts git's own stderr in "output" and only the exit status in
+// "error". Dropping "output" left the UI showing "git checkout failed: exit
+// status 1" twice in a row, and the real cause — the list of untracked files in
+// the way — had to be fetched off the device by hand. BuildWithArgs already
+// appends the output; GitCheckout must too.
+func TestComposeClient_GitCheckout_ErrorIncludesAgentOutput(t *testing.T) {
+	const gitStderr = "error: The following untracked working tree files would be " +
+		"overwritten by checkout:\n\tpnpm-workspace.yaml\nPlease move or remove them " +
+		"before you switch branches.\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":  "git checkout failed: exit status 1",
+			"output": gitStderr,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewComposeClient(srv.URL)
+	err := client.GitCheckout("/srv/truffels/data/ckpoolstats", "8f2e7c2f8403", "commit")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "pnpm-workspace.yaml") {
+		t.Errorf("agent output was discarded; error is not actionable:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Errorf("error field was dropped: %v", err)
+	}
+}
+
+// Long output is truncated to the tail, the same way BuildWithArgs does it:
+// git prints the interesting lines last.
+func TestComposeClient_GitCheckout_ErrorTruncatesLongOutput(t *testing.T) {
+	long := strings.Repeat("x", 4000) + "THE-ACTUAL-CAUSE"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "boom", "output": long})
+	}))
+	defer srv.Close()
+
+	client := NewComposeClient(srv.URL)
+	err := client.GitCheckout("/srv/truffels/data/ckpoolstats", "8f2e7c2f8403", "commit")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "THE-ACTUAL-CAUSE") {
+		t.Errorf("tail of the output was not kept: %v", err)
+	}
+	if len(err.Error()) > 700 {
+		t.Errorf("output was not truncated: %d chars", len(err.Error()))
 	}
 }
 


### PR DESCRIPTION
The ckstats update still failed under dev.26, with the same opaque
`git checkout failed: exit status 1`. Two problems, one of them the reason the
first was hard to find.

## Untracked files that the target commit tracks

The cleanup dev.26 added works — the tree is reset, mode noise is gone. The
checkout still refuses:

```
error: The following untracked working tree files would be overwritten by checkout:
	pnpm-workspace.yaml
```

The target commit tracks `pnpm-workspace.yaml`, the current HEAD does not, and
the working copy holds an untracked copy left over from a local `pnpm install`.
"Never touch untracked files" is right for the user's own checkout, but for a
build source tree it blocks the update permanently with no way out.

The fix is deliberately not `git clean` or `checkout -f`. Both let git decide the
blast radius. Instead the agent intersects `ls-files --others --exclude-standard`
with the paths the target commit tracks, and removes exactly that intersection.
Every file removed is one the checkout was about to overwrite anyway, so the
worst case is bounded by the target commit rather than by git's notion of
"untracked". On the affected device that is one file; the 44k-file pnpm store
next to it survives untouched.

Same guards as the existing reset: only for the build-source allowlist, checked
at the call site and again as the first statement of the function, every path
validated to stay under the repo root, `os.Remove` per file and never
`os.RemoveAll`, and each removal logged.

## The error that hid the error

`GitCheckout` decoded the agent's reply and used only its error field, dropping
the `output` that holds the actual git message. That is why the UI showed
`exit status 1` twice and the cause had to be dug out by hand. It now appends
the output the way `BuildWithArgs` already did.

Five more client methods drop `output` the same way; `Build` is the one worth
doing next, since the agent puts the whole build log there.

Lint clean on both modules, full suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)