### PR TITLE
Pin the pnpm major instead of pulling latest

### DIFF
--- a/dockerfiles/ckstats/Dockerfile
+++ b/dockerfiles/ckstats/Dockerfile
@@ -2,7 +2,14 @@
 FROM node:22-slim AS builder
 
 ENV CI=true
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm 10, not @latest. Upstream declares engines.pnpm ">=10.0.0" and keeps its
+# settings in package.json under "pnpm" (overrides, onlyBuiltDependencies).
+# pnpm 11 stopped reading that field — it moved to pnpm-workspace.yaml — so the
+# approvals for sharp and unrs-resolver were silently dropped and the install
+# died with ERR_PNPM_IGNORED_BUILDS. Nothing here changed; pnpm 11 was released.
+# The major is pinned rather than an exact version because ">=10.0.0" is the
+# contract upstream states, and the settings layout is stable within a major.
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 WORKDIR /app
 COPY ckpoolstats/package.json ckpoolstats/pnpm-lock.yaml ckpoolstats/pnpm-workspace.yaml* ./
@@ -57,7 +64,14 @@ RUN pnpm build
 FROM node:22-slim
 
 ENV CI=true
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm 10, not @latest. Upstream declares engines.pnpm ">=10.0.0" and keeps its
+# settings in package.json under "pnpm" (overrides, onlyBuiltDependencies).
+# pnpm 11 stopped reading that field — it moved to pnpm-workspace.yaml — so the
+# approvals for sharp and unrs-resolver were silently dropped and the install
+# died with ERR_PNPM_IGNORED_BUILDS. Nothing here changed; pnpm 11 was released.
+# The major is pinned rather than an exact version because ">=10.0.0" is the
+# contract upstream states, and the settings layout is stable within a major.
+RUN corepack enable && corepack prepare pnpm@10 --activate
 # retry() wraps apt-get in 4 attempts with 10/30/60s backoff so a transient
 # flake on deb.debian.org doesn't kill the whole build. Total worst-case sleep
 # budget: 100s before giving up.

--- a/install.sh
+++ b/install.sh
@@ -929,7 +929,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.27}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.28}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-web/Dockerfile
+++ b/truffels-web/Dockerfile
@@ -1,7 +1,12 @@
 # truffels-web — React control plane UI
 FROM node:22-slim AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pin the major. This build works on pnpm 11 today, but @latest means every
+# build rolls whatever version shipped that morning — the same unpinned
+# dependency that broke the ckstats build when pnpm 11 dropped the package.json
+# settings layout. CLAUDE.md forbids latest tags for images; the package manager
+# that runs the build deserves the same treatment.
+RUN corepack enable && corepack prepare pnpm@11 --activate
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./


### PR DESCRIPTION
The ckstats build failed with `ERR_PNPM_IGNORED_BUILDS` on `sharp` and
`unrs-resolver`. Nothing in this project changed — pnpm 11 was released.

Upstream ckstats declares `engines.pnpm: ">=10.0.0"` and keeps its settings in
`package.json` under the `"pnpm"` key (`overrides`, `onlyBuiltDependencies`).
pnpm 11 stopped reading that field; it moved to `pnpm-workspace.yaml`. The build
approvals for those two packages were dropped without comment and the install
refused to continue. Both ckstats stages ran `corepack prepare pnpm@latest`, so
the build bound itself to whatever shipped that morning.

Reproduced and verified against the checked-out July source:

- pnpm 11.20.0 → `ERR_PNPM_IGNORED_BUILDS`, install aborts
- pnpm 10.34.5 → installs in 30s, exit 0
- a full image build → exit 0, and the image carries `basePath: '/ckstats'`,
  the patched `fetch()` calls in the compiled bundle, and
  `org.truffels.source-ref=8f2e7c2f8403`

The major is pinned rather than an exact version: `">=10.0.0"` is the contract
upstream states, and the settings layout is stable within a major. An exact pin
would break the day upstream needs a newer 10.x.

`truffels-web/Dockerfile` carried the same unpinned line. It builds on pnpm 11
today, so it is pinned there rather than moved — the point is that the version
stops moving on its own. CLAUDE.md forbids `latest` tags for images; the package
manager that runs the build deserves the same rule, and this is the bill for the
exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)