### PR TITLE
Verify what the build produced, and stop discarding the reason it failed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -929,7 +929,7 @@ cd "$COMPOSE_DIR/proxy" && docker compose up -d
 # --- Step 9b: Truffels control plane ------------------------------------------
 log "Writing truffels control plane compose..."
 
-TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.28}"
+TRUFFELS_VERSION="${TRUFFELS_VERSION:-v0.3.1-dev.29}"
 TRUFFELS_REPO_SRC="${TRUFFELS_REPO_SRC:-$SCRIPT_DIR}"
 TRUFFELS_API_SRC="${TRUFFELS_API_SRC:-$TRUFFELS_REPO_SRC/truffels-api}"
 TRUFFELS_WEB_SRC="${TRUFFELS_WEB_SRC:-$TRUFFELS_REPO_SRC/truffels-web}"

--- a/truffels-api/internal/compose/reconciler_test.go
+++ b/truffels-api/internal/compose/reconciler_test.go
@@ -532,3 +532,71 @@ func TestReconciler_EnsureDirFailsButComposeStillWritten(t *testing.T) {
 		t.Error("expected ensure-dir failure to emit an alert")
 	}
 }
+
+// A rewritten image tag has to survive reconciliation. The reconciler renders
+// the compose file from a template every cycle, so if it did not read the tag
+// back off the file on disk it would quietly undo every retag the update path
+// makes — and ckpool would be pinned at v1.0.0 forever by a second mechanism.
+func TestReconciler_KeepsRewrittenBuildTag(t *testing.T) {
+	cases := []struct {
+		serviceID string
+		before    string
+		after     string
+	}{
+		{"ckpool", "truffels/ckpool:v1.0.0", "truffels/ckpool:v1.3.0"},
+		{"ckstats", "truffels/ckstats:latest", "truffels/ckstats:8f2e7c2f8403"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.serviceID, func(t *testing.T) {
+			// What the file looks like after the update path retagged it.
+			params, err := ExtractParams(tc.serviceID, renderFor(t, tc.serviceID, tc.after))
+			if err != nil {
+				t.Fatalf("extract params: %v", err)
+			}
+			rendered, err := Render(tc.serviceID, params)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if !strings.Contains(rendered, "image: "+tc.after) {
+				t.Errorf("reconciliation dropped the rewritten tag; wanted %q in:\n%s", tc.after, rendered)
+			}
+			if strings.Contains(rendered, "image: "+tc.before) {
+				t.Errorf("reconciliation put the old tag %q back:\n%s", tc.before, rendered)
+			}
+
+			// And it is a fixed point: reconciling the result changes nothing.
+			params2, err := ExtractParams(tc.serviceID, rendered)
+			if err != nil {
+				t.Fatalf("extract params (2nd pass): %v", err)
+			}
+			again, err := Render(tc.serviceID, params2)
+			if err != nil {
+				t.Fatalf("render (2nd pass): %v", err)
+			}
+			if again != rendered {
+				t.Errorf("reconciliation is not stable across cycles for %s", tc.serviceID)
+			}
+		})
+	}
+}
+
+// renderFor produces the on-disk compose file for a custom-built service at the
+// given image ref, going through the same template the reconciler writes.
+func renderFor(t *testing.T, serviceID, imageRef string) string {
+	t.Helper()
+	var params any
+	switch serviceID {
+	case "ckpool":
+		params = CkpoolParams{ImageTag: imageRef}
+	case "ckstats":
+		params = CkstatsParams{CkstatsImageTag: imageRef, DBImageTag: "postgres:16.14-alpine"}
+	default:
+		t.Fatalf("unknown service %q", serviceID)
+	}
+	out, err := Render(serviceID, params)
+	if err != nil {
+		t.Fatalf("render %s: %v", serviceID, err)
+	}
+	return out
+}

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -42,6 +42,26 @@ type agentResponse struct {
 	Output string `json:"output"`
 }
 
+// agentError builds an error from a failed agent response. ar.Error alone is
+// often just an exit status ("git checkout failed: exit status 1" / "build
+// failed: exit status 1"); the actual diagnosis — which untracked files were
+// in the way, which ref failed to resolve, the failing build step — is in
+// ar.Output. Dropping it made failures indistinguishable in the UI and the
+// cause had to be fetched off the device by hand. Output is tail-truncated to
+// the last 500 chars: the interesting lines are printed last, by git and by
+// docker build alike.
+func agentError(op string, ar agentResponse) error {
+	msg := ar.Error
+	if ar.Output != "" {
+		out := ar.Output
+		if len(out) > 500 {
+			out = "..." + out[len(out)-500:]
+		}
+		msg += "\n" + out
+	}
+	return fmt.Errorf("%s: %s", op, msg)
+}
+
 type ImageInfo struct {
 	Image  string            `json:"image"`
 	Digest string            `json:"digest"`
@@ -76,7 +96,7 @@ func (c *ComposeClient) Logs(serviceID string, tail int, since, container string
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return ar.Logs, fmt.Errorf("agent logs: %s", ar.Error)
+		return ar.Logs, agentError("agent logs", ar)
 	}
 	return ar.Logs, nil
 }
@@ -114,7 +134,7 @@ func (c *ComposeClient) ImageInspect(container string) (*ImageInfo, error) {
 	if resp.StatusCode != 200 {
 		var ar agentResponse
 		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, fmt.Errorf("agent image inspect: %s", ar.Error)
+		return nil, agentError("agent image inspect", ar)
 	}
 
 	var info ImageInfo
@@ -140,7 +160,7 @@ func (c *ComposeClient) ImageInspectByName(image string) (*ImageInfo, error) {
 	if resp.StatusCode != 200 {
 		var ar agentResponse
 		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, fmt.Errorf("agent image inspect by name: %s", ar.Error)
+		return nil, agentError("agent image inspect by name", ar)
 	}
 
 	var info ImageInfo
@@ -165,7 +185,7 @@ func (c *ComposeClient) ImageTag(source, target string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent image tag: %s", ar.Error)
+		return agentError("agent image tag", ar)
 	}
 	return nil
 }
@@ -185,7 +205,7 @@ func (c *ComposeClient) Build(serviceID string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent build: %s", ar.Error)
+		return agentError("agent build", ar)
 	}
 	return nil
 }
@@ -202,7 +222,7 @@ func (c *ComposeClient) SystemAction(action string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent system %s: %s", action, ar.Error)
+		return agentError(fmt.Sprintf("agent system %s", action), ar)
 	}
 	return nil
 }
@@ -320,7 +340,7 @@ func (c *ComposeClient) SystemJournal(lines int, priority, unit, since string, b
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return ar.Logs, fmt.Errorf("agent journal: %s", ar.Error)
+		return ar.Logs, agentError("agent journal", ar)
 	}
 	return ar.Logs, nil
 }
@@ -336,7 +356,7 @@ func (c *ComposeClient) SystemTuningGet() (*SystemTuningInfo, error) {
 	if resp.StatusCode != 200 {
 		var ar agentResponse
 		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, fmt.Errorf("agent tuning get: %s", ar.Error)
+		return nil, agentError("agent tuning get", ar)
 	}
 
 	var info SystemTuningInfo
@@ -358,7 +378,7 @@ func (c *ComposeClient) SystemTuningSet(action, value string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent tuning set: %s", ar.Error)
+		return agentError("agent tuning set", ar)
 	}
 	return nil
 }
@@ -380,21 +400,7 @@ func (c *ComposeClient) GitCheckout(repoDir, ref, refScheme string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		msg := ar.Error
-		// ar.Error is only the exit status ("git checkout failed: exit status
-		// 1"); git's own message — which untracked files are in the way, which
-		// ref could not be resolved — is in ar.Output. Dropping it made two
-		// consecutive failed updates indistinguishable in the UI and the cause
-		// had to be fetched off the device by hand. Same tail-truncation as
-		// BuildWithArgs: git prints the interesting lines last.
-		if ar.Output != "" {
-			out := ar.Output
-			if len(out) > 500 {
-				out = "..." + out[len(out)-500:]
-			}
-			msg += "\n" + out
-		}
-		return fmt.Errorf("agent git checkout: %s", msg)
+		return agentError("agent git checkout", ar)
 	}
 	return nil
 }
@@ -420,16 +426,7 @@ func (c *ComposeClient) BuildWithArgs(serviceID string, buildArgs map[string]str
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		msg := ar.Error
-		// Include last ~500 chars of build output for debugging
-		if ar.Output != "" {
-			out := ar.Output
-			if len(out) > 500 {
-				out = "..." + out[len(out)-500:]
-			}
-			msg += "\n" + out
-		}
-		return fmt.Errorf("agent build: %s", msg)
+		return agentError("agent build", ar)
 	}
 	return nil
 }
@@ -450,7 +447,7 @@ func (c *ComposeClient) ComposeUpDetached(serviceID string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		return fmt.Errorf("agent compose up detached: %s", ar.Error)
+		return agentError("agent compose up detached", ar)
 	}
 	return nil
 }
@@ -478,7 +475,7 @@ func (c *ComposeClient) RewriteTags(serviceID string, images []string, oldTag, n
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent rewrite tags: %s", ar.Error)
+		return agentError("agent rewrite tags", ar)
 	}
 	return nil
 }
@@ -497,7 +494,7 @@ func (c *ComposeClient) RemoveImage(image string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent remove image: %s", ar.Error)
+		return agentError("agent remove image", ar)
 	}
 	return nil
 }
@@ -517,7 +514,7 @@ func (c *ComposeClient) FsEnsureDir(path string, uid, gid int, mode string) erro
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent ensure-dir: %s", ar.Error)
+		return agentError("agent ensure-dir", ar)
 	}
 	return nil
 }
@@ -537,7 +534,7 @@ func (c *ComposeClient) FsClearDir(path string, uid, gid int, mode string) error
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent clear-dir: %s", ar.Error)
+		return agentError("agent clear-dir", ar)
 	}
 	return nil
 }
@@ -697,7 +694,7 @@ func (c *ComposeClient) composeAction(path, serviceID string) error {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("agent %s: %s", path, ar.Error)
+		return agentError(fmt.Sprintf("agent %s", path), ar)
 	}
 	return nil
 }

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -116,7 +116,10 @@ func (c *ComposeClient) Pull(image string) (string, error) {
 	var ar agentResponse
 	_ = json.NewDecoder(resp.Body).Decode(&ar)
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("agent pull: %s", ar.Error)
+		// agentError keeps the tail of ar.Output. A failed pull says why in it
+		// — manifest unknown, no space left, auth required — and that text is
+		// what reaches the update log and the alert.
+		return "", agentError("agent pull", ar)
 	}
 	return ar.Output, nil
 }

--- a/truffels-api/internal/docker/docker_test.go
+++ b/truffels-api/internal/docker/docker_test.go
@@ -490,3 +490,32 @@ func TestComposeClient_ComposeUpDetached_Error(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+// A failed pull explains itself in the agent's output — "manifest unknown",
+// "no space left on device", a registry auth prompt. Dropping it left the
+// update log and the alert with nothing but the generic error line.
+func TestComposeClient_Pull_ErrorIncludesAgentOutput(t *testing.T) {
+	const dockerStderr = "Error response from daemon: manifest for " +
+		"mariadb:lts not found: manifest unknown\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":  "pull failed: exit status 1",
+			"output": dockerStderr,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewComposeClient(srv.URL)
+	_, err := client.Pull("mariadb:lts")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "manifest unknown") {
+		t.Errorf("agent output was discarded; error is not actionable:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Errorf("error field was dropped: %v", err)
+	}
+}

--- a/truffels-api/internal/docker/docker_test.go
+++ b/truffels-api/internal/docker/docker_test.go
@@ -292,6 +292,36 @@ func TestComposeClient_SystemAction_AgentError(t *testing.T) {
 	}
 }
 
+// SystemAction was one of the fifteen methods that discarded ar.Output on a
+// failed agent response, keeping only the bare exit status from ar.Error.
+// This mirrors the GitCheckout regression test above: the agent's actual
+// diagnosis must survive into the returned error.
+func TestComposeClient_SystemAction_ErrorIncludesAgentOutput(t *testing.T) {
+	const journalTail = "systemctl: Failed to restart truffels-agent.service: " +
+		"Unit truffels-agent.service not found."
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":  "system restart failed: exit status 1",
+			"output": journalTail,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewComposeClient(srv.URL)
+	err := client.SystemAction("restart")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Unit truffels-agent.service not found") {
+		t.Errorf("agent output was discarded; error is not actionable:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Errorf("error field was dropped: %v", err)
+	}
+}
+
 func TestComposeClient_SystemAction_AgentUnreachable(t *testing.T) {
 	client := NewComposeClient("http://127.0.0.1:1")
 	err := client.SystemAction("shutdown")

--- a/truffels-api/internal/service/templates/ckpool.go
+++ b/truffels-api/internal/service/templates/ckpool.go
@@ -13,8 +13,14 @@ var Ckpool = model.ServiceTemplate{
 	ConfigPath:     "ckpool/ckpool.conf",
 	Port:           "3333 (stratum)",
 	UpdateSource: &model.UpdateSource{
-		Type:       model.SourceBitbucket,
-		Repo:       "ckolivas/ckpool",
+		Type: model.SourceBitbucket,
+		Repo: "ckolivas/ckpool",
+		// Nothing is pulled from a registry for a custom build, but the image
+		// list is also what names the compose lines to retag after a build —
+		// leaving it empty is why the compose file kept saying v1.0.0 while the
+		// image it named carried v1.2.0. Same field, same purpose as the
+		// truffels stack's own list.
+		Images:     []string{"truffels/ckpool"},
 		Branch:     "master",
 		NeedsBuild: true,
 		RefScheme:  model.RefSchemeTag,

--- a/truffels-api/internal/service/templates/ckstats.go
+++ b/truffels-api/internal/service/templates/ckstats.go
@@ -13,8 +13,12 @@ var Ckstats = model.ServiceTemplate{
 	ConfigPath:     "",
 	Port:           "80/ckstats (via proxy)",
 	UpdateSource: &model.UpdateSource{
-		Type:       model.SourceGitHub,
-		Repo:       "mrv777/ckstats",
+		Type: model.SourceGitHub,
+		Repo: "mrv777/ckstats",
+		// Both compose services (ckstats and ckstats-cron) run this image, so
+		// one entry retags both lines. Without it the file kept saying
+		// ":latest" for every build it ever ran.
+		Images:     []string{"truffels/ckstats"},
 		Branch:     "main",
 		NeedsBuild: true,
 		RefScheme:  model.RefSchemeCommit,

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -34,6 +34,31 @@ type mockAgentOpts struct {
 	composeDirs      map[string]string // service_id -> compose dir path for rewrite-tags
 	imageLabels      map[string]string // labels returned by /v1/image/inspect (NeedsBuild verification)
 	tags             *tagRecorder      // records /v1/image/tag calls when set
+	// labelsByRef serves /v1/image/inspect-by-name in the self-update mock,
+	// keyed by the exact image ref requested. A ref with no entry answers with
+	// no labels at all — that is how the real agent reports an image it cannot
+	// resolve, and how an image built without the VERSION arg reaching the
+	// labelling stage looks from here.
+	labelsByRef map[string]map[string]string
+	detached    *callCounter // counts /v1/compose/up-detached calls when set
+}
+
+// callCounter counts handler hits from the httptest server goroutine.
+type callCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *callCounter) inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.n++
+}
+
+func (c *callCounter) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
 }
 
 // tagCall is one /v1/image/tag request. JSON tags match the agent's wire format
@@ -850,6 +875,9 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case "/v1/compose/up-detached":
+			if opts.detached != nil {
+				opts.detached.inc()
+			}
 			w.WriteHeader(202)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "accepted"})
 
@@ -880,6 +908,23 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 			}
 			_ = json.NewEncoder(w).Encode(info)
 
+		case "/v1/image/inspect-by-name":
+			var req struct {
+				Image string `json:"image"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if opts.imageInspectFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "inspect failed"})
+				return
+			}
+			// Mirrors the agent: an unknown image is still a 200, just with
+			// nothing in it.
+			_ = json.NewEncoder(w).Encode(docker.ImageInfo{
+				Image:  req.Image,
+				Labels: opts.labelsByRef[req.Image],
+			})
+
 		case "/v1/inspect":
 			var req struct {
 				Containers []string `json:"containers"`
@@ -903,23 +948,19 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 	}))
 }
 
-func TestApplySelfUpdate_Success(t *testing.T) {
-	cd := t.TempDir()
-	agent := newSelfUpdateMockAgent(mockAgentOpts{composeDirs: map[string]string{"truffels": cd}})
-	defer agent.Close()
+// selfUpdateLabels builds the inspect-by-name answer for a self-update that
+// stamped every image with the version it was asked to build.
+func selfUpdateLabels(version string) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	for _, img := range []string{"truffels/agent", "truffels/api", "truffels/web"} {
+		out[img+":"+version] = map[string]string{VersionLabel: version}
+	}
+	return out
+}
 
-	composeDir := cd
-	composePath := filepath.Join(composeDir, "docker-compose.yml")
-	_ = os.WriteFile(composePath, []byte(`services:
-  agent:
-    image: truffels/agent:v0.1.0
-  api:
-    image: truffels/api:v0.1.0
-  web:
-    image: truffels/web:v0.1.0
-`), 0644)
-
-	tmpls := []model.ServiceTemplate{
+// selfUpdateTemplates is the truffels stack as applySelfUpdate sees it.
+func selfUpdateTemplates(composeDir string) []model.ServiceTemplate {
+	return []model.ServiceTemplate{
 		{
 			ID: "truffels", ComposeDir: composeDir,
 			ContainerNames: []string{"truffels-agent", "truffels-api", "truffels-web"},
@@ -929,6 +970,38 @@ func TestApplySelfUpdate_Success(t *testing.T) {
 			},
 		},
 	}
+}
+
+// writeSelfUpdateCompose lays down a compose file at the pre-update version.
+func writeSelfUpdateCompose(t *testing.T, dir, version string) string {
+	t.Helper()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	body := fmt.Sprintf(`services:
+  agent:
+    image: truffels/agent:%[1]s
+  api:
+    image: truffels/api:%[1]s
+  web:
+    image: truffels/web:%[1]s
+`, version)
+	if err := os.WriteFile(composePath, []byte(body), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	return composePath
+}
+
+func TestApplySelfUpdate_Success(t *testing.T) {
+	cd := t.TempDir()
+	restarts := &callCounter{}
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs: map[string]string{"truffels": cd},
+		labelsByRef: selfUpdateLabels("v0.2.0"),
+		detached:    restarts,
+	})
+	defer agent.Close()
+
+	composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
+	tmpls := selfUpdateTemplates(cd)
 
 	eng, st := newTestEngine(t, agent, tmpls)
 
@@ -964,6 +1037,162 @@ func TestApplySelfUpdate_Success(t *testing.T) {
 	}
 	if logs[0].Status != model.UpdateRestarting {
 		t.Errorf("expected status restarting, got %s", logs[0].Status)
+	}
+
+	if restarts.count() != 1 {
+		t.Errorf("expected exactly one detached restart, got %d", restarts.count())
+	}
+}
+
+// --- Self-update build verification (the images must hold the version we asked
+// for before anything restarts into them) ---
+
+// selfUpdateVerifyCase drives one run of the shared verification harness.
+type selfUpdateVerifyCase struct {
+	name   string
+	labels map[string]map[string]string
+	want   string // substring the failure must name
+}
+
+func TestApplySelfUpdate_RefusesMisbuiltImages(t *testing.T) {
+	// The new tag exists but a layer-cache hit left the old version stamped on
+	// every image behind it.
+	stale := selfUpdateLabels("v0.2.0")
+	for ref := range stale {
+		stale[ref] = map[string]string{VersionLabel: "v0.1.0"}
+	}
+	// Only web is wrong: agent and api verify fine, so a check that stopped
+	// after the first image would sail past this one.
+	lastWrong := selfUpdateLabels("v0.2.0")
+	lastWrong["truffels/web:v0.2.0"] = map[string]string{VersionLabel: "dev"}
+	// The label is missing entirely — also what the agent reports for an image
+	// that does not exist, since it answers 200 with empty fields.
+	noLabel := selfUpdateLabels("v0.2.0")
+	noLabel["truffels/agent:v0.2.0"] = map[string]string{}
+	// Present but blank. Empty is not "matching".
+	blank := selfUpdateLabels("v0.2.0")
+	blank["truffels/agent:v0.2.0"] = map[string]string{VersionLabel: "   "}
+
+	cases := []selfUpdateVerifyCase{
+		{name: "every image still holds the old version", labels: stale, want: `"v0.1.0"`},
+		{name: "only the last image is wrong", labels: lastWrong, want: `"dev"`},
+		{name: "version label missing", labels: noLabel, want: "carries no " + VersionLabel},
+		{name: "version label blank", labels: blank, want: "carries no " + VersionLabel},
+		{name: "no image under the new tag at all", labels: nil, want: "carries no " + VersionLabel},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cd := t.TempDir()
+			restarts := &callCounter{}
+			agent := newSelfUpdateMockAgent(mockAgentOpts{
+				composeDirs: map[string]string{"truffels": cd},
+				labelsByRef: tc.labels,
+				detached:    restarts,
+			})
+			defer agent.Close()
+
+			writeSelfUpdateCompose(t, cd, "v0.1.0")
+			eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+			_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+				ServiceID:      "truffels",
+				CurrentVersion: "v0.1.0",
+				LatestVersion:  "v0.2.0",
+				HasUpdate:      true,
+			})
+
+			err := eng.ApplyUpdate("truffels")
+			if err == nil {
+				t.Fatal("expected the update to fail on build verification")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected %q in error, got: %s", tc.want, err)
+			}
+
+			// The whole point: nothing may restart into an unverified image.
+			if restarts.count() != 0 {
+				t.Errorf("detached restart must not run, got %d call(s)", restarts.count())
+			}
+
+			logs, _ := st.GetUpdateLogs("truffels", 5)
+			if len(logs) == 0 {
+				t.Fatal("expected an update log")
+			}
+			if logs[0].Status != model.UpdateFailed {
+				t.Errorf("expected status failed, got %s", logs[0].Status)
+			}
+
+			alerts, _ := st.GetActiveAlerts()
+			found := false
+			for _, a := range alerts {
+				if a.Type == "update_failed" && a.ServiceID == "truffels" {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("expected an update_failed alert for truffels")
+			}
+		})
+	}
+}
+
+// A build that cannot be inspected at all is not a build that passed.
+func TestApplySelfUpdate_InspectFailureBlocksRestart(t *testing.T) {
+	cd := t.TempDir()
+	restarts := &callCounter{}
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs:      map[string]string{"truffels": cd},
+		imageInspectFail: true,
+		detached:         restarts,
+	})
+	defer agent.Close()
+
+	writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "truffels",
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	if err == nil {
+		t.Fatal("expected the update to fail when the built image cannot be inspected")
+	}
+	if !strings.Contains(err.Error(), "cannot verify") {
+		t.Errorf("expected 'cannot verify' in error, got: %s", err)
+	}
+	if restarts.count() != 0 {
+		t.Errorf("detached restart must not run, got %d call(s)", restarts.count())
+	}
+	logs, _ := st.GetUpdateLogs("truffels", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateFailed {
+		t.Error("expected a failed update log")
+	}
+}
+
+// selfUpdateImage must pair the build loop with the declared image list, and
+// say so rather than guess when the two do not line up.
+func TestSelfUpdateImage(t *testing.T) {
+	images := []string{"truffels/agent", "truffels/api", "truffels/web"}
+	for _, svc := range []string{"agent", "api", "web"} {
+		got, ok := selfUpdateImage(images, svc)
+		if !ok || got != "truffels/"+svc {
+			t.Errorf("svc %q: got %q ok=%v", svc, got, ok)
+		}
+	}
+	if _, ok := selfUpdateImage(images, "nope"); ok {
+		t.Error("an undeclared service must not resolve to an image")
+	}
+	if _, ok := selfUpdateImage(nil, "api"); ok {
+		t.Error("an empty image list must not resolve to an image")
+	}
+	// The prefix is not what matches — the component name is.
+	if got, ok := selfUpdateImage([]string{"ghcr.io/bandrewk/api"}, "api"); !ok || got != "ghcr.io/bandrewk/api" {
+		t.Errorf("expected the declared ref back, got %q ok=%v", got, ok)
 	}
 }
 

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -41,6 +41,10 @@ type mockAgentOpts struct {
 	// labelling stage looks from here.
 	labelsByRef map[string]map[string]string
 	detached    *callCounter // counts /v1/compose/up-detached calls when set
+	// rewriteFailFrom makes /v1/compose/rewrite-tags fail from the Nth call on
+	// (1-based, 0 = never). Step 2 of the self-update is call 1 and the restore
+	// after a refusal is call 2, so this can break the restore alone.
+	rewriteFailFrom int
 }
 
 // callCounter counts handler hits from the httptest server goroutine.
@@ -861,6 +865,7 @@ func TestApplyUpdate_CreatesConfigSnapshot(t *testing.T) {
 // --- Self-update (github_release) ---
 
 func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
+	rewrites := &callCounter{}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/git/checkout":
@@ -889,12 +894,22 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 				NewTag    string   `json:"new_tag"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
+			rewrites.inc()
+			if opts.rewriteFailFrom > 0 && rewrites.count() >= opts.rewriteFailFrom {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "write compose file: read-only file system"})
+				return
+			}
 			if dir, ok := opts.composeDirs[req.ServiceID]; ok {
 				composePath := filepath.Join(dir, "docker-compose.yml")
 				data, _ := os.ReadFile(composePath)
 				content := string(data)
 				for _, img := range req.Images {
-					pattern := fmt.Sprintf(`(image:\s*)%s:%s(@sha256:[a-f0-9]+)?`, regexp.QuoteMeta(img), regexp.QuoteMeta(req.OldTag))
+					// handleComposeRewriteTags ignores old_tag and replaces
+					// whatever tag is on the line. Mirror that: step 2 of the
+					// self-update sends an empty old_tag, and a mock keyed on it
+					// would mangle the file instead of moving the tag.
+					pattern := fmt.Sprintf(`(image:\s*)%s:[^\s@]+(@sha256:[a-f0-9]+)?`, regexp.QuoteMeta(img))
 					re, _ := regexp.Compile(pattern)
 					content = re.ReplaceAllString(content, fmt.Sprintf("${1}%s:%s", img, req.NewTag))
 				}
@@ -990,6 +1005,27 @@ func writeSelfUpdateCompose(t *testing.T, dir, version string) string {
 	return composePath
 }
 
+// assertComposeTags fails unless all three services name exactly version, and
+// no other version is left anywhere in the file.
+func assertComposeTags(t *testing.T, composePath, version string) {
+	t.Helper()
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("read compose: %v", err)
+	}
+	content := string(data)
+	for _, img := range []string{"truffels/agent", "truffels/api", "truffels/web"} {
+		want := img + ":" + version
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %s in the compose file, got:\n%s", want, content)
+		}
+	}
+	// Catch a tag that was appended rather than replaced.
+	if n := strings.Count(content, ":"+version); n != 3 {
+		t.Errorf("expected exactly 3 image tags at %s, found %d:\n%s", version, n, content)
+	}
+}
+
 func TestApplySelfUpdate_Success(t *testing.T) {
 	cd := t.TempDir()
 	restarts := &callCounter{}
@@ -1017,18 +1053,9 @@ func TestApplySelfUpdate_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify compose file was rewritten for all three
-	data, _ := os.ReadFile(composePath)
-	content := string(data)
-	if !strings.Contains(content, "truffels/agent:v0.2.0") {
-		t.Error("expected agent image tag updated to v0.2.0")
-	}
-	if !strings.Contains(content, "truffels/api:v0.2.0") {
-		t.Error("expected api image tag updated to v0.2.0")
-	}
-	if !strings.Contains(content, "truffels/web:v0.2.0") {
-		t.Error("expected web image tag updated to v0.2.0")
-	}
+	// Verify compose file was rewritten for all three — and only rewritten,
+	// with no remnant of the old tag left behind.
+	assertComposeTags(t, composePath, "v0.2.0")
 
 	// Verify single update log is "restarting" (will be reconciled on startup)
 	logs, _ := st.GetUpdateLogs("truffels", 5)
@@ -1092,7 +1119,7 @@ func TestApplySelfUpdate_RefusesMisbuiltImages(t *testing.T) {
 			})
 			defer agent.Close()
 
-			writeSelfUpdateCompose(t, cd, "v0.1.0")
+			composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
 			eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
 
 			_ = st.UpsertUpdateCheck(&model.UpdateCheck{
@@ -1114,6 +1141,12 @@ func TestApplySelfUpdate_RefusesMisbuiltImages(t *testing.T) {
 			if restarts.count() != 0 {
 				t.Errorf("detached restart must not run, got %d call(s)", restarts.count())
 			}
+
+			// Step 2 moved the compose file onto v0.2.0 before building. A
+			// refusal that leaves it there hands the rejected version to the
+			// next `up` from anywhere — and compose would build the missing
+			// image itself, without the VERSION arg.
+			assertComposeTags(t, composePath, "v0.1.0")
 
 			logs, _ := st.GetUpdateLogs("truffels", 5)
 			if len(logs) == 0 {
@@ -1137,6 +1170,110 @@ func TestApplySelfUpdate_RefusesMisbuiltImages(t *testing.T) {
 	}
 }
 
+// The build-failure path predates verifySelfBuild and left the same debris:
+// step 2 had already moved the compose file onto the version that then failed
+// to build.
+func TestApplySelfUpdate_BuildFailureRestoresComposeTag(t *testing.T) {
+	cd := t.TempDir()
+	restarts := &callCounter{}
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs: map[string]string{"truffels": cd},
+		buildFail:   true,
+		detached:    restarts,
+	})
+	defer agent.Close()
+
+	composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "truffels",
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	if err == nil {
+		t.Fatal("expected error for build failure")
+	}
+	if !strings.Contains(err.Error(), "build failed") {
+		t.Errorf("expected 'build failed' in error, got: %s", err)
+	}
+	assertComposeTags(t, composePath, "v0.1.0")
+	if restarts.count() != 0 {
+		t.Errorf("detached restart must not run, got %d call(s)", restarts.count())
+	}
+}
+
+// When the compose file cannot be put back, the failure has to say so — a file
+// left naming a rejected version needs a human, and silence is how it stays
+// unnoticed until the next restart builds an unlabelled image over it.
+func TestApplySelfUpdate_RestoreFailureIsNamed(t *testing.T) {
+	cd := t.TempDir()
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs: map[string]string{"truffels": cd},
+		buildFail:   true,
+		// Call 1 is step 2's rewrite onto v0.2.0; call 2 is the restore.
+		rewriteFailFrom: 2,
+	})
+	defer agent.Close()
+
+	writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "truffels",
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	if err == nil {
+		t.Fatal("expected error for build failure")
+	}
+	if !strings.Contains(err.Error(), "still names v0.2.0") {
+		t.Errorf("expected the stranded compose file to be named in the error, got: %s", err)
+	}
+	if !strings.Contains(err.Error(), `restore the image tags to "v0.1.0"`) {
+		t.Errorf("expected the error to say what to restore, got: %s", err)
+	}
+	logs, _ := st.GetUpdateLogs("truffels", 5)
+	if len(logs) == 0 || !strings.Contains(logs[0].Error, "still names v0.2.0") {
+		t.Errorf("expected the update log to carry the same warning, got: %+v", logs)
+	}
+}
+
+// With no known previous version there is no tag to write back. Say that
+// instead of inventing one or leaving the file quietly on the rejected version.
+func TestApplySelfUpdate_UnknownPreviousVersionIsReported(t *testing.T) {
+	cd := t.TempDir()
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs: map[string]string{"truffels": cd},
+		buildFail:   true,
+	})
+	defer agent.Close()
+
+	writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "truffels",
+		CurrentVersion: "",
+		LatestVersion:  "v0.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	if err == nil {
+		t.Fatal("expected error for build failure")
+	}
+	if !strings.Contains(err.Error(), "the previous version is unknown") {
+		t.Errorf("expected the unknown previous version to be reported, got: %s", err)
+	}
+}
+
 // A build that cannot be inspected at all is not a build that passed.
 func TestApplySelfUpdate_InspectFailureBlocksRestart(t *testing.T) {
 	cd := t.TempDir()
@@ -1148,7 +1285,7 @@ func TestApplySelfUpdate_InspectFailureBlocksRestart(t *testing.T) {
 	})
 	defer agent.Close()
 
-	writeSelfUpdateCompose(t, cd, "v0.1.0")
+	composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
 	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
 
 	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
@@ -1168,6 +1305,7 @@ func TestApplySelfUpdate_InspectFailureBlocksRestart(t *testing.T) {
 	if restarts.count() != 0 {
 		t.Errorf("detached restart must not run, got %d call(s)", restarts.count())
 	}
+	assertComposeTags(t, composePath, "v0.1.0")
 	logs, _ := st.GetUpdateLogs("truffels", 5)
 	if len(logs) == 0 || logs[0].Status != model.UpdateFailed {
 		t.Error("expected a failed update log")

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -913,6 +913,13 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 					re, _ := regexp.Compile(pattern)
 					content = re.ReplaceAllString(content, fmt.Sprintf("${1}%s:%s", img, req.NewTag))
 				}
+				// handleComposeRewriteTags moves the VERSION build args along
+				// with the tags (main.go:2138). The truffels stack builds all
+				// three services from source, so this line is what the next
+				// build stamps into the image label — leaving it on a rejected
+				// version is the same lie as leaving the tag there.
+				versionRe := regexp.MustCompile(`(VERSION:\s+)\S+`)
+				content = versionRe.ReplaceAllString(content, "${1}"+req.NewTag)
 				_ = os.WriteFile(composePath, []byte(content), 0644)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
@@ -991,13 +998,29 @@ func selfUpdateTemplates(composeDir string) []model.ServiceTemplate {
 func writeSelfUpdateCompose(t *testing.T, dir, version string) string {
 	t.Helper()
 	composePath := filepath.Join(dir, "docker-compose.yml")
+	// Shaped like the real /srv/truffels/compose/truffels/docker-compose.yml:
+	// all three services carry a build: block with a VERSION arg alongside the
+	// image tag. Both move together, and both have to move back — a file left
+	// with the rejected version in build.args would hand it to the next build.
 	body := fmt.Sprintf(`services:
   agent:
     image: truffels/agent:%[1]s
+    build:
+      context: /repo/truffels-agent
+      args:
+        VERSION: %[1]s
   api:
     image: truffels/api:%[1]s
+    build:
+      context: /repo/truffels-api
+      args:
+        VERSION: %[1]s
   web:
     image: truffels/web:%[1]s
+    build:
+      context: /repo/truffels-web
+      args:
+        VERSION: %[1]s
 `, version)
 	if err := os.WriteFile(composePath, []byte(body), 0644); err != nil {
 		t.Fatalf("write compose: %v", err)
@@ -1005,8 +1028,31 @@ func writeSelfUpdateCompose(t *testing.T, dir, version string) string {
 	return composePath
 }
 
-// assertComposeTags fails unless all three services name exactly version, and
-// no other version is left anywhere in the file.
+// composeTagProblems reports every way the compose file fails to sit at version:
+// each of the three image lines and each of the three VERSION build args must be
+// exactly that version and nothing else.
+//
+// It anchors whole lines rather than counting substrings. A count of
+// occurrences passes the one shape this exists to catch — an appended rather
+// than replaced tag, "image: truffels/agent:v0.2.0v0.1.0", which contains
+// ":v0.2.0" exactly once and satisfies any Contains check for it.
+func composeTagProblems(content, version string) []string {
+	var problems []string
+	for _, img := range []string{"truffels/agent", "truffels/api", "truffels/web"} {
+		re := regexp.MustCompile(`(?m)^\s*image:\s*` + regexp.QuoteMeta(img+":"+version) + `\s*$`)
+		if n := len(re.FindAllString(content, -1)); n != 1 {
+			problems = append(problems, fmt.Sprintf("expected exactly one line naming %s:%s, found %d", img, version, n))
+		}
+	}
+	argRe := regexp.MustCompile(`(?m)^\s*VERSION:\s*` + regexp.QuoteMeta(version) + `\s*$`)
+	if n := len(argRe.FindAllString(content, -1)); n != 3 {
+		problems = append(problems, fmt.Sprintf("expected 3 VERSION build args at %s, found %d", version, n))
+	}
+	return problems
+}
+
+// assertComposeTags fails unless all three services, image tag and build arg
+// alike, sit exactly at version.
 func assertComposeTags(t *testing.T, composePath, version string) {
 	t.Helper()
 	data, err := os.ReadFile(composePath)
@@ -1014,15 +1060,56 @@ func assertComposeTags(t *testing.T, composePath, version string) {
 		t.Fatalf("read compose: %v", err)
 	}
 	content := string(data)
-	for _, img := range []string{"truffels/agent", "truffels/api", "truffels/web"} {
-		want := img + ":" + version
-		if !strings.Contains(content, want) {
-			t.Errorf("expected %s in the compose file, got:\n%s", want, content)
-		}
+	if problems := composeTagProblems(content, version); len(problems) > 0 {
+		t.Errorf("compose file is not at %s: %s\n%s", version, strings.Join(problems, "; "), content)
 	}
-	// Catch a tag that was appended rather than replaced.
-	if n := strings.Count(content, ":"+version); n != 3 {
-		t.Errorf("expected exactly 3 image tags at %s, found %d:\n%s", version, n, content)
+}
+
+// The assertion has to reject the exact mangling that motivated it, or it is
+// decoration. An appended tag survives every substring check for the version it
+// claims to be at.
+func TestComposeTagProblems(t *testing.T) {
+	clean := `services:
+  agent:
+    image: truffels/agent:v0.2.0
+    build:
+      args:
+        VERSION: v0.2.0
+  api:
+    image: truffels/api:v0.2.0
+    build:
+      args:
+        VERSION: v0.2.0
+  web:
+    image: truffels/web:v0.2.0
+    build:
+      args:
+        VERSION: v0.2.0
+`
+	if problems := composeTagProblems(clean, "v0.2.0"); len(problems) > 0 {
+		t.Errorf("a correct file must pass, got: %v", problems)
+	}
+
+	// The mock bug: the new tag written in front of the old one instead of over
+	// it. strings.Contains(content, "truffels/agent:v0.2.0") is true here and
+	// strings.Count(content, ":v0.2.0") is still 3.
+	mangled := strings.Replace(clean, "truffels/agent:v0.2.0", "truffels/agent:v0.2.0v0.1.0", 1)
+	if strings.Count(mangled, ":v0.2.0") != 3 || !strings.Contains(mangled, "truffels/agent:v0.2.0") {
+		t.Fatal("this fixture no longer reproduces the shape a counting check misses")
+	}
+	if problems := composeTagProblems(mangled, "v0.2.0"); len(problems) == 0 {
+		t.Error("an appended tag must be rejected")
+	}
+
+	// A tag that was never written back at all.
+	if problems := composeTagProblems(clean, "v0.1.0"); len(problems) != 4 {
+		t.Errorf("expected all three images and the build args to be reported, got: %v", problems)
+	}
+
+	// The build args left behind while the image tags moved.
+	staleArgs := strings.ReplaceAll(clean, "VERSION: v0.2.0", "VERSION: v0.1.0")
+	if problems := composeTagProblems(staleArgs, "v0.2.0"); len(problems) != 1 {
+		t.Errorf("expected the stale build args to be reported on their own, got: %v", problems)
 	}
 }
 

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -161,17 +161,18 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 			// For digest-based checks, use the local image digest directly
 			currentVersion = info.Digest
 		} else {
-			// Labels first: for the services we build ourselves the image tag is
-			// pinned (truffels/ckpool:v1.0.0 stays put across builds), so the only
-			// statement about what is actually running is the ref stamped into the
-			// image at build time. Everything else still reads the tag.
+			// Labels first: for the services we build ourselves the tag is only a
+			// claim the update path tries to keep true (it retags the compose
+			// file on every build, best-effort), while the ref stamped into the
+			// image at build time is the proof. Everything else still reads the
+			// tag.
 			currentVersion = ExtractCurrentVersionFromLabels(src, info.Image, info.Labels)
 		}
 	}
 
 	// For a service we build ourselves from a git source, the source-ref label is
-	// the only authority on what is running: the compose tag is pinned and never
-	// moves across builds. No label means the running version is unknown, and an
+	// the only authority on what is running: the compose tag is written by us and
+	// can lag the image behind it. No label means the running version is unknown, and an
 	// unknown version must not be papered over — not with the stored row (which
 	// the initialisation below used to poison), and not with latestVersion.
 	labelIsAuthority := src.NeedsBuild && (src.Type == model.SourceGitHub || src.Type == model.SourceBitbucket)
@@ -555,7 +556,13 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		}
 	}
 
-	// Step 1b: Update compose file image tags (skip for floating-tag and custom builds)
+	// Step 1b: Update compose file image tags.
+	//
+	// Floating tags stay put by definition — the tag is the target. Custom
+	// builds are rewritten too, but inside applyNeedsBuild and *before* the
+	// build: the build tags its output with what the file says, so a rewrite
+	// here would name a tag no image carries. Their rewrite is not repeated
+	// here.
 	if !src.NeedsBuild && !tmpl.FloatingTag {
 		if err := e.compose.RewriteTags(serviceID, src.Images, check.CurrentVersion, check.LatestVersion); err != nil {
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "compose rewrite failed: "+err.Error(), "")
@@ -759,11 +766,33 @@ func (e *Engine) RollbackService(serviceID string) error {
 			return &UpdateError{Msg: msg}
 		}
 
-		live := liveImageRef(tmpl, serviceID)
-		if err := e.compose.ImageTag(rollbackRef, live); err != nil {
+		// The update that got us here moved the compose tag to the version we
+		// are leaving, so the file names the wrong version for the image we are
+		// about to restore. Put the image on the tag prevVersion *will* be named
+		// by, then move the file — in that order, because a retag that fails
+		// leaves the compose file untouched, while a compose file pointed at a
+		// tag no image carries would break the next restart.
+		live, refFromFile := composeImageRef(tmpl, serviceID)
+		repo, liveTag := splitImageRef(live)
+		target := live
+		if refFromFile && len(src.Images) > 0 && repo != "" && liveTag != prevVersion {
+			target = repo + ":" + prevVersion
+		}
+		if err := e.compose.ImageTag(rollbackRef, target); err != nil {
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "no rollback image available: "+err.Error(), "")
 			e.alertUpdateFailed(serviceID, "rollback image restore failed: "+err.Error())
 			return &UpdateError{Msg: "no rollback image available: " + err.Error()}
+		}
+		if target != live {
+			// Fatal: without the rewrite the file still names the version we are
+			// rolling away from, and Down/Up below would restart exactly that
+			// image while this reported a rollback.
+			if err := e.compose.RewriteTags(serviceID, src.Images, liveTag, prevVersion); err != nil {
+				msg := "compose rewrite failed: " + err.Error()
+				_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+				e.alertUpdateFailed(serviceID, "rollback compose rewrite failed: "+err.Error())
+				return &UpdateError{Msg: msg}
+			}
 		}
 	} else {
 		for _, img := range src.Images {
@@ -826,10 +855,29 @@ func (e *Engine) rollback(serviceID string, tmpl model.ServiceTemplate, src *mod
 		// previous image was staged under :rollback before the build overwrote
 		// the live tag; move it back, otherwise Down/Up would simply restart the
 		// very image that just failed while we reported a successful rollback.
-		live := liveImageRef(tmpl, serviceID)
-		if err := e.compose.ImageTag(rollbackImageRef(serviceID), live); err != nil {
-			slog.Error("rollback: retag failed", "service", serviceID, "image", live, "err", err)
+		//
+		// applyNeedsBuild also moved the compose tag to newVersion, so the ref
+		// the file names has to go back to currentVersion as well — restore the
+		// image onto that ref first, then move the file, so a failed retag never
+		// leaves the compose pointing at a tag no image carries. An unknown
+		// currentVersion has no tag to go back to; then the ref stays as it is
+		// and only the image is restored, exactly as before.
+		live, refFromFile := composeImageRef(tmpl, serviceID)
+		repo, liveTag := splitImageRef(live)
+		target := live
+		if refFromFile && len(src.Images) > 0 && repo != "" && currentVersion != "" && liveTag != currentVersion {
+			target = repo + ":" + currentVersion
+		}
+		if err := e.compose.ImageTag(rollbackImageRef(serviceID), target); err != nil {
+			slog.Error("rollback: retag failed", "service", serviceID, "image", target, "err", err)
 			rollbackErr = fmt.Errorf("restoring previous image failed: %w", err)
+		} else if target != live {
+			if err := e.compose.RewriteTags(serviceID, src.Images, liveTag, currentVersion); err != nil {
+				// Down/Up below would restart the failed build under its own
+				// name. The caller must not report this as a rollback.
+				slog.Error("rollback: compose rewrite failed", "service", serviceID, "err", err)
+				rollbackErr = fmt.Errorf("restoring the previous compose tag failed: %w", err)
+			}
 		}
 	} else {
 		// Revert compose file to old version
@@ -873,37 +921,57 @@ func composeImageRe(serviceID string) *regexp.Regexp {
 	return regexp.MustCompile(`(?m)^\s*image:\s*(truffels/` + regexp.QuoteMeta(serviceID) + `:[A-Za-z0-9._-]+)\s*$`)
 }
 
-// liveImageRef is the image reference a custom-built service actually runs.
-// The convention is truffels/<id>:latest — but ckpool's compose file pins
-// truffels/ckpool:v1.0.0, and staging or restoring :latest there would move a
-// tag nothing runs: the same silent no-op this rollback path exists to end. So
-// read the compose file and fall back to the convention only when it says
-// nothing.
+// splitImageRef splits an image reference into repository and tag:
+// "truffels/ckpool:v1.0.0" -> ("truffels/ckpool", "v1.0.0"). A ref carrying no
+// tag returns an empty tag, and a colon belonging to a registry host:port (one
+// that appears before the last "/") is not read as a tag separator.
+func splitImageRef(ref string) (repo, tag string) {
+	idx := strings.LastIndex(ref, ":")
+	if idx < 0 || idx < strings.LastIndex(ref, "/") {
+		return ref, ""
+	}
+	return ref[:idx], ref[idx+1:]
+}
+
+// liveImageRef is the image reference a custom-built service actually runs —
+// the single source of truth for it is the compose file, because that is what
+// `docker compose build` tags its output with and what `up` starts. The
+// convention truffels/<id>:latest is only a fallback for a file that names
+// nothing usable; staging or restoring a tag nothing runs is the silent no-op
+// this path exists to end.
 // Every path to the fallback warns: each one is a misconfiguration that turns
 // staging and rollback into tag moves nothing runs, and it has to be visible
 // before a rollback needs the ref, not afterwards.
 func liveImageRef(tmpl model.ServiceTemplate, serviceID string) string {
+	ref, _ := composeImageRef(tmpl, serviceID)
+	return ref
+}
+
+// composeImageRef additionally reports whether the ref was really read off the
+// compose file. Only then may the tag be moved: under the fallback we do not
+// know what the file says, and rewriting it would be a guess written to disk.
+func composeImageRef(tmpl model.ServiceTemplate, serviceID string) (ref string, fromFile bool) {
 	fallback := "truffels/" + serviceID + ":latest"
 	if tmpl.ComposeDir == "" {
 		slog.Warn("no compose dir for service, assuming conventional image ref",
 			"service", serviceID, "image", fallback)
-		return fallback
+		return fallback, false
 	}
 	path := tmpl.ComposeDir + "/docker-compose.yml"
 	data, err := os.ReadFile(path)
 	if err != nil {
 		slog.Warn("cannot read compose file, assuming conventional image ref",
 			"service", serviceID, "path", path, "image", fallback, "err", err)
-		return fallback
+		return fallback, false
 	}
 	if m := composeImageRe(serviceID).FindSubmatch(data); m != nil {
-		return string(m[1])
+		return string(m[1]), true
 	}
 	// A trailing comment ("image: truffels/ckpool:v1.0.0 # pinned") or an
 	// interpolated tag ("image: truffels/ckpool:${TAG}") both miss the pattern.
 	slog.Warn("no plain truffels image line in compose file, assuming conventional image ref",
 		"service", serviceID, "path", path, "image", fallback)
-	return fallback
+	return fallback, false
 }
 
 // rollbackImageRef names the single retained rollback generation. Exactly one:
@@ -932,61 +1000,115 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 		}
 	}
 
-	// Stage the running image for rollback before the build overwrites its tag.
+	// Stage the running image for rollback FIRST — before the tag rewrite below
+	// moves the name it is staged from. liveImageRef reads the compose file, so
+	// staging after the rewrite would ask docker to tag an image that does not
+	// exist yet and leave :rollback pointing into nothing, i.e. a rollback that
+	// silently restores the wrong generation or fails outright.
+	//
 	// Staging itself is best-effort: a first-time build has nothing to stage,
 	// and refusing to update over that would be worse than losing the rollback
 	// option.
-	live := liveImageRef(tmpl, serviceID)
+	oldRef, refFromFile := composeImageRef(tmpl, serviceID)
+	_, oldTag := splitImageRef(oldRef)
 	rollbackRef := rollbackImageRef(serviceID)
-	if err := e.compose.ImageTag(live, rollbackRef); err != nil {
+	if err := e.compose.ImageTag(oldRef, rollbackRef); err != nil {
 		// Whatever :rollback still points at is now one generation too old —
 		// it was staged by the *previous* update. Restoring it later would
 		// install the wrong build and report a successful rollback, which is
 		// the class of lie this whole path exists to end. Drop the tag so a
 		// later rollback fails honestly instead. Removing a tag does not delete
 		// the image it shares with other tags.
-		slog.Warn("could not stage rollback image", "service", serviceID, "image", live, "err", err)
+		slog.Warn("could not stage rollback image", "service", serviceID, "image", oldRef, "err", err)
 		if rmErr := e.compose.RemoveImage(rollbackRef); rmErr != nil {
 			slog.Warn("could not drop the stale rollback tag", "service", serviceID, "image", rollbackRef, "err", rmErr)
 		}
 	}
 
-	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
-	buildArgs := map[string]string{"SOURCE_REF": check.LatestVersion}
-	if err := e.compose.BuildWithArgs(serviceID, buildArgs); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "build failed: "+err.Error(), "")
-		e.alertUpdateFailed(serviceID, "build failed: "+err.Error())
-		return &UpdateError{Msg: "build failed: " + err.Error()}
+	// Move the compose tag onto the version about to be built. It has to happen
+	// here — after staging, before the build — because `docker compose build`
+	// tags its output with whatever the file says: rewriting afterwards would
+	// name a tag no image carries, and the next `up` would rebuild it without a
+	// SOURCE_REF arg. This is the same order applySelfUpdate has always used.
+	//
+	// Best-effort on purpose. The tag is a claim about the image, the source-ref
+	// label is the proof, and every check in this file keys off the label. A
+	// compose file the agent will not rewrite must not block an update that
+	// otherwise works — it only leaves the tag as stale as it already was.
+	if refFromFile && len(src.Images) > 0 && oldTag != check.LatestVersion {
+		if err := e.compose.RewriteTags(serviceID, src.Images, oldTag, check.LatestVersion); err != nil {
+			slog.Warn("could not move the compose image tag onto the new version; the build keeps the old tag",
+				"service", serviceID, "old", oldTag, "new", check.LatestVersion, "err", err)
+		}
 	}
 
-	// Verify before restarting: a mismatched image must never get to run. The
-	// agent resolves the image by the name the container references, so this
-	// reads the freshly built image even though the old one is still running.
-	var info *docker.ImageInfo
-	err := fmt.Errorf("service %s has no container to inspect", serviceID)
-	if len(tmpl.ContainerNames) > 0 {
-		info, err = e.compose.ImageInspect(tmpl.ContainerNames[0])
-	}
-	if err != nil {
-		// No container to resolve through — the case checkService deliberately
-		// does not skip for git sources, i.e. ckpool and ckstats after a failed
-		// or never-completed start. Ask for the image by name instead; only a
-		// second failure means we cannot verify at all.
-		byName, nameErr := e.compose.ImageInspectByName(live)
-		if nameErr != nil {
-			msg := "image inspect failed: " + err.Error() + "; by name: " + nameErr.Error()
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+	// Re-read rather than assume the rewrite took: a failure can mean "file
+	// untouched" or "written, but the answer was lost on the way back", and what
+	// the build produces is whatever the file says now. Everything below —
+	// verification and putting the tag back on failure — keys off this ref.
+	buildRef := liveImageRef(tmpl, serviceID)
+
+	// restoreComposeTag puts the old tag back when the file really did move.
+	// Without it a failed build leaves the compose naming a version whose image
+	// is that failed build: the running container is left alone, but any later
+	// restart from any cause would pull the broken name up. Returns a suffix for
+	// the failure message when even that does not work, because then the file
+	// needs a human.
+	restoreComposeTag := func() string {
+		if buildRef == oldRef {
+			return ""
 		}
-		info = byName
+		_, newTag := splitImageRef(buildRef)
+		if err := e.compose.RewriteTags(serviceID, src.Images, newTag, oldTag); err != nil {
+			slog.Error("could not put the compose image tag back after a failed build",
+				"service", serviceID, "image", buildRef, "want", oldTag, "err", err)
+			return fmt.Sprintf("; the compose file still names %s — restore the tag to %q before restarting the service", buildRef, oldTag)
+		}
+		return ""
 	}
-	built := info.Labels[SourceRefLabel]
-	if built != check.LatestVersion {
-		msg := fmt.Sprintf("built ref %q does not match requested %q", built, check.LatestVersion)
+	fail := func(msg string) error {
+		msg += restoreComposeTag()
 		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
 		e.alertUpdateFailed(serviceID, msg)
 		return &UpdateError{Msg: msg}
+	}
+
+	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
+	buildArgs := map[string]string{"SOURCE_REF": check.LatestVersion}
+	if err := e.compose.BuildWithArgs(serviceID, buildArgs); err != nil {
+		return fail("build failed: " + err.Error())
+	}
+
+	// Verify before restarting: a mismatched image must never get to run.
+	//
+	// Ask for the ref the compose file names first. The container route resolves
+	// {{.Config.Image}} of the container that is *still running the old tag*, so
+	// after a rewrite it would inspect the image we just replaced and fail a
+	// build that is in fact correct. It stays as a second attempt for the case
+	// the by-name lookup produces no ref at all — the agent reports an image it
+	// cannot resolve as a 200 with empty fields, which is also what the :latest
+	// fallback above looks like when the compose file names something else. That
+	// cannot become a hole: after a rewrite the container's image is the old one
+	// and its label fails the comparison just the same.
+	var built string
+	var inspectErrs []string
+	if info, err := e.compose.ImageInspectByName(buildRef); err != nil {
+		inspectErrs = append(inspectErrs, "by name "+buildRef+": "+err.Error())
+	} else {
+		built = info.Labels[SourceRefLabel]
+	}
+	if built == "" && len(tmpl.ContainerNames) > 0 {
+		if info, err := e.compose.ImageInspect(tmpl.ContainerNames[0]); err != nil {
+			inspectErrs = append(inspectErrs, "via container "+tmpl.ContainerNames[0]+": "+err.Error())
+		} else {
+			built = info.Labels[SourceRefLabel]
+		}
+	}
+	if built == "" && len(inspectErrs) > 0 {
+		return fail("image inspect failed: " + strings.Join(inspectErrs, "; "))
+	}
+	if built != check.LatestVersion {
+		return fail(fmt.Sprintf("built ref %q does not match requested %q", built, check.LatestVersion))
 	}
 
 	return nil

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -991,6 +992,84 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 	return nil
 }
 
+// selfUpdateImage returns the image repository the compose service svc is built
+// into, taken from the template's declared image list rather than assembled
+// here. The build loop and the image list are two hand-maintained sequences for
+// the same three components; deriving the ref from a string built on the spot
+// would let them drift apart silently and verify an image nobody built. Matching
+// on the last path element ties them together and reports a miss instead.
+func selfUpdateImage(images []string, svc string) (string, bool) {
+	for _, img := range images {
+		name := img
+		if idx := strings.LastIndex(name, "/"); idx >= 0 {
+			name = name[idx+1:]
+		}
+		if name == svc {
+			return img, true
+		}
+	}
+	return "", false
+}
+
+// verifySelfBuild proves that the image just built for one component of the
+// truffels stack really carries the version that was requested, and fails the
+// update if it does not.
+//
+// The build.args.VERSION block in the compose template is what carries the
+// version into the binary's ldflag and into the image's OCI version label — but
+// "we asked for it" is not "it happened". A template regression, a build arg
+// that never reaches the stage stamping the label, or a layer-cache hit on an
+// older build all yield an image labelled with the wrong version while the
+// build command itself reports success. That is the failure dev.24 closed for
+// ckpool and ckstats in applyNeedsBuild; this is the same check for the one
+// service that replaces the API, the agent and the web UI at once.
+//
+// It runs between build and the detached restart on purpose. Once
+// ComposeUpDetached fires, the wrong image is live, this API process is gone
+// mid-flight and the outcome is left to reconcileStuckUpdates — which can only
+// see whether containers came up healthy, not which version they hold. Nothing
+// is staged under a :rollback tag for the truffels stack either, so afterwards
+// there is nothing to undo it with. Refusing here leaves the old containers
+// running and untouched.
+func (e *Engine) verifySelfBuild(serviceID string, tmpl model.ServiceTemplate, svc, wantVersion string, logID int64) error {
+	fail := func(msg string) error {
+		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+		e.alertUpdateFailed(serviceID, msg)
+		return &UpdateError{Msg: msg}
+	}
+
+	img, ok := selfUpdateImage(tmpl.UpdateSource.Images, svc)
+	if !ok {
+		return fail(fmt.Sprintf("cannot verify the %s build: the update source declares no image for it", svc))
+	}
+	// Step 2 rewrote the compose tags to the new version before the build, so
+	// the image that was just built already answers to the new tag.
+	ref := img + ":" + wantVersion
+
+	info, err := e.compose.ImageInspectByName(ref)
+	if err != nil {
+		return fail(fmt.Sprintf("cannot verify the %s build: %v", svc, err))
+	}
+	// Trimmed for the comparison, so a padded label cannot fail a build that is
+	// in fact correct — and so whitespace alone still counts as absent below.
+	built := strings.TrimSpace(info.Labels[VersionLabel])
+	switch {
+	case built == "":
+		// Two shapes end up here and both are disqualifying: an image built
+		// without the VERSION arg reaching the labelling stage, and no such
+		// image at all — the agent answers 200 with empty fields for a name it
+		// cannot resolve. An absent label is not a matching label; treating
+		// empty as "close enough" is precisely the hole this check exists to
+		// close.
+		return fail(fmt.Sprintf("%s carries no %s label, so the %s build cannot be shown to be %s", ref, VersionLabel, svc, wantVersion))
+	case built != wantVersion:
+		// Includes the "dev" the Dockerfiles default VERSION to, which is what
+		// a dropped build arg looks like from the outside.
+		return fail(fmt.Sprintf("%s was built as %q, not %q — refusing to restart into it", ref, built, wantVersion))
+	}
+	return nil
+}
+
 // applySelfUpdate handles the self-update flow for truffels services (agent/api/web).
 // Flow: git checkout tag → build with VERSION arg → rewrite compose tags → detached restart.
 func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, check *model.UpdateCheck, logID int64) error {
@@ -1032,11 +1111,9 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 			e.alertUpdateFailed(serviceID, "build failed ("+svc+"): "+err.Error())
 			return &UpdateError{Msg: "build failed (" + svc + "): " + err.Error()}
 		}
-		// The truffelsTemplate.build.args.VERSION block (added in dev.16)
-		// is the primary mechanism that gets VERSION into the binary's
-		// ldflag and the image's OCI version label. A post-build label
-		// verification would be defense-in-depth but requires a new
-		// agent-side endpoint to expose image labels — tracked for dev.17+.
+		if err := e.verifySelfBuild(serviceID, tmpl, svc, check.LatestVersion, logID); err != nil {
+			return err
+		}
 	}
 
 	// Step 4: Detached restart — agent calls docker compose up -d via nsenter

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -1133,9 +1133,56 @@ func selfUpdateImage(images []string, svc string) (string, bool) {
 	return "", false
 }
 
+// restoreSelfComposeTags puts the pre-update image tags back after the stack
+// refused to go through with an update, and returns a suffix for the failure
+// message when it could not.
+//
+// Step 2 moves the compose file onto the new version before anything is built,
+// so every refusal after it leaves the file naming images that were just
+// rejected. Nothing restarts on its own, but the next `docker compose up` from
+// any source — the services API, the compose reconciler, a human — takes the
+// file at its word. All three services carry a build: block, so compose would
+// then build the missing image itself, without the VERSION arg, and stamp the
+// Dockerfile default "dev" into the label: the update refused, and the stack
+// silently ends up on an unidentifiable build anyway. Putting the tag back is
+// what keeps a refusal a refusal. The agent's rewrite also resets the
+// build.args.VERSION line, which step 2 moved for the same reason.
+//
+// This is deliberately not applyNeedsBuild's restoreComposeTag. That one
+// re-reads the single ref a custom-built service runs out of the compose file,
+// because there the pre-build rewrite is best-effort and only warns, so what
+// the file says afterwards is genuinely unknown. Here the rewrite is fatal on
+// failure — getting this far means the file really did move — the version to go
+// back to is the one the check row already holds, and three images move as a
+// set. The shared residue is a single RewriteTags call; parameterising one
+// helper for both would cost more than it saves and would mean reopening a path
+// that has shipped since dev.24.
+func (e *Engine) restoreSelfComposeTags(serviceID string, tmpl model.ServiceTemplate, check *model.UpdateCheck) string {
+	if check.CurrentVersion == "" {
+		// checkService leaves this empty when it cannot identify what runs. We
+		// have no tag to write back and must not invent one — say so instead of
+		// leaving the file quietly naming the rejected version.
+		slog.Error("cannot restore the compose image tags: the previous version is unknown",
+			"service", serviceID, "rejected", check.LatestVersion)
+		return fmt.Sprintf("; the compose file still names %s and the previous version is unknown — set the image tags by hand before restarting the stack", check.LatestVersion)
+	}
+	if check.CurrentVersion == check.LatestVersion {
+		return ""
+	}
+	if err := e.compose.RewriteTags(serviceID, tmpl.UpdateSource.Images, check.LatestVersion, check.CurrentVersion); err != nil {
+		slog.Error("could not put the compose image tags back after a refused self-update",
+			"service", serviceID, "rejected", check.LatestVersion, "want", check.CurrentVersion, "err", err)
+		return fmt.Sprintf("; the compose file still names %s — restore the image tags to %q before restarting the stack", check.LatestVersion, check.CurrentVersion)
+	}
+	slog.Info("self-update refused; compose image tags restored",
+		"service", serviceID, "version", check.CurrentVersion)
+	return ""
+}
+
 // verifySelfBuild proves that the image just built for one component of the
-// truffels stack really carries the version that was requested, and fails the
-// update if it does not.
+// truffels stack really carries the version that was requested, and reports an
+// error describing the mismatch if it does not. The caller turns that into the
+// failure — it owns the update log, the alert and putting the compose tag back.
 //
 // The build.args.VERSION block in the compose template is what carries the
 // version into the binary's ldflag and into the image's OCI version label — but
@@ -1153,16 +1200,10 @@ func selfUpdateImage(images []string, svc string) (string, bool) {
 // is staged under a :rollback tag for the truffels stack either, so afterwards
 // there is nothing to undo it with. Refusing here leaves the old containers
 // running and untouched.
-func (e *Engine) verifySelfBuild(serviceID string, tmpl model.ServiceTemplate, svc, wantVersion string, logID int64) error {
-	fail := func(msg string) error {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-		e.alertUpdateFailed(serviceID, msg)
-		return &UpdateError{Msg: msg}
-	}
-
+func (e *Engine) verifySelfBuild(tmpl model.ServiceTemplate, svc, wantVersion string) error {
 	img, ok := selfUpdateImage(tmpl.UpdateSource.Images, svc)
 	if !ok {
-		return fail(fmt.Sprintf("cannot verify the %s build: the update source declares no image for it", svc))
+		return fmt.Errorf("cannot verify the %s build: the update source declares no image for it", svc)
 	}
 	// Step 2 rewrote the compose tags to the new version before the build, so
 	// the image that was just built already answers to the new tag.
@@ -1170,7 +1211,7 @@ func (e *Engine) verifySelfBuild(serviceID string, tmpl model.ServiceTemplate, s
 
 	info, err := e.compose.ImageInspectByName(ref)
 	if err != nil {
-		return fail(fmt.Sprintf("cannot verify the %s build: %v", svc, err))
+		return fmt.Errorf("cannot verify the %s build: %w", svc, err)
 	}
 	// Trimmed for the comparison, so a padded label cannot fail a build that is
 	// in fact correct — and so whitespace alone still counts as absent below.
@@ -1183,11 +1224,11 @@ func (e *Engine) verifySelfBuild(serviceID string, tmpl model.ServiceTemplate, s
 		// cannot resolve. An absent label is not a matching label; treating
 		// empty as "close enough" is precisely the hole this check exists to
 		// close.
-		return fail(fmt.Sprintf("%s carries no %s label, so the %s build cannot be shown to be %s", ref, VersionLabel, svc, wantVersion))
+		return fmt.Errorf("%s carries no %s label, so the %s build cannot be shown to be %s", ref, VersionLabel, svc, wantVersion)
 	case built != wantVersion:
 		// Includes the "dev" the Dockerfiles default VERSION to, which is what
 		// a dropped build arg looks like from the outside.
-		return fail(fmt.Sprintf("%s was built as %q, not %q — refusing to restart into it", ref, built, wantVersion))
+		return fmt.Errorf("%s was built as %q, not %q — refusing to restart into it", ref, built, wantVersion)
 	}
 	return nil
 }
@@ -1225,16 +1266,25 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 
 	// Step 3: Build with VERSION arg — build each service sequentially to avoid
 	// I/O contention on slower storage (SD cards) causing TLS timeouts during go mod download.
+	//
+	// Every way out of this step puts the compose file back on the old version
+	// first: step 2 already moved it, and a file naming a version that was just
+	// rejected is a loaded gun for the next `up` from any source.
+	fail := func(msg string) error {
+		msg += e.restoreSelfComposeTags(serviceID, tmpl, check)
+		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
+		e.alertUpdateFailed(serviceID, msg)
+		return &UpdateError{Msg: msg}
+	}
+
 	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
 	buildArgs := map[string]string{"VERSION": check.LatestVersion}
 	for _, svc := range []string{"agent", "api", "web"} {
 		if err := e.compose.BuildWithArgs("truffels-agent", buildArgs, svc); err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "build failed ("+svc+"): "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "build failed ("+svc+"): "+err.Error())
-			return &UpdateError{Msg: "build failed (" + svc + "): " + err.Error()}
+			return fail("build failed (" + svc + "): " + err.Error())
 		}
-		if err := e.verifySelfBuild(serviceID, tmpl, svc, check.LatestVersion, logID); err != nil {
-			return err
+		if err := e.verifySelfBuild(tmpl, svc, check.LatestVersion); err != nil {
+			return fail(err.Error())
 		}
 	}
 

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -1152,11 +1152,20 @@ func selfUpdateImage(images []string, svc string) (string, bool) {
 // re-reads the single ref a custom-built service runs out of the compose file,
 // because there the pre-build rewrite is best-effort and only warns, so what
 // the file says afterwards is genuinely unknown. Here the rewrite is fatal on
-// failure — getting this far means the file really did move — the version to go
-// back to is the one the check row already holds, and three images move as a
-// set. The shared residue is a single RewriteTags call; parameterising one
-// helper for both would cost more than it saves and would mean reopening a path
-// that has shipped since dev.24.
+// failure, the version to go back to is the one the check row already holds,
+// and three images move as a set. The shared residue is a single RewriteTags
+// call; parameterising one helper for both would cost more than it saves and
+// would mean reopening a path that has shipped since dev.24.
+//
+// Writing the old tags unconditionally is not quite the same as knowing the
+// file moved: a RewriteTags error can also mean "written, but the answer was
+// lost on the way back", the distinction applyNeedsBuild draws by re-reading.
+// That residue is accepted here rather than hidden. Step 2 treats such an error
+// as fatal and returns before anything is built, so the only way to reach this
+// function is through a rewrite that reported success; and the restore is
+// idempotent — the agent replaces whatever tag is on the line, so writing the
+// old version over a file that never left it is a no-op that reports "already
+// at target version".
 func (e *Engine) restoreSelfComposeTags(serviceID string, tmpl model.ServiceTemplate, check *model.UpdateCheck) string {
 	if check.CurrentVersion == "" {
 		// checkService leaves this empty when it cannot identify what runs. We

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +17,7 @@ import (
 
 	"truffels-api/internal/docker"
 	"truffels-api/internal/model"
+	"truffels-api/internal/store"
 )
 
 // --- getCheckInterval / isCheckEnabled tests ---
@@ -1720,18 +1722,41 @@ type needsBuildRecorder struct {
 	imageLabels    map[string]string
 	inspectFail    bool              // /v1/image/inspect 500s — container gone
 	byNameLabels   map[string]string // labels served by /v1/image/inspect-by-name
-	byNameImage    string            // ref the engine asked for by name
+	byNameByRef    map[string]map[string]string
+	byNameImage    string // ref the engine asked for by name
+	byNameRefs     []string
 	byNameCalls    int
 	tagFail        bool // /v1/image/tag 500s — nothing staged to restore
 	tags           []tagCall
 	removed        []string // images dropped via /v1/image/remove
 	unhealthy      bool     // /v1/inspect reports the containers unhealthy
+	buildFail      bool     // /v1/compose/build 500s
 	buildArgs      map[string]string
 	checkoutDir    string
 	checkoutRef    string
 	checkoutScheme string
 	checkoutCalls  int
 	upCalls        int
+	// composeDirs maps service_id -> compose dir, mirroring the agent's own
+	// service_id -> /srv/truffels/compose/<id> mapping. A service registered
+	// here gets its docker-compose.yml really rewritten by the mock; one that is
+	// not registered gets the answer the agent gives for a file it cannot read.
+	composeDirs  map[string]string
+	rewriteFail  bool
+	rewrites     []rewriteCall
+	rewriteCalls int
+	// events is the ordered trace of everything the engine asked for, so a test
+	// can assert that staging happened *before* the tag was rewritten rather
+	// than merely that both happened.
+	events []string
+}
+
+// rewriteCall is one /v1/compose/rewrite-tags request.
+type rewriteCall struct {
+	ServiceID string   `json:"service_id"`
+	Images    []string `json:"images"`
+	OldTag    string   `json:"old_tag"`
+	NewTag    string   `json:"new_tag"`
 }
 
 func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
@@ -1739,6 +1764,7 @@ func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
 	defer r.mu.Unlock()
 	return needsBuildRecorder{
 		byNameImage:    r.byNameImage,
+		byNameRefs:     append([]string(nil), r.byNameRefs...),
 		byNameCalls:    r.byNameCalls,
 		tags:           append([]tagCall(nil), r.tags...),
 		removed:        append([]string(nil), r.removed...),
@@ -1748,7 +1774,27 @@ func (r *needsBuildRecorder) snapshot() needsBuildRecorder {
 		checkoutScheme: r.checkoutScheme,
 		checkoutCalls:  r.checkoutCalls,
 		upCalls:        r.upCalls,
+		rewrites:       append([]rewriteCall(nil), r.rewrites...),
+		rewriteCalls:   r.rewriteCalls,
+		events:         append([]string(nil), r.events...),
 	}
+}
+
+// event appends to the ordered trace. Caller must hold the lock.
+func (r *needsBuildRecorder) event(format string, args ...any) {
+	r.events = append(r.events, fmt.Sprintf(format, args...))
+}
+
+// indexOf returns the position of the first event with the given prefix, or -1.
+// Called on a snapshot, which nothing else holds — the pointer receiver is only
+// there to avoid copying the recorder's mutex.
+func (r *needsBuildRecorder) indexOf(prefix string) int {
+	for i, e := range r.events {
+		if strings.HasPrefix(e, prefix) {
+			return i
+		}
+	}
+	return -1
 }
 
 func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
@@ -1775,7 +1821,60 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			rec.mu.Lock()
 			rec.buildArgs = req.BuildArgs
+			rec.event("build %s", req.BuildArgs["SOURCE_REF"])
+			fail := rec.buildFail
 			rec.mu.Unlock()
+			if fail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "build failed"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		// Mirrors handleComposeRewriteTags: the agent ignores old_tag and
+		// matches whatever tag the file currently carries, refuses when nothing
+		// matched, and 500s when it cannot read the file at all.
+		case "/v1/compose/rewrite-tags":
+			var req rewriteCall
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.rewrites = append(rec.rewrites, req)
+			rec.rewriteCalls++
+			rec.event("rewrite %s->%s", req.OldTag, req.NewTag)
+			dir, known := rec.composeDirs[req.ServiceID]
+			fail := rec.rewriteFail
+			rec.mu.Unlock()
+			if fail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "write compose file: read-only file system"})
+				return
+			}
+			if !known {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "read compose file: no such file or directory"})
+				return
+			}
+			composePath := filepath.Join(dir, "docker-compose.yml")
+			data, readErr := os.ReadFile(composePath)
+			if readErr != nil {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "read compose file: " + readErr.Error()})
+				return
+			}
+			content, matched := string(data), 0
+			for _, img := range req.Images {
+				re := regexp.MustCompile(fmt.Sprintf(`(image:\s*)%s:[^\s@]+(@sha256:[a-f0-9]+)?`, regexp.QuoteMeta(img)))
+				if re.MatchString(content) {
+					matched++
+				}
+				content = re.ReplaceAllString(content, fmt.Sprintf("${1}%s:%s", img, req.NewTag))
+			}
+			if matched == 0 {
+				w.WriteHeader(400)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "no image tags matched in compose file"})
+				return
+			}
+			_ = os.WriteFile(composePath, []byte(content), 0644)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case "/v1/image/inspect":
@@ -1796,8 +1895,17 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			rec.mu.Lock()
 			rec.byNameImage = req.Image
+			rec.byNameRefs = append(rec.byNameRefs, req.Image)
 			rec.byNameCalls++
+			rec.event("inspect-by-name %s", req.Image)
 			labels := rec.byNameLabels
+			// byNameByRef answers per ref, so a test can hand the newly built
+			// tag one label and the ref the old container still names another.
+			if byRef, ok := rec.byNameByRef[req.Image]; ok {
+				labels = byRef
+			} else if rec.byNameByRef != nil {
+				labels = nil
+			}
 			rec.mu.Unlock()
 			if labels == nil {
 				w.WriteHeader(500)
@@ -1811,6 +1919,7 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			rec.mu.Lock()
 			rec.tags = append(rec.tags, req)
+			rec.event("tag %s->%s", req.Source, req.Target)
 			fail := rec.tagFail
 			rec.mu.Unlock()
 			if fail {
@@ -1823,6 +1932,20 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 		case "/v1/compose/up":
 			rec.mu.Lock()
 			rec.upCalls++
+			rec.event("up")
+			rec.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
+		// A custom build has no registry behind it. Recording pulls proves the
+		// populated Images list did not divert the apply path into the
+		// registry branch that pulls each image by tag.
+		case "/v1/image/pull":
+			var req struct {
+				Image string `json:"image"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			rec.mu.Lock()
+			rec.event("pull %s", req.Image)
 			rec.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
@@ -1861,6 +1984,9 @@ func newNeedsBuildAgent(rec *needsBuildRecorder) *httptest.Server {
 	}))
 }
 
+// The Images list mirrors templates.Ckpool: it is what names the compose lines
+// the update path retags, and a fixture without it would never catch the field
+// going missing again.
 func ckpoolBuildTemplate(composeDir string) model.ServiceTemplate {
 	return model.ServiceTemplate{
 		ID:             "ckpool",
@@ -1870,6 +1996,7 @@ func ckpoolBuildTemplate(composeDir string) model.ServiceTemplate {
 		UpdateSource: &model.UpdateSource{
 			Type:       model.SourceBitbucket,
 			Repo:       "ckolivas/ckpool",
+			Images:     []string{"truffels/ckpool"},
 			Branch:     "master",
 			NeedsBuild: true,
 			RefScheme:  model.RefSchemeTag,
@@ -1887,12 +2014,47 @@ func ckstatsBuildTemplate(composeDir, refScheme string) model.ServiceTemplate {
 		UpdateSource: &model.UpdateSource{
 			Type:       model.SourceGitHub,
 			Repo:       "mrv777/ckstats",
+			Images:     []string{"truffels/ckstats"},
 			Branch:     "main",
 			NeedsBuild: true,
 			RefScheme:  refScheme,
 			RepoDir:    "/srv/truffels/data/ckpoolstats",
 		},
 	}
+}
+
+// buildComposeDir lays down the compose file a custom-built service really has
+// on disk — a build block plus the pinned image line the build tags its output
+// with — and returns the directory holding it.
+func buildComposeDir(t *testing.T, serviceID, tag string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := fmt.Sprintf(`services:
+  %[1]s:
+    build:
+      context: /srv/truffels/compose/%[1]s
+    image: truffels/%[1]s:%[2]s
+    container_name: truffels-%[1]s
+`, serviceID, tag)
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(body), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	return dir
+}
+
+// composeImageTag reads back the tag the compose file in dir names for the
+// service's own image — the statement `docker ps` and the file itself make.
+func composeImageTag(t *testing.T, dir, serviceID string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("read compose: %v", err)
+	}
+	m := regexp.MustCompile(`image:\s*truffels/` + regexp.QuoteMeta(serviceID) + `:(\S+)`).FindStringSubmatch(string(data))
+	if m == nil {
+		t.Fatalf("no truffels/%s image line in:\n%s", serviceID, string(data))
+	}
+	return m[1]
 }
 
 // A build whose image carries a different ref than the one requested must not
@@ -2376,4 +2538,480 @@ func TestPruneOldImages_NoLogs(t *testing.T) {
 
 	// Should not panic with no logs
 	eng.pruneOldImages("electrs", tmpl.UpdateSource)
+}
+
+// --- Compose tag follows the build (ckpool / ckstats) ---
+//
+// The tag a custom-built service runs under is a statement about its contents:
+// it is what `docker ps` shows and what the compose file says. ckpool shipped
+// for six releases as truffels/ckpool:v1.0.0 while the image behind that name
+// carried source-ref v1.2.0, because the update path never retagged it. These
+// tests hold the tag to the build.
+
+// needsBuildEngine wires a ckpool template whose compose file the mock really
+// rewrites, the way the agent does on the device.
+func needsBuildEngine(t *testing.T, rec *needsBuildRecorder, serviceID, tag string) (*Engine, *store.Store, model.ServiceTemplate, string) {
+	t.Helper()
+	dir := buildComposeDir(t, serviceID, tag)
+	if rec.composeDirs == nil {
+		rec.composeDirs = map[string]string{}
+	}
+	rec.composeDirs[serviceID] = dir
+	agent := newNeedsBuildAgent(rec)
+	t.Cleanup(agent.Close)
+
+	tmpl := ckpoolBuildTemplate(dir)
+	if serviceID != "ckpool" {
+		tmpl = ckstatsBuildTemplate(dir, model.RefSchemeCommit)
+	}
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+	return eng, st, tmpl, dir
+}
+
+func TestApplyUpdate_NeedsBuild_ComposeTagFollowsTheBuild(t *testing.T) {
+	rec := &needsBuildRecorder{
+		// The old container still references truffels/ckpool:v1.0.0, and that
+		// image carries the old ref. Verifying through the container would read
+		// exactly this and fail a build that is in fact correct.
+		imageLabels: map[string]string{SourceRefLabel: "v1.0.0"},
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {SourceRefLabel: "v1.2.0"},
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.2.0" {
+		t.Errorf("compose file names truffels/ckpool:%s, want the version that was just built", got)
+	}
+
+	got := rec.snapshot()
+	if got.byNameImage != "truffels/ckpool:v1.2.0" {
+		t.Errorf("verification asked for %q, want the ref the compose file now names", got.byNameImage)
+	}
+	if got.upCalls != 1 {
+		t.Errorf("expected the service to be restarted once, up calls = %d", got.upCalls)
+	}
+	// Filling in Images must not divert a custom build into the registry
+	// branch: there is no truffels/ckpool on any registry to pull.
+	if i := got.indexOf("pull "); i >= 0 {
+		t.Errorf("a custom build must never pull from a registry: %v", got.events)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateDone {
+		t.Fatalf("expected a done update log, got %+v", logs)
+	}
+}
+
+// The rollback image is staged from the ref the compose file names, so staging
+// has to happen before the rewrite moves that name. Afterwards it would tag an
+// image that does not exist yet and the rollback would be silently useless.
+func TestApplyUpdate_NeedsBuild_StagesRollbackBeforeTheRewrite(t *testing.T) {
+	rec := &needsBuildRecorder{
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {SourceRefLabel: "v1.2.0"},
+		},
+	}
+	eng, st, _, _ := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := rec.snapshot()
+	staged := got.indexOf("tag truffels/ckpool:v1.0.0->truffels/ckpool:rollback")
+	rewritten := got.indexOf("rewrite ")
+	built := got.indexOf("build ")
+	if staged < 0 {
+		t.Fatalf("the running image was never staged from its own ref: %v", got.events)
+	}
+	if rewritten < 0 || built < 0 {
+		t.Fatalf("expected a rewrite and a build, got: %v", got.events)
+	}
+	if staged > rewritten {
+		t.Errorf("staged after the tag was rewritten — :rollback would point at nothing: %v", got.events)
+	}
+	if rewritten > built {
+		t.Errorf("rewrote after the build — the build would carry the old tag: %v", got.events)
+	}
+}
+
+// A build that cannot be shown to hold the requested ref must leave nothing
+// behind that says it does. The container is not restarted, but the compose
+// file would still name a version whose image is the failed build, and the next
+// restart from any other cause would pull it up.
+func TestApplyUpdate_NeedsBuild_FailedVerificationPutsTheComposeTagBack(t *testing.T) {
+	rec := &needsBuildRecorder{
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {SourceRefLabel: "v1.0.0"}, // build produced the old code
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected the mismatched build to fail the update")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose file left at truffels/ckpool:%s — it names a version whose image is a failed build", got)
+	}
+	if got := rec.snapshot(); got.upCalls != 0 {
+		t.Errorf("service must not be restarted on a failed verification (up calls=%d)", got.upCalls)
+	}
+}
+
+func TestApplyUpdate_NeedsBuild_FailedBuildPutsTheComposeTagBack(t *testing.T) {
+	rec := &needsBuildRecorder{buildFail: true}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected the failed build to fail the update")
+	}
+	if !strings.Contains(err.Error(), "build failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose file left at truffels/ckpool:%s after a failed build", got)
+	}
+}
+
+// The tag is a claim, the source-ref label is the proof — so a compose file the
+// agent will not rewrite must not block an update that otherwise works. It only
+// leaves the tag as stale as it already was, and the engine has to notice that
+// and keep verifying the ref the file still names.
+func TestApplyUpdate_NeedsBuild_RewriteFailureKeepsTheOldTagAndStillUpdates(t *testing.T) {
+	rec := &needsBuildRecorder{
+		rewriteFail: true,
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.0.0": {SourceRefLabel: "v1.2.0"}, // built under the old tag
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("a failed retag must not block the update: %v", err)
+	}
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose tag = %s, want the untouched old tag", got)
+	}
+	if got := rec.snapshot(); got.byNameImage != "truffels/ckpool:v1.0.0" {
+		t.Errorf("verification asked for %q, want the ref the file still names", got.byNameImage)
+	}
+}
+
+// The device state this fix was written for: the compose file says v1.0.0 while
+// the image it names carries v1.2.0, so the update check reports v1.2.0 as the
+// current version. The old tag has to come off the file, not off the check —
+// otherwise the rewrite reasons about a tag that is not there.
+func TestApplyUpdate_NeedsBuild_OldTagComesFromTheComposeFile(t *testing.T) {
+	rec := &needsBuildRecorder{
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.3.0": {SourceRefLabel: "v1.3.0"},
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.2.0", // the source-ref label, not the tag
+		LatestVersion:  "v1.3.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := rec.snapshot()
+	if len(got.rewrites) == 0 {
+		t.Fatal("expected a rewrite call")
+	}
+	if got.rewrites[0].OldTag != "v1.0.0" {
+		t.Errorf("old tag = %q, want the tag the compose file actually carries", got.rewrites[0].OldTag)
+	}
+	if got.rewrites[0].NewTag != "v1.3.0" {
+		t.Errorf("new tag = %q, want the version being built", got.rewrites[0].NewTag)
+	}
+	if got.tags[0].Source != "truffels/ckpool:v1.0.0" {
+		t.Errorf("staged from %q, want the ref the compose file names", got.tags[0].Source)
+	}
+	if tag := composeImageTag(t, dir, "ckpool"); tag != "v1.3.0" {
+		t.Errorf("compose tag = %s, want v1.3.0", tag)
+	}
+}
+
+// A rollback has to undo the rewrite as well. Leaving the new tag in the file
+// while restoring the old image would put the lie back, one generation on.
+func TestApplyUpdate_NeedsBuild_UnhealthyRollbackPutsTheComposeTagBack(t *testing.T) {
+	rec := &needsBuildRecorder{
+		unhealthy: true,
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {SourceRefLabel: "v1.2.0"},
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected an error when the service comes up unhealthy")
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose tag = %s after the rollback, want the version that is running again", got)
+	}
+
+	got := rec.snapshot()
+	last := got.tags[len(got.tags)-1]
+	if last.Source != "truffels/ckpool:rollback" || last.Target != "truffels/ckpool:v1.0.0" {
+		t.Errorf("restored %q -> %q, want the staged image onto the restored tag", last.Source, last.Target)
+	}
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateRolledBack {
+		t.Fatalf("expected a rolled_back log, got %+v", logs)
+	}
+}
+
+// Same for the manual rollback: the file has to name the version that runs
+// after it, not the one it left.
+func TestRollbackService_CustomBuildMovesTheComposeTagBack(t *testing.T) {
+	rec := &needsBuildRecorder{
+		byNameLabels: map[string]string{SourceRefLabel: "v1.0.0"}, // what :rollback holds
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.2.0")
+
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckpool", FromVersion: "v1.0.0", ToVersion: "v1.2.0", Status: model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "v1.2.0", LatestVersion: "v1.2.0",
+	})
+
+	if err := eng.RollbackService("ckpool"); err != nil {
+		t.Fatalf("unexpected rollback error: %v", err)
+	}
+
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose tag = %s after the rollback, want v1.0.0", got)
+	}
+
+	got := rec.snapshot()
+	if len(got.tags) != 1 {
+		t.Fatalf("expected exactly one retag, got %+v", got.tags)
+	}
+	if got.tags[0].Target != "truffels/ckpool:v1.0.0" {
+		t.Errorf("restored onto %q, want the ref the compose file now names", got.tags[0].Target)
+	}
+	// Order matters here too: a retag that fails must leave the file alone.
+	if got.indexOf("tag ") > got.indexOf("rewrite ") {
+		t.Errorf("rewrote the compose file before the image was restored: %v", got.events)
+	}
+}
+
+// ckstats runs the same image in two compose services (the app and its cron).
+// One entry in Images has to move both lines — a half-rewritten file would
+// start one container on an image that no longer exists.
+func TestApplyUpdate_NeedsBuild_RewritesEveryImageLine(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	_ = os.WriteFile(composePath, []byte(`services:
+  ckstats:
+    build:
+      context: /srv/truffels/data
+    image: truffels/ckstats:latest
+    container_name: truffels-ckstats
+  ckstats-cron:
+    image: truffels/ckstats:latest
+    container_name: truffels-ckstats-cron
+  ckstats-db:
+    image: postgres:16.14-alpine
+`), 0644)
+
+	rec := &needsBuildRecorder{
+		composeDirs: map[string]string{"ckstats": dir},
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckstats:8f2e7c2f8403": {SourceRefLabel: "8f2e7c2f8403"},
+		},
+	}
+	agent := newNeedsBuildAgent(rec)
+	defer agent.Close()
+
+	tmpl := ckstatsBuildTemplate(dir, model.RefSchemeCommit)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckstats",
+		CurrentVersion: "c9bf72e4cb6e",
+		LatestVersion:  "8f2e7c2f8403",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckstats"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(composePath)
+	if n := strings.Count(string(data), "image: truffels/ckstats:8f2e7c2f8403"); n != 2 {
+		t.Errorf("expected both ckstats image lines rewritten, got %d:\n%s", n, string(data))
+	}
+	if strings.Contains(string(data), "truffels/ckstats:latest") {
+		t.Errorf("a stale :latest line survived:\n%s", string(data))
+	}
+	// The database is not ours to retag.
+	if !strings.Contains(string(data), "image: postgres:16.14-alpine") {
+		t.Errorf("the postgres image line was touched:\n%s", string(data))
+	}
+}
+
+// Filling in Images also switches pruning on for the custom builds — it never
+// removed anything for them before, because there was no image name to remove.
+// The rule it now applies has to spare both the image that is running and the
+// one generation staged for rollback.
+func TestPruneOldImages_NeedsBuildSparesRunningAndRollback(t *testing.T) {
+	rec := &needsBuildRecorder{}
+	eng, st, tmpl, _ := needsBuildEngine(t, rec, "ckpool", "v1.3.0")
+
+	// ckpool's real history on the device: commit-scheme updates, then the
+	// switch to tags, then the update that just landed.
+	for _, l := range []model.UpdateLog{
+		{ServiceID: "ckpool", FromVersion: "7f1a7d573699", ToVersion: "481f4cfe348e", Status: model.UpdateDone},
+		{ServiceID: "ckpool", FromVersion: "481f4cfe348e", ToVersion: "2e44101e2da2", Status: model.UpdateDone},
+		{ServiceID: "ckpool", FromVersion: "v1.2.0", ToVersion: "v1.3.0", Status: model.UpdateDone},
+	} {
+		_, _ = st.CreateUpdateLog(&l)
+	}
+
+	eng.pruneOldImages("ckpool", tmpl.UpdateSource)
+
+	got := rec.snapshot()
+	for _, img := range got.removed {
+		switch img {
+		case "truffels/ckpool:v1.3.0":
+			t.Errorf("prune removed the tag the compose file runs: %v", got.removed)
+		case "truffels/ckpool:v1.2.0":
+			t.Errorf("prune removed the rollback generation: %v", got.removed)
+		case "truffels/ckpool:rollback":
+			t.Errorf("prune removed the staged rollback tag: %v", got.removed)
+		}
+	}
+	// It does clean up the generations before those two.
+	if len(got.removed) == 0 {
+		t.Error("expected the older generations to be pruned now that Images is set")
+	}
+}
+
+// The agent answers a ref it cannot resolve with a 200 and empty fields, and
+// the :latest fallback looks exactly the same from here. Verification must then
+// still try the container route rather than fail a correct build — and the
+// container's label still has to match, so this cannot pass anything through.
+func TestApplyUpdate_NeedsBuild_EmptyByNameFallsBackToTheContainer(t *testing.T) {
+	rec := &needsBuildRecorder{
+		imageLabels: map[string]string{SourceRefLabel: "v1.2.0"}, // the container route
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {}, // resolved, but carries no label
+		},
+	}
+	eng, st, _, _ := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	if err := eng.ApplyUpdate("ckpool"); err != nil {
+		t.Fatalf("verification should fall back to the container: %v", err)
+	}
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if len(logs) == 0 || logs[0].Status != model.UpdateDone {
+		t.Fatalf("expected a done update log, got %+v", logs)
+	}
+}
+
+// ...and when neither route produces a ref, the update fails with the honest
+// "nothing proves what this image holds" message instead of starting it.
+func TestApplyUpdate_NeedsBuild_NoLabelAnywhereFails(t *testing.T) {
+	rec := &needsBuildRecorder{
+		imageLabels: map[string]string{},
+		byNameByRef: map[string]map[string]string{
+			"truffels/ckpool:v1.2.0": {},
+		},
+	}
+	eng, st, _, dir := needsBuildEngine(t, rec, "ckpool", "v1.0.0")
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID:      "ckpool",
+		CurrentVersion: "v1.0.0",
+		LatestVersion:  "v1.2.0",
+		HasUpdate:      true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	if err == nil {
+		t.Fatal("expected an unverifiable build to fail the update")
+	}
+	if !strings.Contains(err.Error(), `does not match`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got := rec.snapshot(); got.upCalls != 0 {
+		t.Errorf("service must not start unverified (up calls=%d)", got.upCalls)
+	}
+	if got := composeImageTag(t, dir, "ckpool"); got != "v1.0.0" {
+		t.Errorf("compose tag = %s, want the old tag restored", got)
+	}
 }

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -669,7 +669,7 @@ func ExtractCurrentVersion(src *model.UpdateSource, imageName string) string {
 		if idx := strings.LastIndex(name, ":"); idx >= 0 {
 			return name[idx+1:]
 		}
-		return "unknown"
+		return ""
 	case model.SourceDockerDigest:
 		// Digest is extracted directly in checkService via ImageInspect
 		return ""
@@ -685,9 +685,9 @@ func ExtractCurrentVersion(src *model.UpdateSource, imageName string) string {
 		if idx := strings.LastIndex(name, ":"); idx >= 0 {
 			return name[idx+1:]
 		}
-		return "unknown"
+		return ""
 	default:
-		return "unknown"
+		return ""
 	}
 }
 

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -696,6 +696,15 @@ func ExtractCurrentVersion(src *model.UpdateSource, imageName string) string {
 // the update_checks row merely records what the engine intended to build.
 const SourceRefLabel = "org.truffels.source-ref"
 
+// VersionLabel carries the release version an image was built for. It is the
+// truffels stack's own equivalent of SourceRefLabel and the two must not be
+// confused: SourceRefLabel records an *upstream* git ref for the sources we
+// vendor and build (ckpool, ckstats), while this one records *our* release tag,
+// stamped by truffels-{agent,api,web}/Dockerfile from the VERSION build arg.
+// Those Dockerfiles default the arg to "dev", so an image built without it says
+// so rather than claiming a version it does not have.
+const VersionLabel = "org.opencontainers.image.version"
+
 // ExtractCurrentVersionFromLabels resolves the running version, preferring the
 // build label for the git sources we build ourselves (ckpool, ckstats).
 // Returns "" when such an image carries no label; that means it predates label

--- a/truffels-api/internal/updates/registry_test.go
+++ b/truffels-api/internal/updates/registry_test.go
@@ -31,8 +31,8 @@ func TestExtractCurrentVersion_DockerHub_StripDigest(t *testing.T) {
 func TestExtractCurrentVersion_DockerHub_NoTag(t *testing.T) {
 	src := &model.UpdateSource{Type: model.SourceDockerHub}
 	got := ExtractCurrentVersion(src, "owner/repo")
-	if got != "unknown" {
-		t.Errorf("expected unknown, got %s", got)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
 	}
 }
 
@@ -55,8 +55,8 @@ func TestExtractCurrentVersion_Bitbucket(t *testing.T) {
 func TestExtractCurrentVersion_UnknownType(t *testing.T) {
 	src := &model.UpdateSource{Type: "something_else"}
 	got := ExtractCurrentVersion(src, "whatever")
-	if got != "unknown" {
-		t.Errorf("expected unknown, got %s", got)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
 	}
 }
 
@@ -503,8 +503,8 @@ func TestExtractCurrentVersion_GitHubRelease(t *testing.T) {
 func TestExtractCurrentVersion_GitHubRelease_NoTag(t *testing.T) {
 	src := &model.UpdateSource{Type: model.SourceGitHubRelease}
 	got := ExtractCurrentVersion(src, "truffels/agent")
-	if got != "unknown" {
-		t.Errorf("expected unknown, got %s", got)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
 	}
 }
 


### PR DESCRIPTION
A sweep after v0.3.1-dev.28 looked for the patterns that drove the previous five
releases — something reporting success without it being true — and found four
places they still applied.

## The self-update never verified its own result

`applySelfUpdate` built agent, api and web and restarted into them without ever
checking what it had built. The comment there deferred it to "dev.17+" because an
agent endpoint for image labels was missing; that endpoint has existed since
dev.24. So the one service that replaces the whole control plane was the only one
still trusting its build blindly — exactly the bug dev.24 fixed for ckpool and
ckstats.

`verifySelfBuild` now checks `org.opencontainers.image.version` against the target
after each build and refuses before the detached restart. A missing label
disqualifies on its own rather than falling through the equality check.

When a build or a verification is refused, the compose tags are put back. Step 2
rewrites them before building, so without the restore the file named a version
whose images had just been rejected — and since all three services carry a
`build:` block, a later `docker compose up` would have rebuilt them without the
VERSION arg and stamped `dev` into the label. The same lie through another door.

## Seventeen client methods threw away the reason

The agent returns both an error and its output; the output holds the git message,
the build log, the command's stderr. Two methods read it. That is why a failing
ckstats update showed `git checkout failed: exit status 1` twice while the cause
sat in a field nobody read, and it cost a full release round to dig out. All of
them now go through one `agentError` helper, which also removes the duplication
the two correct ones had.

## The image tag contradicted its contents

ckpool ran as `truffels/ckpool:v1.0.0` carrying a `v1.2.0` build. `RewriteTags`
was skipped for built services, and their templates had no `Images` to rewrite —
while the truffels stack, also `NeedsBuild`, had them and did it correctly. Both
templates now declare their image, and `applyNeedsBuild` rewrites the tag in the
right order: stage the rollback image from the file first, then rewrite, then
build, then verify — and put the old tag back on every failure path after the
rewrite.

## An unprovable version claimed to be one

`ExtractCurrentVersion` returned the literal string "unknown", which is not empty,
so every `!= ""` check treated it as a real version and it travelled into update
logs, the UI and rollback comparisons. It returns "" now.

Lint clean on both modules, full suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)