### PR TITLE
Simplify the agent client, the update engine and the agent's command plumbing

### DIFF
--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Characterization tests for the handlers whose only untested part was the
+// external command they run: what gets executed, what the caller sees when it
+// fails, and — for git checkout — what a successful run returns.
+//
+// These pin the observable surface (status code, error prefix, which keys are
+// present) around every command site that the runCapture/runStdout refactor
+// rewrites, so the same assertions hold before and after it.
+//
+// The suite runs in a container without a docker CLI, which is what makes the
+// failure paths reachable at all. Where the outcome would differ on a host that
+// does have docker, the assertion is written to hold in both worlds and the
+// docker-less expectation is guarded by exec.LookPath.
+
+func dockerMissing() bool {
+	_, err := exec.LookPath("docker")
+	return err != nil
+}
+
+// --- inspectContainer ---
+
+func TestInspectContainer_ReportsNotFoundWhenTheCommandFails(t *testing.T) {
+	cs := inspectContainer("truffels-bitcoind")
+
+	if cs.Name != "truffels-bitcoind" {
+		t.Errorf("name = %q, want the requested container", cs.Name)
+	}
+	if cs.Status == "" {
+		t.Error("status must never be empty — every return path sets it")
+	}
+	if dockerMissing() {
+		if cs.Status != "not_found" || cs.Health != "unknown" {
+			t.Errorf("docker unavailable: got status=%q health=%q, want not_found/unknown",
+				cs.Status, cs.Health)
+		}
+	}
+}
+
+// --- handleImagePull ---
+
+func TestHandleImagePull_SurfacesCommandFailure(t *testing.T) {
+	// A repository that cannot resolve, so the pull fails whether or not a
+	// docker CLI is present.
+	body, _ := json.Marshal(map[string]string{
+		"image": "truffels/agent-test-nonexistent:v0.0.0",
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(body))
+
+	handleImagePull(w, r)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] == "" {
+		t.Error("failure response must carry the command error")
+	}
+	if _, ok := resp["output"]; !ok {
+		t.Error("failure response must carry the command output")
+	}
+}
+
+// --- handleImageInspect ---
+
+func TestHandleImageInspect_AllowedContainerReachesDocker(t *testing.T) {
+	body, _ := json.Marshal(imageInspectRequest{Container: "truffels-bitcoind"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/inspect", bytes.NewReader(body))
+
+	handleImageInspect(w, r)
+
+	if w.Code == 400 || w.Code == 403 {
+		t.Fatalf("allowed container must get past the guard, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Code == 500 {
+		var resp map[string]string
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		if !strings.HasPrefix(resp["error"], "cannot inspect container: ") {
+			t.Errorf("error = %q, want the 'cannot inspect container: ' prefix", resp["error"])
+		}
+	}
+}
+
+// --- handleImageTag ---
+
+func TestHandleImageTag_AllowedRefsReachDockerTag(t *testing.T) {
+	// Both refs pass isAllowedImageRef; the source image does not exist, so the
+	// tag fails with or without a docker CLI.
+	body, _ := json.Marshal(map[string]string{
+		"source": "truffels/agent-test-nonexistent:src",
+		"target": "truffels/agent-test-nonexistent:dst",
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/tag", bytes.NewReader(body))
+
+	handleImageTag(w, r)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(resp["error"], "docker tag failed: ") {
+		t.Errorf("error = %q, want the 'docker tag failed: ' prefix", resp["error"])
+	}
+	if _, ok := resp["output"]; !ok {
+		t.Error("failure response must carry the command output")
+	}
+}
+
+// --- fetchDockerStorage ---
+
+func TestFetchDockerStorage_ReturnsNilWhenTheCommandFails(t *testing.T) {
+	items := fetchDockerStorage()
+
+	if dockerMissing() && items != nil {
+		t.Fatalf("docker unavailable: expected nil, got %v", items)
+	}
+	for _, it := range items {
+		if it.Type == "" {
+			t.Errorf("parsed row with empty type: %+v", it)
+		}
+	}
+}
+
+// --- fallbackContainerLogs ---
+
+func TestFallbackContainerLogs_UnknownServiceReturnsEmpty(t *testing.T) {
+	if got := fallbackContainerLogs(context.Background(), "not-a-service", 100, ""); got != "" {
+		t.Fatalf("unknown service must yield no logs, got %q", got)
+	}
+}
+
+func TestFallbackContainerLogs_PrefixesOnlyMultiContainerServices(t *testing.T) {
+	// mempool has two containers, so every line is tagged with its origin.
+	multi := fallbackContainerLogs(context.Background(), "mempool", 100, "")
+	for _, line := range strings.Split(multi, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "truffels-mempool-") {
+			t.Errorf("multi-container line is missing its container prefix: %q", line)
+		}
+	}
+
+	// bitcoind has one, so nothing is prefixed.
+	single := fallbackContainerLogs(context.Background(), "bitcoind", 100, "")
+	for _, line := range strings.Split(single, "\n") {
+		if strings.HasPrefix(line, "truffels-bitcoind  | ") {
+			t.Errorf("single-container line must not be prefixed: %q", line)
+		}
+	}
+}
+
+// --- handleGitCheckout, past the validators ---
+
+// allowRepoDir registers a temp repo as checkout-able for one test, the same
+// way registerResettable does for the reset path. It is deliberately NOT added
+// to resettableRepoDirs: that keeps these tests on the /repo code path, where
+// nothing is reset and nothing is removed.
+func allowRepoDir(t *testing.T, dir string) {
+	t.Helper()
+	allowedRepoDirs[dir] = true
+	t.Cleanup(func() { delete(allowedRepoDirs, dir) })
+}
+
+func TestHandleGitCheckout_SurfacesFetchFailure(t *testing.T) {
+	dir := t.TempDir() // allowed, but not a git repository
+	allowRepoDir(t, dir)
+
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: dir, Tag: "v0.0.1"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(resp["error"], "git fetch failed: ") {
+		t.Errorf("error = %q, want the 'git fetch failed: ' prefix", resp["error"])
+	}
+	if resp["output"] == "" {
+		t.Error("the git output is what tells the operator why it failed — it must be returned")
+	}
+}
+
+func TestHandleGitCheckout_ChecksOutTagFromLocalRemote(t *testing.T) {
+	// A real fetch and checkout end to end. The remote is a directory on local
+	// disk, so nothing touches the network.
+	upstream := t.TempDir()
+	git(t, upstream, "init", "-q", "-b", "main")
+	git(t, upstream, "config", "user.email", "t@example.invalid")
+	git(t, upstream, "config", "user.name", "t")
+	write(t, upstream, "README.md", "one\n")
+	git(t, upstream, "add", "README.md")
+	git(t, upstream, "commit", "-q", "-m", "first")
+	git(t, upstream, "tag", "v0.0.1")
+
+	work := t.TempDir()
+	git(t, work, "clone", "-q", upstream, work)
+	allowRepoDir(t, work)
+
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: work, Tag: "v0.0.1"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Fatalf("status = %q, want ok", resp["status"])
+	}
+	if _, ok := resp["output"]; !ok {
+		t.Error("success response must still carry the git output")
+	}
+
+	head := strings.TrimSpace(git(t, work, "rev-parse", "HEAD"))
+	tagged := strings.TrimSpace(git(t, upstream, "rev-parse", "v0.0.1^{commit}"))
+	if head != tagged {
+		t.Errorf("HEAD = %s, want the tagged commit %s", head, tagged)
+	}
+}

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -308,14 +308,12 @@ func handleComposeLogs(w http.ResponseWriter, r *http.Request) {
 		if req.Since != "" {
 			shellCmd = fmt.Sprintf("docker logs --tail %d --since %s %s 2>&1 | tail -c 65536", req.Tail, req.Since, req.Container)
 		}
-		cmd := exec.CommandContext(ctx, "sh", "-c", shellCmd)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		if err := cmd.Run(); err != nil {
+		out, err := runStdout(ctx, "sh", "-c", shellCmd)
+		if err != nil {
 			writeJSON(w, 500, map[string]string{"error": err.Error()})
 			return
 		}
-		cleaned := stripANSI(out.String())
+		cleaned := stripANSI(out)
 		writeJSON(w, 200, map[string]string{"logs": cleaned})
 		return
 	}
@@ -329,12 +327,8 @@ func handleComposeLogs(w http.ResponseWriter, r *http.Request) {
 	if req.Since != "" {
 		args = append(args, "--since", req.Since)
 	}
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err := cmd.Run()
-	cleaned := stripANSI(out.String())
+	out, err := runCapture(ctx, "docker", args...)
+	cleaned := stripANSI(out)
 
 	// If compose logs returned empty, fall back to docker logs for each container.
 	// This handles services like ckpool whose \r-heavy output breaks --tail.
@@ -373,15 +367,13 @@ func inspectContainer(name string) containerState {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{json .}}", name)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
+	out, err := runStdout(ctx, "docker", "inspect", "--format", "{{json .}}", name)
+	if err != nil {
 		return containerState{Name: name, Status: "not_found", Health: "unknown"}
 	}
 
 	var ir inspectResult
-	if err := json.Unmarshal(out.Bytes(), &ir); err != nil {
+	if err := json.Unmarshal([]byte(out), &ir); err != nil {
 		slog.Error("parse inspect", "container", name, "err", err)
 		return containerState{Name: name, Status: "unknown", Health: "unknown"}
 	}
@@ -420,15 +412,12 @@ func handleImagePull(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "pull", req.Image)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out.String()})
+	out, err := runCapture(ctx, "docker", "pull", req.Image)
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out})
 		return
 	}
-	writeJSON(w, 200, map[string]string{"status": "ok", "output": out.String()})
+	writeJSON(w, 200, map[string]string{"status": "ok", "output": out})
 }
 
 // allowedImagePrefixes controls which images can be removed via /v1/image/remove.
@@ -467,13 +456,9 @@ func handleImageRemove(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "rmi", req.Image)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
+	errMsg, err := runCapture(ctx, "docker", "rmi", req.Image)
+	if err != nil {
 		// Best-effort: log warning but return OK for "in use" or "not found" errors
-		errMsg := out.String()
 		slog.Warn("image remove failed (best-effort)", "image", req.Image, "err", errMsg)
 		writeJSON(w, 200, map[string]string{"status": "ok", "warning": errMsg})
 		return
@@ -486,37 +471,24 @@ func handleDockerPrune(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
+	// Each prune is best-effort: a failure is logged and the next one still
+	// runs, and whatever it printed still counts towards the reclaimed total.
+	prunes := []struct {
+		name string
+		args []string
+	}{
+		{"builder prune", []string{"builder", "prune", "-a", "-f"}},
+		{"image prune", []string{"image", "prune", "-a", "-f"}},
+		{"system prune", []string{"system", "prune", "-f"}},
+	}
 	var totalReclaimed bytes.Buffer
-
-	// Builder prune
-	cmd := exec.CommandContext(ctx, "docker", "builder", "prune", "-a", "-f")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		slog.Warn("builder prune failed", "err", err)
+	for _, p := range prunes {
+		out, err := runCapture(ctx, "docker", p.args...)
+		if err != nil {
+			slog.Warn(p.name+" failed", "err", err)
+		}
+		totalReclaimed.WriteString(out)
 	}
-	totalReclaimed.WriteString(out.String())
-
-	// Image prune
-	out.Reset()
-	cmd = exec.CommandContext(ctx, "docker", "image", "prune", "-a", "-f")
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		slog.Warn("image prune failed", "err", err)
-	}
-	totalReclaimed.WriteString(out.String())
-
-	// System prune
-	out.Reset()
-	cmd = exec.CommandContext(ctx, "docker", "system", "prune", "-f")
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		slog.Warn("system prune failed", "err", err)
-	}
-	totalReclaimed.WriteString(out.String())
 
 	// Extract reclaimed sizes from output
 	reclaimed := "unknown"
@@ -546,17 +518,14 @@ func handleDockerPruneBuildCache(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "builder", "prune", "-a", "-f")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
+	out, err := runCapture(ctx, "docker", "builder", "prune", "-a", "-f")
+	if err != nil {
 		writeJSON(w, 500, map[string]string{"error": "builder prune failed: " + err.Error()})
 		return
 	}
 
 	reclaimed := "unknown"
-	for _, line := range strings.Split(out.String(), "\n") {
+	for _, line := range strings.Split(out, "\n") {
 		if strings.Contains(line, "reclaimed") {
 			reclaimed = strings.TrimSpace(line)
 			break
@@ -599,15 +568,13 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Get image name from container
-	cmd := exec.CommandContext(ctx, "docker", "inspect", "--format",
+	imageOut, err := runStdout(ctx, "docker", "inspect", "--format",
 		"{{.Config.Image}}", req.Container)
-	var imageOut bytes.Buffer
-	cmd.Stdout = &imageOut
-	if err := cmd.Run(); err != nil {
+	if err != nil {
 		writeJSON(w, 500, map[string]string{"error": "cannot inspect container: " + err.Error()})
 		return
 	}
-	imageName := strings.TrimSpace(imageOut.String())
+	imageName := strings.TrimSpace(imageOut)
 
 	writeJSON(w, 200, inspectImageByName(ctx, imageName))
 }
@@ -617,14 +584,11 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 // than as a failure, which is what the digest/tag lookups have always done.
 func inspectImageByName(ctx context.Context, imageName string) imageInspectResponse {
 	// Get image digest
-	cmd2 := exec.CommandContext(ctx, "docker", "inspect", "--format",
+	digestOut, err := runCapture(ctx, "docker", "inspect", "--format",
 		"{{index .RepoDigests 0}}", imageName)
-	var digestOut bytes.Buffer
-	cmd2.Stdout = &digestOut
-	cmd2.Stderr = &digestOut
 	digest := ""
-	if err := cmd2.Run(); err == nil {
-		digest = strings.TrimSpace(digestOut.String())
+	if err == nil {
+		digest = strings.TrimSpace(digestOut)
 		// Extract just the digest part after @
 		if idx := strings.Index(digest, "@"); idx >= 0 {
 			digest = digest[idx+1:]
@@ -632,23 +596,19 @@ func inspectImageByName(ctx context.Context, imageName string) imageInspectRespo
 	}
 
 	// Get tags
-	cmd3 := exec.CommandContext(ctx, "docker", "inspect", "--format",
+	tagsOut, err := runStdout(ctx, "docker", "inspect", "--format",
 		"{{json .RepoTags}}", imageName)
-	var tagsOut bytes.Buffer
-	cmd3.Stdout = &tagsOut
 	var tags []string
-	if cmd3.Run() == nil {
-		_ = json.Unmarshal(bytes.TrimSpace(tagsOut.Bytes()), &tags)
+	if err == nil {
+		_ = json.Unmarshal([]byte(strings.TrimSpace(tagsOut)), &tags)
 	}
 
 	// Get labels — carries org.truffels.source-ref, the ref the image was built from.
-	cmd4 := exec.CommandContext(ctx, "docker", "inspect", "--format",
+	labelsOut, err := runStdout(ctx, "docker", "inspect", "--format",
 		"{{json .Config.Labels}}", imageName)
-	var labelsOut bytes.Buffer
-	cmd4.Stdout = &labelsOut
 	labels := map[string]string{}
-	if cmd4.Run() == nil {
-		_ = json.Unmarshal(bytes.TrimSpace(labelsOut.Bytes()), &labels)
+	if err == nil {
+		_ = json.Unmarshal([]byte(strings.TrimSpace(labelsOut)), &labels)
 	}
 
 	return imageInspectResponse{
@@ -720,12 +680,9 @@ func handleImageTag(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "docker", "tag", req.Source, req.Target)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		writeJSON(w, 500, map[string]string{"error": "docker tag failed: " + err.Error(), "output": out.String()})
+	out, err := runCapture(ctx, "docker", "tag", req.Source, req.Target)
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": "docker tag failed: " + err.Error(), "output": out})
 		return
 	}
 	slog.Info("image tagged", "source", req.Source, "target", req.Target)
@@ -764,18 +721,15 @@ func handleStats(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	args := append([]string{"stats", "--no-stream", "--format", "{{json .}}"}, names...)
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &bytes.Buffer{}
-	if err := cmd.Run(); err != nil {
+	out, err := runStdout(ctx, "docker", args...)
+	if err != nil {
 		slog.Error("docker stats", "err", err)
 		writeJSON(w, 500, map[string]string{"error": err.Error()})
 		return
 	}
 
 	var results []containerStats
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line == "" {
 			continue
 		}
@@ -899,17 +853,13 @@ func handleComposeBuild(w http.ResponseWriter, r *http.Request) {
 	var lastErr error
 	var lastOutput string
 	for attempt := 1; attempt <= composeBuildMaxAttempts; attempt++ {
-		var out bytes.Buffer
-		cmd := exec.CommandContext(ctx, "nsenter", nsArgs...)
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		err := cmd.Run()
+		out, err := runCapture(ctx, "nsenter", nsArgs...)
 		if err == nil {
-			writeJSON(w, 200, map[string]string{"status": "ok", "output": out.String()})
+			writeJSON(w, 200, map[string]string{"status": "ok", "output": out})
 			return
 		}
 		lastErr = err
-		lastOutput = out.String()
+		lastOutput = out
 		slog.Warn("compose build failed", "service", req.ServiceID, "attempt", attempt, "max", composeBuildMaxAttempts, "error", err.Error())
 		if attempt < composeBuildMaxAttempts {
 			select {
@@ -943,6 +893,33 @@ func decodeAndValidate(w http.ResponseWriter, r *http.Request, req *serviceReque
 	}
 	slog.Info("agent action", "action", strings.TrimPrefix(r.URL.Path, "/v1/compose/"), "service", req.ServiceID)
 	return true
+}
+
+// runCapture runs a command under ctx and returns its combined stdout+stderr
+// alongside the run error. The combined stream is what nearly every caller
+// reports back as "output": for docker and git the reason a command failed is
+// in what it printed, not in its exit status, so the two are always wanted
+// together.
+func runCapture(ctx context.Context, name string, args ...string) (string, error) {
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// runStdout is runCapture for the commands whose stderr must stay out of the
+// result: the log fetches, which already fold stderr into stdout inside the
+// shell, and the `docker inspect --format` lookups, whose output is parsed as
+// JSON and would be corrupted by a warning landing in the same buffer. stderr
+// is discarded, exactly as it was when these call sites set only cmd.Stdout.
+func runStdout(ctx context.Context, name string, args ...string) (string, error) {
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
 }
 
 func runCompose(composeDir string, args ...string) error {
@@ -1036,22 +1013,14 @@ func handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 
 	// nsrun enters mount namespace (filesystem access)
 	nsrun := func(args ...string) string {
-		a := append([]string{"-t", "1", "-m", "--"}, args...)
-		cmd := exec.CommandContext(ctx, "nsenter", a...)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		_ = cmd.Run()
-		return strings.TrimSpace(out.String())
+		out, _ := runStdout(ctx, "nsenter", append([]string{"-t", "1", "-m", "--"}, args...)...)
+		return strings.TrimSpace(out)
 	}
 
 	// nsrunAll enters mount + UTS + network namespaces
 	nsrunAll := func(args ...string) string {
-		a := append([]string{"-t", "1", "-m", "-u", "-n", "--"}, args...)
-		cmd := exec.CommandContext(ctx, "nsenter", a...)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		_ = cmd.Run()
-		return strings.TrimSpace(out.String())
+		out, _ := runStdout(ctx, "nsenter", append([]string{"-t", "1", "-m", "-u", "-n", "--"}, args...)...)
+		return strings.TrimSpace(out)
 	}
 
 	// Hostname (needs UTS namespace)
@@ -1325,14 +1294,12 @@ func walkDockerStorageForever(c *dockerStorageCache) {
 func fetchDockerStorage() []dockerStorageItem {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "docker", "system", "df", "--format", "{{json .}}")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
+	out, err := runStdout(ctx, "docker", "system", "df", "--format", "{{json .}}")
+	if err != nil {
 		return nil
 	}
 	var items []dockerStorageItem
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line == "" {
 			continue
 		}
@@ -1518,21 +1485,17 @@ func handleSystemJournal(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "nsenter", args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
+	out, err := runCapture(ctx, "nsenter", args...)
+	if err != nil {
 		// journalctl exits 1 when boot not found — return empty logs, not an error
-		text := out.String()
-		if strings.Contains(text, "no persistent journal") || strings.Contains(text, "No boot ID matched") || strings.Contains(text, "No journal boot entry found") {
+		if strings.Contains(out, "no persistent journal") || strings.Contains(out, "No boot ID matched") || strings.Contains(out, "No journal boot entry found") {
 			writeJSON(w, 200, map[string]string{"logs": ""})
 			return
 		}
-		writeJSON(w, 500, map[string]string{"error": err.Error(), "logs": text})
+		writeJSON(w, 500, map[string]string{"error": err.Error(), "logs": out})
 		return
 	}
-	writeJSON(w, 200, map[string]string{"logs": out.String()})
+	writeJSON(w, 200, map[string]string{"logs": out})
 }
 
 type bootEntry struct {
@@ -1554,25 +1517,19 @@ func handleSystemTuningGet(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Check if persistent journal is configured via drop-in
-	cmd1 := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
+	_, testErr := runStdout(ctx, "nsenter", "-t", "1", "-m", "--",
 		"test", "-f", "/etc/systemd/journald.conf.d/truffels.conf")
-	persistent := cmd1.Run() == nil
+	persistent := testErr == nil
 
 	// Read swappiness
-	cmd2 := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
+	swapOut, _ := runStdout(ctx, "nsenter", "-t", "1", "-m", "--",
 		"cat", "/proc/sys/vm/swappiness")
-	var swapOut bytes.Buffer
-	cmd2.Stdout = &swapOut
-	_ = cmd2.Run()
-	swappiness, _ := strconv.Atoi(strings.TrimSpace(swapOut.String()))
+	swappiness, _ := strconv.Atoi(strings.TrimSpace(swapOut))
 
 	// Journal disk usage
-	cmd3 := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
+	usageOut, _ := runStdout(ctx, "nsenter", "-t", "1", "-m", "--",
 		"journalctl", "--disk-usage")
-	var usageOut bytes.Buffer
-	cmd3.Stdout = &usageOut
-	_ = cmd3.Run()
-	usage := strings.TrimSpace(usageOut.String())
+	usage := strings.TrimSpace(usageOut)
 	// Extract just the size part, e.g. "Archived and active journals take up 8.0M in the file system."
 	if idx := strings.Index(usage, "take up "); idx >= 0 {
 		rest := usage[idx+8:]
@@ -1582,13 +1539,10 @@ func handleSystemTuningGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// List available boots
-	cmd4 := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
+	bootsOut, _ := runStdout(ctx, "nsenter", "-t", "1", "-m", "--",
 		"journalctl", "--list-boots", "--no-pager")
-	var bootsOut bytes.Buffer
-	cmd4.Stdout = &bootsOut
-	_ = cmd4.Run()
 	var boots []bootEntry
-	for _, line := range strings.Split(bootsOut.String(), "\n") {
+	for _, line := range strings.Split(bootsOut, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "IDX") {
 			continue
@@ -1638,18 +1592,16 @@ func handleSystemTuningSet(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Value == "true" {
 			// Create persistent journal dir, set Storage=persistent via drop-in, restart journald
-			cmd := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
-				"sh", "-c", "mkdir -p /var/log/journal && systemd-tmpfiles --create --prefix /var/log/journal && mkdir -p /etc/systemd/journald.conf.d && printf '[Journal]\\nStorage=persistent\\n' > /etc/systemd/journald.conf.d/truffels.conf && systemctl restart systemd-journald")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				writeJSON(w, 500, map[string]string{"error": err.Error(), "output": string(out)})
+			if out, err := runCapture(ctx, "nsenter", "-t", "1", "-m", "--",
+				"sh", "-c", "mkdir -p /var/log/journal && systemd-tmpfiles --create --prefix /var/log/journal && mkdir -p /etc/systemd/journald.conf.d && printf '[Journal]\\nStorage=persistent\\n' > /etc/systemd/journald.conf.d/truffels.conf && systemctl restart systemd-journald"); err != nil {
+				writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out})
 				return
 			}
 		} else {
 			// Remove persistent journal dir + drop-in config, restart journald
-			cmd := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--",
-				"sh", "-c", "rm -rf /var/log/journal && rm -f /etc/systemd/journald.conf.d/truffels.conf && systemctl restart systemd-journald")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				writeJSON(w, 500, map[string]string{"error": err.Error(), "output": string(out)})
+			if out, err := runCapture(ctx, "nsenter", "-t", "1", "-m", "--",
+				"sh", "-c", "rm -rf /var/log/journal && rm -f /etc/systemd/journald.conf.d/truffels.conf && systemctl restart systemd-journald"); err != nil {
+				writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out})
 				return
 			}
 		}
@@ -1664,9 +1616,8 @@ func handleSystemTuningSet(w http.ResponseWriter, r *http.Request) {
 		script := fmt.Sprintf(
 			"sysctl -w vm.swappiness=%d && mkdir -p /etc/sysctl.d && echo 'vm.swappiness=%d' > /etc/sysctl.d/90-truffels.conf",
 			val, val)
-		cmd := exec.CommandContext(ctx, "nsenter", "-t", "1", "-m", "--", "sh", "-c", script)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			writeJSON(w, 500, map[string]string{"error": err.Error(), "output": string(out)})
+		if out, err := runCapture(ctx, "nsenter", "-t", "1", "-m", "--", "sh", "-c", script); err != nil {
+			writeJSON(w, 500, map[string]string{"error": err.Error(), "output": out})
 			return
 		}
 
@@ -1763,12 +1714,8 @@ func prepareBuildSourceForCheckout(ctx context.Context, repoDir string) (string,
 	var log bytes.Buffer
 	for _, args := range steps {
 		full := append([]string{"-c", "safe.directory=*", "-C", repoDir}, args...)
-		cmd := exec.CommandContext(ctx, "git", full...)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		err := cmd.Run()
-		log.WriteString(out.String())
+		out, err := runCapture(ctx, "git", full...)
+		log.WriteString(out)
 		if err != nil {
 			return log.String(), fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 		}
@@ -1959,12 +1906,9 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch tags (safe.directory needed: agent runs as root, repo owned by uid 1000)
-	fetchCmd := exec.CommandContext(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "fetch", "--tags", "--force")
-	var fetchOut bytes.Buffer
-	fetchCmd.Stdout = &fetchOut
-	fetchCmd.Stderr = &fetchOut
-	if err := fetchCmd.Run(); err != nil {
-		writeJSON(w, 500, map[string]string{"error": "git fetch failed: " + err.Error(), "output": fetchOut.String()})
+	fetchOut, err := runCapture(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "fetch", "--tags", "--force")
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": "git fetch failed: " + err.Error(), "output": fetchOut})
 		return
 	}
 
@@ -1979,26 +1923,23 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			writeJSON(w, 500, map[string]string{
 				"error":  "git prepare failed: " + err.Error(),
-				"output": prepOut + fetchOut.String() + out,
+				"output": prepOut + fetchOut + out,
 			})
 			return
 		}
 	}
 
 	// Checkout tag
-	checkoutCmd := exec.CommandContext(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "checkout", req.Tag)
-	var checkoutOut bytes.Buffer
-	checkoutCmd.Stdout = &checkoutOut
-	checkoutCmd.Stderr = &checkoutOut
-	if err := checkoutCmd.Run(); err != nil {
+	checkoutOut, err := runCapture(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "checkout", req.Tag)
+	if err != nil {
 		writeJSON(w, 500, map[string]string{
 			"error":  "git checkout failed: " + err.Error(),
-			"output": prepOut + fetchOut.String() + collisionOut + checkoutOut.String(),
+			"output": prepOut + fetchOut + collisionOut + checkoutOut,
 		})
 		return
 	}
 
-	writeJSON(w, 200, map[string]string{"status": "ok", "output": prepOut + fetchOut.String() + collisionOut + checkoutOut.String()})
+	writeJSON(w, 200, map[string]string{"status": "ok", "output": prepOut + fetchOut + collisionOut + checkoutOut})
 }
 
 func isValidTag(tag string) bool {
@@ -2494,13 +2435,11 @@ func fallbackContainerLogs(ctx context.Context, serviceID string, tail int, sinc
 		if since != "" {
 			shellCmd = fmt.Sprintf("docker logs --since %s %s 2>&1 | tail -c 65536", since, name)
 		}
-		cmd := exec.CommandContext(ctx, "sh", "-c", shellCmd)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		if err := cmd.Run(); err != nil {
+		out, err := runStdout(ctx, "sh", "-c", shellCmd)
+		if err != nil {
 			continue
 		}
-		cleaned := stripANSI(out.String())
+		cleaned := stripANSI(out)
 		// Split on \n, take last N lines
 		lines := strings.Split(strings.TrimRight(cleaned, "\n"), "\n")
 		if len(lines) > tail {

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -43,7 +43,7 @@ func newMockAgent(t *testing.T, state *mockAgentState) *httptest.Server {
 				"model": "Raspberry Pi 5", "cpu_cores": 4,
 				"mem_total": "8063 MB", "mem_free": "4000 MB", "uptime": "1d 2h",
 				"networks": []map[string]string{
-					{"name": "wlan0", "ip": "192.168.0.196/16", "mac": "aa:bb:cc:dd:ee:ff"},
+					{"name": "wlan0", "ip": "192.0.2.10/24", "mac": "aa:bb:cc:dd:ee:ff"},
 				},
 			})
 

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -10,6 +10,14 @@ import (
 	"time"
 )
 
+const (
+	// defaultTimeout bounds an ordinary agent call.
+	defaultTimeout = 6 * time.Minute
+	// buildTimeout covers image pulls and builds, which routinely outrun the
+	// default budget on a Pi.
+	buildTimeout = 20 * time.Minute
+)
+
 type ComposeClient struct {
 	agentURL   string
 	httpClient *http.Client
@@ -19,7 +27,7 @@ func NewComposeClient(agentURL string) *ComposeClient {
 	return &ComposeClient{
 		agentURL: agentURL,
 		httpClient: &http.Client{
-			Timeout: 6 * time.Minute,
+			Timeout: defaultTimeout,
 		},
 	}
 }
@@ -42,6 +50,18 @@ type agentResponse struct {
 	Output string `json:"output"`
 }
 
+// agentResult is the agent's other reply shape, used by the endpoints that
+// answer with a concrete payload field instead of the logs/output envelope.
+// These deliberately do not go through agentError: they surface only the error
+// line, which is what their callers have always shown.
+type agentResult struct {
+	Status    string `json:"status"`
+	Error     string `json:"error"`
+	Changed   bool   `json:"changed"`
+	Reclaimed string `json:"reclaimed"`
+	Content   string `json:"content"`
+}
+
 // agentError builds an error from a failed agent response. ar.Error alone is
 // often just an exit status ("git checkout failed: exit status 1" / "build
 // failed: exit status 1"); the actual diagnosis — which untracked files were
@@ -60,6 +80,136 @@ func agentError(op string, ar agentResponse) error {
 		msg += "\n" + out
 	}
 	return fmt.Errorf("%s: %s", op, msg)
+}
+
+// agentReq describes one call to the agent: where it goes, what it carries, and
+// the three knobs that a handful of endpoints need.
+type agentReq struct {
+	// path is appended to agentURL and may carry a query string.
+	path string
+	// payload is marshalled as the JSON request body. A nil payload makes the
+	// call a GET.
+	payload any
+	// extraOK is a second status code to accept besides 200. Only the detached
+	// compose up needs it: it answers 202 before the work has finished.
+	extraOK int
+	// timeout replaces the shared client's budget for this one call.
+	timeout time.Duration
+	// decodeOp overrides the operation name used when an accepted response
+	// fails to parse. Only the tuning endpoint needs it: its decode error has
+	// always read "agent tuning decode", not "agent tuning get decode".
+	decodeOp string
+}
+
+func (r agentReq) accepts(status int) bool {
+	return status == 200 || (r.extraOK != 0 && status == r.extraOK)
+}
+
+func (r agentReq) decodeOpFor(op string) string {
+	if r.decodeOp != "" {
+		return r.decodeOp
+	}
+	return op + " decode"
+}
+
+// send performs the request described by r. Transport failures are wrapped with
+// op and %w, so callers can still reach the underlying *url.Error. On success
+// the caller owns the response body.
+func (c *ComposeClient) send(op string, r agentReq) (*http.Response, error) {
+	client := c.httpClient
+	if r.timeout > 0 {
+		client = &http.Client{Timeout: r.timeout}
+	}
+
+	var (
+		resp *http.Response
+		err  error
+	)
+	if r.payload == nil {
+		resp, err = client.Get(c.agentURL + r.path)
+	} else {
+		body, _ := json.Marshal(r.payload)
+		resp, err = client.Post(c.agentURL+r.path, "application/json", bytes.NewReader(body))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return resp, nil
+}
+
+// call sends r and returns the decoded agent envelope. A rejected status yields
+// an agentError, which keeps the agent's output in the message. The envelope is
+// returned in that case too — Logs and SystemJournal hand the partial text back
+// to their callers alongside the error. A body that will not parse is ignored:
+// only the status code decides.
+func (c *ComposeClient) call(op string, r agentReq) (agentResponse, error) {
+	resp, err := c.send(op, r)
+	if err != nil {
+		return agentResponse{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var ar agentResponse
+	_ = json.NewDecoder(resp.Body).Decode(&ar)
+	if !r.accepts(resp.StatusCode) {
+		return ar, agentError(op, ar)
+	}
+	return ar, nil
+}
+
+// callInto sends r and decodes an accepted response into out. A rejected status
+// is reported through agentError, a body that will not parse with the decode
+// operation name.
+func (c *ComposeClient) callInto(op string, r agentReq, out any) error {
+	resp, err := c.send(op, r)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !r.accepts(resp.StatusCode) {
+		var ar agentResponse
+		_ = json.NewDecoder(resp.Body).Decode(&ar)
+		return agentError(op, ar)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s: %w", r.decodeOpFor(op), err)
+	}
+	return nil
+}
+
+// callDecode sends r and decodes the body into out without consulting the
+// status code. The two host-info endpoints have always behaved this way: an
+// agent that answers with a parseable body is treated as a success even when it
+// reports a failure status.
+func (c *ComposeClient) callDecode(op string, r agentReq, out any) error {
+	resp, err := c.send(op, r)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s: %w", r.decodeOpFor(op), err)
+	}
+	return nil
+}
+
+// callResult sends r and returns the agent's payload reply. Failures report only
+// res.Error — these endpoints do not carry an output field to append.
+func (c *ComposeClient) callResult(op string, r agentReq) (agentResult, error) {
+	resp, err := c.send(op, r)
+	if err != nil {
+		return agentResult{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var res agentResult
+	_ = json.NewDecoder(resp.Body).Decode(&res)
+	if !r.accepts(resp.StatusCode) {
+		return agentResult{}, fmt.Errorf("%s: %s", op, res.Error)
+	}
+	return res, nil
 }
 
 type ImageInfo struct {
@@ -86,63 +236,41 @@ func (c *ComposeClient) Restart(serviceID string) error {
 }
 
 func (c *ComposeClient) Logs(serviceID string, tail int, since, container string) (string, error) {
-	body, _ := json.Marshal(agentLogsReq{ServiceID: serviceID, Tail: tail, Since: since, Container: container})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/compose/logs", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("agent logs: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return ar.Logs, agentError("agent logs", ar)
-	}
-	return ar.Logs, nil
+	ar, err := c.call("agent logs", agentReq{
+		path:    "/v1/compose/logs",
+		payload: agentLogsReq{ServiceID: serviceID, Tail: tail, Since: since, Container: container},
+	})
+	// ar.Logs is returned on both paths: a failed call still hands back
+	// whatever the agent managed to collect before giving up.
+	return ar.Logs, err
 }
 
 // Pull pulls a Docker image via the agent. Returns the docker pull output.
 func (c *ComposeClient) Pull(image string) (string, error) {
-	body, _ := json.Marshal(map[string]string{"image": image})
 	slog.Info("agent pull", "image", image)
 
-	longClient := &http.Client{Timeout: 20 * time.Minute}
-	resp, err := longClient.Post(c.agentURL+"/v1/image/pull", "application/json", bytes.NewReader(body))
+	// agentError keeps the tail of ar.Output. A failed pull says why in it —
+	// manifest unknown, no space left, auth required — and that text is what
+	// reaches the update log and the alert.
+	ar, err := c.call("agent pull", agentReq{
+		path:    "/v1/image/pull",
+		payload: map[string]string{"image": image},
+		timeout: buildTimeout,
+	})
 	if err != nil {
-		return "", fmt.Errorf("agent pull: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		// agentError keeps the tail of ar.Output. A failed pull says why in it
-		// — manifest unknown, no space left, auth required — and that text is
-		// what reaches the update log and the alert.
-		return "", agentError("agent pull", ar)
+		return "", err
 	}
 	return ar.Output, nil
 }
 
 // ImageInspect returns image info for a running container via the agent.
 func (c *ComposeClient) ImageInspect(container string) (*ImageInfo, error) {
-	body, _ := json.Marshal(map[string]string{"container": container})
-
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/inspect", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("agent image inspect: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		var ar agentResponse
-		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, agentError("agent image inspect", ar)
-	}
-
 	var info ImageInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("agent image inspect decode: %w", err)
+	if err := c.callInto("agent image inspect", agentReq{
+		path:    "/v1/image/inspect",
+		payload: map[string]string{"container": container},
+	}, &info); err != nil {
+		return nil, err
 	}
 	return &info, nil
 }
@@ -152,23 +280,12 @@ func (c *ComposeClient) ImageInspect(container string) (*ImageInfo, error) {
 // absent (never started, or removed by a failed update), and the container-based
 // lookup then reports nothing at all.
 func (c *ComposeClient) ImageInspectByName(image string) (*ImageInfo, error) {
-	body, _ := json.Marshal(map[string]string{"image": image})
-
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/inspect-by-name", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("agent image inspect by name: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		var ar agentResponse
-		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, agentError("agent image inspect by name", ar)
-	}
-
 	var info ImageInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("agent image inspect by name decode: %w", err)
+	if err := c.callInto("agent image inspect by name", agentReq{
+		path:    "/v1/image/inspect-by-name",
+		payload: map[string]string{"image": image},
+	}, &info); err != nil {
+		return nil, err
 	}
 	return &info, nil
 }
@@ -176,58 +293,34 @@ func (c *ComposeClient) ImageInspectByName(image string) (*ImageInfo, error) {
 // ImageTag points target at the image currently behind source. Used to stage
 // and to restore the rollback generation of a custom-built service.
 func (c *ComposeClient) ImageTag(source, target string) error {
-	body, _ := json.Marshal(map[string]string{"source": source, "target": target})
 	slog.Info("agent image tag", "source", source, "target", target)
 
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/tag", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent image tag: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent image tag", ar)
-	}
-	return nil
+	_, err := c.call("agent image tag", agentReq{
+		path:    "/v1/image/tag",
+		payload: map[string]string{"source": source, "target": target},
+	})
+	return err
 }
 
 // Build runs docker compose build for a service via the agent.
 func (c *ComposeClient) Build(serviceID string) error {
-	body, _ := json.Marshal(agentServiceReq{ServiceID: serviceID})
 	slog.Info("agent build", "service", serviceID)
 
-	longClient := &http.Client{Timeout: 20 * time.Minute}
-	resp, err := longClient.Post(c.agentURL+"/v1/compose/build", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent build: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent build", ar)
-	}
-	return nil
+	_, err := c.call("agent build", agentReq{
+		path:    "/v1/compose/build",
+		payload: agentServiceReq{ServiceID: serviceID},
+		timeout: buildTimeout,
+	})
+	return err
 }
 
 // SystemAction sends a shutdown or restart command to the agent.
 func (c *ComposeClient) SystemAction(action string) error {
-	body, _ := json.Marshal(map[string]string{"action": action})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/system/"+action, "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent system %s: %w", action, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError(fmt.Sprintf("agent system %s", action), ar)
-	}
-	return nil
+	_, err := c.call("agent system "+action, agentReq{
+		path:    "/v1/system/" + action,
+		payload: map[string]string{"action": action},
+	})
+	return err
 }
 
 // BootEntry represents a journal boot entry.
@@ -299,14 +392,9 @@ type SystemInfo struct {
 
 // SystemInfoGet fetches host system info via the agent.
 func (c *ComposeClient) SystemInfoGet() (*SystemInfo, error) {
-	resp, err := c.httpClient.Get(c.agentURL + "/v1/system/info")
-	if err != nil {
-		return nil, fmt.Errorf("agent system info: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
 	var info SystemInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("agent system info decode: %w", err)
+	if err := c.callDecode("agent system info", agentReq{path: "/v1/system/info"}, &info); err != nil {
+		return nil, err
 	}
 	return &info, nil
 }
@@ -314,98 +402,63 @@ func (c *ComposeClient) SystemInfoGet() (*SystemInfo, error) {
 // HostDirSize asks the agent for the cached size of a data-dir path.
 // Returns (-1, false, nil) if the agent has not yet walked the path.
 func (c *ComposeClient) HostDirSize(path string) (int64, bool, error) {
-	resp, err := c.httpClient.Get(c.agentURL + "/v1/host/dir-size?path=" + url.QueryEscape(path))
-	if err != nil {
-		return 0, false, fmt.Errorf("agent dir-size: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
 	var out struct {
 		SizeBytes int64 `json:"size_bytes"`
 		Fresh     bool  `json:"fresh"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return 0, false, fmt.Errorf("agent dir-size decode: %w", err)
+	if err := c.callDecode("agent dir-size", agentReq{
+		path: "/v1/host/dir-size?path=" + url.QueryEscape(path),
+	}, &out); err != nil {
+		return 0, false, err
 	}
 	return out.SizeBytes, out.Fresh, nil
 }
 
 // SystemJournal fetches journalctl output via the agent.
 func (c *ComposeClient) SystemJournal(lines int, priority, unit, since string, boot int) (string, error) {
-	body, _ := json.Marshal(map[string]interface{}{
-		"lines": lines, "priority": priority, "unit": unit, "since": since, "boot": boot,
+	ar, err := c.call("agent journal", agentReq{
+		path: "/v1/system/journal",
+		payload: map[string]any{
+			"lines": lines, "priority": priority, "unit": unit, "since": since, "boot": boot,
+		},
 	})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/system/journal", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("agent journal: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return ar.Logs, agentError("agent journal", ar)
-	}
-	return ar.Logs, nil
+	// As with Logs, the partial text goes back to the caller either way.
+	return ar.Logs, err
 }
 
 // SystemTuningGet reads current host tuning values via the agent.
 func (c *ComposeClient) SystemTuningGet() (*SystemTuningInfo, error) {
-	resp, err := c.httpClient.Get(c.agentURL + "/v1/system/tuning")
-	if err != nil {
-		return nil, fmt.Errorf("agent tuning get: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		var ar agentResponse
-		_ = json.NewDecoder(resp.Body).Decode(&ar)
-		return nil, agentError("agent tuning get", ar)
-	}
-
 	var info SystemTuningInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("agent tuning decode: %w", err)
+	if err := c.callInto("agent tuning get", agentReq{
+		path:     "/v1/system/tuning",
+		decodeOp: "agent tuning decode",
+	}, &info); err != nil {
+		return nil, err
 	}
 	return &info, nil
 }
 
 // SystemTuningSet applies a tuning change via the agent.
 func (c *ComposeClient) SystemTuningSet(action, value string) error {
-	body, _ := json.Marshal(map[string]string{"action": action, "value": value})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/system/tuning", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent tuning set: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent tuning set", ar)
-	}
-	return nil
+	_, err := c.call("agent tuning set", agentReq{
+		path:    "/v1/system/tuning",
+		payload: map[string]string{"action": action, "value": value},
+	})
+	return err
 }
 
 // GitCheckout tells the agent to fetch and checkout a specific ref.
 // refScheme is "tag" or "commit"; empty means tag.
 func (c *ComposeClient) GitCheckout(repoDir, ref, refScheme string) error {
-	body, _ := json.Marshal(map[string]string{
-		"repo_dir": repoDir, "tag": ref, "ref_scheme": refScheme,
-	})
 	slog.Info("agent git checkout", "repo", repoDir, "ref", ref, "scheme", refScheme)
 
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/git/checkout", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent git checkout: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent git checkout", ar)
-	}
-	return nil
+	_, err := c.call("agent git checkout", agentReq{
+		path: "/v1/git/checkout",
+		payload: map[string]string{
+			"repo_dir": repoDir, "tag": ref, "ref_scheme": refScheme,
+		},
+	})
+	return err
 }
 
 // BuildWithArgs runs docker compose build with extra build args via the agent.
@@ -416,49 +469,35 @@ func (c *ComposeClient) BuildWithArgs(serviceID string, buildArgs map[string]str
 		BuildArgs map[string]string `json:"build_args,omitempty"`
 		Services  []string          `json:"services,omitempty"`
 	}
-	body, _ := json.Marshal(buildReq{ServiceID: serviceID, BuildArgs: buildArgs, Services: services})
 	slog.Info("agent build with args", "service", serviceID, "args", buildArgs, "services", services)
 
-	longClient := &http.Client{Timeout: 20 * time.Minute}
-	resp, err := longClient.Post(c.agentURL+"/v1/compose/build", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent build: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent build", ar)
-	}
-	return nil
+	// Shares Build's operation name, and therefore its error prefix.
+	_, err := c.call("agent build", agentReq{
+		path:    "/v1/compose/build",
+		payload: buildReq{ServiceID: serviceID, BuildArgs: buildArgs, Services: services},
+		timeout: buildTimeout,
+	})
+	return err
 }
 
 // ComposeUpDetached triggers a detached compose up via nsenter on the host.
 // This is used for self-updates where the agent container will be replaced.
 // Returns immediately with 202 Accepted.
 func (c *ComposeClient) ComposeUpDetached(serviceID string) error {
-	body, _ := json.Marshal(map[string]string{"service_id": serviceID})
 	slog.Info("agent compose up detached", "service", serviceID)
 
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/compose/up-detached", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent compose up detached: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		return agentError("agent compose up detached", ar)
-	}
-	return nil
+	_, err := c.call("agent compose up detached", agentReq{
+		path:    "/v1/compose/up-detached",
+		payload: map[string]string{"service_id": serviceID},
+		extraOK: 202,
+	})
+	return err
 }
 
 // RewriteTags rewrites image tags in a compose file via the agent.
 // oldTag is optional — if empty, the agent matches any current tag (idempotent).
 func (c *ComposeClient) RewriteTags(serviceID string, images []string, oldTag, newTag string) error {
-	req := map[string]interface{}{
+	req := map[string]any{
 		"service_id": serviceID,
 		"images":     images,
 		"new_tag":    newTag,
@@ -466,238 +505,123 @@ func (c *ComposeClient) RewriteTags(serviceID string, images []string, oldTag, n
 	if oldTag != "" {
 		req["old_tag"] = oldTag
 	}
-	body, _ := json.Marshal(req)
 	slog.Info("agent rewrite tags", "service", serviceID, "old", oldTag, "new", newTag)
 
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/compose/rewrite-tags", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent rewrite tags: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent rewrite tags", ar)
-	}
-	return nil
+	_, err := c.call("agent rewrite tags", agentReq{
+		path:    "/v1/compose/rewrite-tags",
+		payload: req,
+	})
+	return err
 }
 
 // RemoveImage removes a Docker image via the agent (best-effort).
 func (c *ComposeClient) RemoveImage(image string) error {
-	body, _ := json.Marshal(map[string]string{"image": image})
 	slog.Info("agent remove image", "image", image)
 
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/image/remove", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent remove image: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent remove image", ar)
-	}
-	return nil
+	_, err := c.call("agent remove image", agentReq{
+		path:    "/v1/image/remove",
+		payload: map[string]string{"image": image},
+	})
+	return err
 }
 
 // FsEnsureDir creates a directory under the agent's dataRoot with the requested
 // ownership and mode. Idempotent. Used by the compose reconciler to guarantee
 // bind-mount source paths exist before bringing a service up.
 func (c *ComposeClient) FsEnsureDir(path string, uid, gid int, mode string) error {
-	body, _ := json.Marshal(map[string]interface{}{
-		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	_, err := c.call("agent ensure-dir", agentReq{
+		path: "/v1/fs/ensure-dir",
+		payload: map[string]any{
+			"path": path, "uid": uid, "gid": gid, "mode": mode,
+		},
 	})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/fs/ensure-dir", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent ensure-dir: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent ensure-dir", ar)
-	}
-	return nil
+	return err
 }
 
 // FsClearDir empties a directory under the agent's dataRoot and recreates it
 // with the requested ownership/mode. The agent enforces a basename+depth
 // allowlist; callers must ensure the path is one we want to expose.
 func (c *ComposeClient) FsClearDir(path string, uid, gid int, mode string) error {
-	body, _ := json.Marshal(map[string]interface{}{
-		"path": path, "uid": uid, "gid": gid, "mode": mode,
+	_, err := c.call("agent clear-dir", agentReq{
+		path: "/v1/fs/clear-dir",
+		payload: map[string]any{
+			"path": path, "uid": uid, "gid": gid, "mode": mode,
+		},
 	})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/fs/clear-dir", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent clear-dir: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError("agent clear-dir", ar)
-	}
-	return nil
+	return err
 }
 
 // FileReconcile writes `content` to `path` via the agent's POST /v1/file/reconcile
 // endpoint. Used by the reconciler for config files (Caddyfile) that live outside
 // composeRoot. Returns (changed, error).
 func (c *ComposeClient) FileReconcile(path, content string) (bool, error) {
-	body, _ := json.Marshal(map[string]string{
-		"path":             path,
-		"expected_content": content,
+	res, err := c.callResult("agent file reconcile", agentReq{
+		path: "/v1/file/reconcile",
+		payload: map[string]string{
+			"path":             path,
+			"expected_content": content,
+		},
 	})
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/file/reconcile", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return false, fmt.Errorf("agent file reconcile: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	var result struct {
-		Status  string `json:"status"`
-		Error   string `json:"error"`
-		Changed bool   `json:"changed"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return false, fmt.Errorf("agent file reconcile: %s", result.Error)
-	}
-	return result.Changed, nil
+	return res.Changed, err
+}
+
+// ReconcileFile compares expected content with a file under the compose root via
+// the agent. The path is relative to /srv/truffels/compose/ (e.g.
+// "ckstats/Dockerfile"). Returns true if the file was changed.
+//
+// Same endpoint, payload and error text as FileReconcile, which takes an
+// absolute path outside composeRoot; the two differ only in what the caller is
+// expected to pass.
+func (c *ComposeClient) ReconcileFile(relativePath, content string) (bool, error) {
+	return c.FileReconcile(relativePath, content)
 }
 
 // DockerPrune runs a full docker cleanup via the agent (builder + image + system prune).
 func (c *ComposeClient) DockerPrune() (string, error) {
-	longClient := &http.Client{Timeout: 6 * time.Minute}
-	resp, err := longClient.Post(c.agentURL+"/v1/docker/prune", "application/json", bytes.NewReader([]byte("{}")))
-	if err != nil {
-		return "", fmt.Errorf("agent docker prune: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Status    string `json:"status"`
-		Error     string `json:"error"`
-		Reclaimed string `json:"reclaimed"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("agent docker prune: %s", result.Error)
-	}
-	return result.Reclaimed, nil
+	res, err := c.callResult("agent docker prune", agentReq{
+		path:    "/v1/docker/prune",
+		payload: map[string]any{},
+	})
+	return res.Reclaimed, err
 }
 
 // DockerPruneBuildCache runs only docker builder prune via the agent.
 func (c *ComposeClient) DockerPruneBuildCache() (string, error) {
-	longClient := &http.Client{Timeout: 6 * time.Minute}
-	resp, err := longClient.Post(c.agentURL+"/v1/docker/prune-buildcache", "application/json", bytes.NewReader([]byte("{}")))
-	if err != nil {
-		return "", fmt.Errorf("agent docker prune buildcache: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Status    string `json:"status"`
-		Error     string `json:"error"`
-		Reclaimed string `json:"reclaimed"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("agent docker prune buildcache: %s", result.Error)
-	}
-	return result.Reclaimed, nil
+	res, err := c.callResult("agent docker prune buildcache", agentReq{
+		path:    "/v1/docker/prune-buildcache",
+		payload: map[string]any{},
+	})
+	return res.Reclaimed, err
 }
 
 // ComposeRead returns the content of a service's compose file via the agent.
 func (c *ComposeClient) ComposeRead(serviceID string) (string, error) {
-	body, _ := json.Marshal(agentServiceReq{ServiceID: serviceID})
-
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/compose/read", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("agent compose read: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Status  string `json:"status"`
-		Error   string `json:"error"`
-		Content string `json:"content"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("agent compose read: %s", result.Error)
-	}
-	return result.Content, nil
+	res, err := c.callResult("agent compose read", agentReq{
+		path:    "/v1/compose/read",
+		payload: agentServiceReq{ServiceID: serviceID},
+	})
+	return res.Content, err
 }
 
 // ComposeReconcile compares expected content with the compose file on disk via the agent.
 // Returns true if the file was changed.
 func (c *ComposeClient) ComposeReconcile(serviceID, expectedContent string) (bool, error) {
-	body, _ := json.Marshal(map[string]string{
-		"service_id":       serviceID,
-		"expected_content": expectedContent,
+	res, err := c.callResult("agent compose reconcile", agentReq{
+		path: "/v1/compose/reconcile",
+		payload: map[string]string{
+			"service_id":       serviceID,
+			"expected_content": expectedContent,
+		},
 	})
-
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/compose/reconcile", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return false, fmt.Errorf("agent compose reconcile: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Status  string `json:"status"`
-		Error   string `json:"error"`
-		Changed bool   `json:"changed"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return false, fmt.Errorf("agent compose reconcile: %s", result.Error)
-	}
-	return result.Changed, nil
-}
-
-// ReconcileFile compares expected content with a file under the compose root via the agent.
-// The path is relative to /srv/truffels/compose/ (e.g. "ckstats/Dockerfile").
-// Returns true if the file was changed.
-func (c *ComposeClient) ReconcileFile(relativePath, content string) (bool, error) {
-	body, _ := json.Marshal(map[string]string{
-		"path":             relativePath,
-		"expected_content": content,
-	})
-
-	resp, err := c.httpClient.Post(c.agentURL+"/v1/file/reconcile", "application/json", bytes.NewReader(body))
-	if err != nil {
-		return false, fmt.Errorf("agent file reconcile: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var result struct {
-		Status  string `json:"status"`
-		Error   string `json:"error"`
-		Changed bool   `json:"changed"`
-	}
-	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if resp.StatusCode != 200 {
-		return false, fmt.Errorf("agent file reconcile: %s", result.Error)
-	}
-	return result.Changed, nil
+	return res.Changed, err
 }
 
 func (c *ComposeClient) composeAction(path, serviceID string) error {
-	body, _ := json.Marshal(agentServiceReq{ServiceID: serviceID})
 	slog.Info("agent request", "path", path, "service", serviceID)
 
-	resp, err := c.httpClient.Post(c.agentURL+path, "application/json", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("agent %s: %w", path, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var ar agentResponse
-	_ = json.NewDecoder(resp.Body).Decode(&ar)
-	if resp.StatusCode != 200 {
-		return agentError(fmt.Sprintf("agent %s", path), ar)
-	}
-	return nil
+	_, err := c.call("agent "+path, agentReq{
+		path:    path,
+		payload: agentServiceReq{ServiceID: serviceID},
+	})
+	return err
 }

--- a/truffels-api/internal/docker/compose_characterization_test.go
+++ b/truffels-api/internal/docker/compose_characterization_test.go
@@ -1,0 +1,1073 @@
+package docker
+
+// Characterization tests for ComposeClient.
+//
+// These tests describe the behaviour of compose.go AS IT IS, not as it ought to
+// be. They were written before the client was refactored onto shared request
+// helpers, specifically so that the refactor could be proven behaviour-
+// preserving: the file is expected to stay byte-identical across that change.
+//
+// That means a few of the assertions below deliberately pin behaviour that
+// looks wrong:
+//
+//   - SystemInfoGet and HostDirSize never inspect the status code, so a 500 that
+//     still carries a JSON body is reported as success.
+//   - Logs and SystemJournal return the agent's partial log text alongside the
+//     error; Pull and ComposeRead return "" in the same situation.
+//   - The reconcile/prune/read family reports only ar.Error and drops the
+//     agent's output, while everything else routes through agentError and keeps
+//     it.
+//
+// If one of these has to change, that is a behaviour change and belongs in its
+// own commit with its own reasoning — not a silent edit during a cleanup.
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- harness ---------------------------------------------------------------
+
+// recordedRequest captures what the fake agent received.
+type recordedRequest struct {
+	path     string
+	method   string
+	rawQuery string
+	body     []byte
+}
+
+// newFakeAgent starts a stub agent that records the request it gets and answers
+// with the given status and JSON body. Returns a client pointed at it.
+func newFakeAgent(t *testing.T, status int, respBody any) (*ComposeClient, *recordedRequest) {
+	t.Helper()
+	rec := &recordedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.path = r.URL.Path
+		rec.method = r.Method
+		rec.rawQuery = r.URL.RawQuery
+		rec.body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return NewComposeClient(srv.URL), rec
+}
+
+// newRawAgent starts a stub agent answering with a literal body, for the
+// malformed-JSON cases.
+func newRawAgent(t *testing.T, status int, raw string) *ComposeClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, raw)
+	}))
+	t.Cleanup(srv.Close)
+	return NewComposeClient(srv.URL)
+}
+
+// unreachableAgent points the client at a port nothing listens on, so every
+// call fails at the transport layer.
+func unreachableAgent() *ComposeClient {
+	return NewComposeClient("http://127.0.0.1:1")
+}
+
+// assertJSONBody compares a recorded request body against an expected value,
+// normalising both through JSON so that numeric types and key order do not
+// matter.
+func assertJSONBody(t *testing.T, got []byte, want any) {
+	t.Helper()
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+	var gotAny, wantAny any
+	if err := json.Unmarshal(got, &gotAny); err != nil {
+		t.Fatalf("request body is not valid JSON: %v (%q)", err, got)
+	}
+	if err := json.Unmarshal(wantJSON, &wantAny); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	if !reflect.DeepEqual(gotAny, wantAny) {
+		t.Errorf("request body mismatch\n got: %s\nwant: %s", got, wantJSON)
+	}
+}
+
+func assertContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err, want)
+	}
+}
+
+// The agent's diagnosis marker: methods that route failures through agentError
+// must carry it into the returned error, the others must not.
+const diagnosisMarker = "DIAGNOSIS-FROM-AGENT-OUTPUT"
+
+func failureBody() map[string]string {
+	return map[string]string{
+		"error":  "op failed: exit status 1",
+		"output": diagnosisMarker,
+	}
+}
+
+// --- constructor -----------------------------------------------------------
+
+func TestCharacterize_NewComposeClient(t *testing.T) {
+	c := NewComposeClient("http://agent:9000")
+	if c.agentURL != "http://agent:9000" {
+		t.Errorf("agentURL = %q", c.agentURL)
+	}
+	if c.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+	// The shared client's timeout is the default for every call that does not
+	// explicitly ask for a longer one.
+	if c.httpClient.Timeout != 6*time.Minute {
+		t.Errorf("default timeout = %v, want 6m", c.httpClient.Timeout)
+	}
+}
+
+// --- POST, 200 expected, error-only result, agentError on failure ----------
+
+// errorOnlyCase describes one method whose entire contract is "POST this body
+// to this path; return nil on 200, an agentError otherwise".
+type errorOnlyCase struct {
+	name     string
+	wantPath string
+	wantBody any
+	// wantOp is the exact prefix of the returned error, on both the agent-error
+	// and the transport-error path. These strings reach the update log and the
+	// UI, so they are part of the observable surface.
+	wantOp string
+	call   func(*ComposeClient) error
+}
+
+func errorOnlyCases() []errorOnlyCase {
+	return []errorOnlyCase{
+		{
+			name: "Up", wantPath: "/v1/compose/up",
+			wantBody: map[string]any{"service_id": "bitcoind"},
+			wantOp:   "agent /v1/compose/up",
+			call:     func(c *ComposeClient) error { return c.Up("bitcoind") },
+		},
+		{
+			name: "Down", wantPath: "/v1/compose/down",
+			wantBody: map[string]any{"service_id": "bitcoind"},
+			wantOp:   "agent /v1/compose/down",
+			call:     func(c *ComposeClient) error { return c.Down("bitcoind") },
+		},
+		{
+			name: "Stop", wantPath: "/v1/compose/stop",
+			wantBody: map[string]any{"service_id": "electrs"},
+			wantOp:   "agent /v1/compose/stop",
+			call:     func(c *ComposeClient) error { return c.Stop("electrs") },
+		},
+		{
+			name: "Restart", wantPath: "/v1/compose/restart",
+			wantBody: map[string]any{"service_id": "electrs"},
+			wantOp:   "agent /v1/compose/restart",
+			call:     func(c *ComposeClient) error { return c.Restart("electrs") },
+		},
+		{
+			name: "ImageTag", wantPath: "/v1/image/tag",
+			wantBody: map[string]any{"source": "img:new", "target": "img:rollback"},
+			wantOp:   "agent image tag",
+			call:     func(c *ComposeClient) error { return c.ImageTag("img:new", "img:rollback") },
+		},
+		{
+			name: "Build", wantPath: "/v1/compose/build",
+			wantBody: map[string]any{"service_id": "truffels-api"},
+			wantOp:   "agent build",
+			call:     func(c *ComposeClient) error { return c.Build("truffels-api") },
+		},
+		{
+			// The op string interpolates the action, so shutdown and restart
+			// produce different error prefixes.
+			name: "SystemAction", wantPath: "/v1/system/restart",
+			wantBody: map[string]any{"action": "restart"},
+			wantOp:   "agent system restart",
+			call:     func(c *ComposeClient) error { return c.SystemAction("restart") },
+		},
+		{
+			name: "SystemTuningSet", wantPath: "/v1/system/tuning",
+			wantBody: map[string]any{"action": "swappiness", "value": "10"},
+			wantOp:   "agent tuning set",
+			call:     func(c *ComposeClient) error { return c.SystemTuningSet("swappiness", "10") },
+		},
+		{
+			name: "GitCheckout", wantPath: "/v1/git/checkout",
+			wantBody: map[string]any{"repo_dir": "/repo", "tag": "abc123", "ref_scheme": "commit"},
+			wantOp:   "agent git checkout",
+			call:     func(c *ComposeClient) error { return c.GitCheckout("/repo", "abc123", "commit") },
+		},
+		{
+			// Note the op is "agent build", not "agent build with args" — it
+			// shares Build's error prefix.
+			name: "BuildWithArgs", wantPath: "/v1/compose/build",
+			wantBody: map[string]any{
+				"service_id": "truffels-web",
+				"build_args": map[string]any{"VERSION": "v0.3.0"},
+				"services":   []any{"web"},
+			},
+			wantOp: "agent build",
+			call: func(c *ComposeClient) error {
+				return c.BuildWithArgs("truffels-web", map[string]string{"VERSION": "v0.3.0"}, "web")
+			},
+		},
+		{
+			name: "RewriteTags", wantPath: "/v1/compose/rewrite-tags",
+			wantBody: map[string]any{
+				"service_id": "mempool",
+				"images":     []any{"mempool/backend"},
+				"new_tag":    "v3.2.1",
+				"old_tag":    "v3.2.0",
+			},
+			wantOp: "agent rewrite tags",
+			call: func(c *ComposeClient) error {
+				return c.RewriteTags("mempool", []string{"mempool/backend"}, "v3.2.0", "v3.2.1")
+			},
+		},
+		{
+			name: "RemoveImage", wantPath: "/v1/image/remove",
+			wantBody: map[string]any{"image": "old:tag"},
+			wantOp:   "agent remove image",
+			call:     func(c *ComposeClient) error { return c.RemoveImage("old:tag") },
+		},
+		{
+			name: "FsEnsureDir", wantPath: "/v1/fs/ensure-dir",
+			wantBody: map[string]any{"path": "bitcoin", "uid": 1000, "gid": 1000, "mode": "0750"},
+			wantOp:   "agent ensure-dir",
+			call:     func(c *ComposeClient) error { return c.FsEnsureDir("bitcoin", 1000, 1000, "0750") },
+		},
+		{
+			name: "FsClearDir", wantPath: "/v1/fs/clear-dir",
+			wantBody: map[string]any{"path": "electrs", "uid": 1000, "gid": 1000, "mode": "0755"},
+			wantOp:   "agent clear-dir",
+			call:     func(c *ComposeClient) error { return c.FsClearDir("electrs", 1000, 1000, "0755") },
+		},
+		{
+			// ComposeUpDetached also accepts 202; the 200 path is checked here,
+			// the 202 path in its own test below.
+			name: "ComposeUpDetached", wantPath: "/v1/compose/up-detached",
+			wantBody: map[string]any{"service_id": "truffels-agent"},
+			wantOp:   "agent compose up detached",
+			call:     func(c *ComposeClient) error { return c.ComposeUpDetached("truffels-agent") },
+		},
+	}
+}
+
+func TestCharacterize_ErrorOnly_Success(t *testing.T) {
+	for _, tc := range errorOnlyCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok"})
+			if err := tc.call(c); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rec.method != http.MethodPost {
+				t.Errorf("method = %s, want POST", rec.method)
+			}
+			if rec.path != tc.wantPath {
+				t.Errorf("path = %s, want %s", rec.path, tc.wantPath)
+			}
+			assertJSONBody(t, rec.body, tc.wantBody)
+		})
+	}
+}
+
+func TestCharacterize_ErrorOnly_AgentFailure(t *testing.T) {
+	for _, tc := range errorOnlyCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newFakeAgent(t, 500, failureBody())
+			err := tc.call(c)
+			assertContains(t, err, tc.wantOp+": ")
+			assertContains(t, err, "exit status 1")
+			// Every method in this group routes through agentError, so the
+			// agent's own output has to survive into the message.
+			assertContains(t, err, diagnosisMarker)
+		})
+	}
+}
+
+func TestCharacterize_ErrorOnly_TransportFailure(t *testing.T) {
+	for _, tc := range errorOnlyCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call(unreachableAgent())
+			assertContains(t, err, tc.wantOp+": ")
+			// Transport errors are wrapped with %w, so callers can still reach
+			// the *url.Error underneath.
+			var urlErr *url.Error
+			if !errors.As(err, &urlErr) {
+				t.Errorf("transport error is not wrapped as *url.Error: %v", err)
+			}
+		})
+	}
+}
+
+// A non-2xx response whose body is not JSON at all still yields an error — the
+// decode failure is swallowed and only the status code decides.
+func TestCharacterize_ErrorOnly_NonJSONFailureBody(t *testing.T) {
+	c := newRawAgent(t, 502, "<html>bad gateway</html>")
+	err := c.Up("bitcoind")
+	assertContains(t, err, "agent /v1/compose/up: ")
+}
+
+// A 200 whose body is not JSON is still a success: the decode error is ignored
+// and nothing about the response is inspected.
+func TestCharacterize_ErrorOnly_NonJSONSuccessBody(t *testing.T) {
+	c := newRawAgent(t, 200, "not json")
+	if err := c.Up("bitcoind"); err != nil {
+		t.Fatalf("expected success despite unparseable body, got %v", err)
+	}
+}
+
+// --- optional-field payload shapes -----------------------------------------
+
+// An empty oldTag omits the key entirely, which is what makes the agent's
+// rewrite idempotent.
+func TestCharacterize_RewriteTags_OmitsEmptyOldTag(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok"})
+	if err := c.RewriteTags("mempool", []string{"a", "b"}, "", "v2"); err != nil {
+		t.Fatalf("rewrite tags: %v", err)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"service_id": "mempool",
+		"images":     []any{"a", "b"},
+		"new_tag":    "v2",
+	})
+	if strings.Contains(string(rec.body), "old_tag") {
+		t.Errorf("old_tag must be absent when empty, body: %s", rec.body)
+	}
+}
+
+// build_args and services are omitempty: with neither supplied only service_id
+// goes on the wire.
+func TestCharacterize_BuildWithArgs_OmitsEmptyOptionals(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok"})
+	if err := c.BuildWithArgs("truffels-api", nil); err != nil {
+		t.Fatalf("build with args: %v", err)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"service_id": "truffels-api"})
+}
+
+// Build always sends service_id, even for an empty service.
+func TestCharacterize_Build_EmptyServiceID(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok"})
+	if err := c.Build(""); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"service_id": ""})
+}
+
+// SystemAction builds its path from the action, so an unknown action simply
+// produces an unknown path rather than being rejected client-side.
+func TestCharacterize_SystemAction_PathFollowsAction(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok"})
+	if err := c.SystemAction("shutdown"); err != nil {
+		t.Fatalf("system action: %v", err)
+	}
+	if rec.path != "/v1/system/shutdown" {
+		t.Errorf("path = %s, want /v1/system/shutdown", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"action": "shutdown"})
+}
+
+func TestCharacterize_SystemAction_ErrorPrefixCarriesAction(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	err := c.SystemAction("shutdown")
+	assertContains(t, err, "agent system shutdown: ")
+}
+
+// --- ComposeUpDetached: 202 is a success ------------------------------------
+
+// The detached self-update returns before the work is done, so 202 must not be
+// treated as a failure.
+func TestCharacterize_ComposeUpDetached_Accepts202(t *testing.T) {
+	c, rec := newFakeAgent(t, 202, map[string]string{"status": "accepted"})
+	if err := c.ComposeUpDetached("truffels-agent"); err != nil {
+		t.Fatalf("202 must be accepted, got %v", err)
+	}
+	if rec.path != "/v1/compose/up-detached" {
+		t.Errorf("path = %s", rec.path)
+	}
+}
+
+// Only 200 and 202 pass; every other 2xx is an error.
+func TestCharacterize_ComposeUpDetached_RejectsOther2xx(t *testing.T) {
+	for _, status := range []int{201, 204} {
+		c, _ := newFakeAgent(t, status, failureBody())
+		err := c.ComposeUpDetached("truffels-agent")
+		if err == nil {
+			t.Errorf("status %d must be an error", status)
+		}
+	}
+}
+
+// No other method inherits the 202 tolerance.
+func TestCharacterize_Up_Rejects202(t *testing.T) {
+	c, _ := newFakeAgent(t, 202, failureBody())
+	if err := c.Up("bitcoind"); err == nil {
+		t.Fatal("202 must be an error for Up")
+	}
+}
+
+// --- POST returning text from the agentResponse envelope --------------------
+
+func TestCharacterize_Logs_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok", "logs": "line1\nline2\n"})
+	logs, err := c.Logs("electrs", 250, "10m", "electrs-main")
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if logs != "line1\nline2\n" {
+		t.Errorf("logs = %q", logs)
+	}
+	if rec.path != "/v1/compose/logs" || rec.method != http.MethodPost {
+		t.Errorf("%s %s", rec.method, rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"service_id": "electrs",
+		"tail":       250,
+		"since":      "10m",
+		"container":  "electrs-main",
+	})
+}
+
+// since and container are omitempty; tail is not.
+func TestCharacterize_Logs_OmitsEmptyOptionals(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"logs": ""})
+	if _, err := c.Logs("electrs", 0, "", ""); err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"service_id": "electrs", "tail": 0})
+}
+
+// On failure Logs returns BOTH the partial log text and the error. The UI shows
+// whatever the agent managed to collect next to the failure.
+func TestCharacterize_Logs_ReturnsPartialLogsWithError(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, map[string]string{
+		"error":  "op failed: exit status 1",
+		"output": diagnosisMarker,
+		"logs":   "partial output",
+	})
+	logs, err := c.Logs("electrs", 100, "", "")
+	assertContains(t, err, "agent logs: ")
+	assertContains(t, err, diagnosisMarker)
+	if logs != "partial output" {
+		t.Errorf("partial logs must still be returned, got %q", logs)
+	}
+}
+
+func TestCharacterize_Logs_TransportFailure(t *testing.T) {
+	logs, err := unreachableAgent().Logs("electrs", 100, "", "")
+	assertContains(t, err, "agent logs: ")
+	if logs != "" {
+		t.Errorf("logs = %q, want empty on transport failure", logs)
+	}
+}
+
+func TestCharacterize_SystemJournal_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok", "logs": "journal text"})
+	out, err := c.SystemJournal(500, "err", "docker.service", "2026-01-01", 2)
+	if err != nil {
+		t.Fatalf("journal: %v", err)
+	}
+	if out != "journal text" {
+		t.Errorf("out = %q", out)
+	}
+	if rec.path != "/v1/system/journal" {
+		t.Errorf("path = %s", rec.path)
+	}
+	// This payload is a plain map, so every key is present even when empty.
+	assertJSONBody(t, rec.body, map[string]any{
+		"lines": 500, "priority": "err", "unit": "docker.service",
+		"since": "2026-01-01", "boot": 2,
+	})
+}
+
+func TestCharacterize_SystemJournal_SendsEmptyKeys(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"logs": ""})
+	if _, err := c.SystemJournal(0, "", "", "", 0); err != nil {
+		t.Fatalf("journal: %v", err)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"lines": 0, "priority": "", "unit": "", "since": "", "boot": 0,
+	})
+}
+
+// Like Logs, SystemJournal hands back the partial text with the error.
+func TestCharacterize_SystemJournal_ReturnsPartialLogsWithError(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, map[string]string{
+		"error": "op failed: exit status 1", "output": diagnosisMarker, "logs": "partial",
+	})
+	out, err := c.SystemJournal(100, "", "", "", 0)
+	assertContains(t, err, "agent journal: ")
+	assertContains(t, err, diagnosisMarker)
+	if out != "partial" {
+		t.Errorf("out = %q, want partial", out)
+	}
+}
+
+func TestCharacterize_SystemJournal_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().SystemJournal(100, "", "", "", 0)
+	assertContains(t, err, "agent journal: ")
+}
+
+func TestCharacterize_Pull_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]string{"status": "ok", "output": "pull log"})
+	out, err := c.Pull("bitcoin/bitcoin:29.0")
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if out != "pull log" {
+		t.Errorf("out = %q", out)
+	}
+	if rec.path != "/v1/image/pull" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"image": "bitcoin/bitcoin:29.0"})
+}
+
+// Unlike Logs, Pull discards the output when the pull failed and returns "".
+func TestCharacterize_Pull_DiscardsOutputOnError(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	out, err := c.Pull("mariadb:lts")
+	assertContains(t, err, "agent pull: ")
+	assertContains(t, err, diagnosisMarker)
+	if out != "" {
+		t.Errorf("out = %q, want empty on error", out)
+	}
+}
+
+func TestCharacterize_Pull_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().Pull("img")
+	assertContains(t, err, "agent pull: ")
+}
+
+// --- POST decoding into a typed struct --------------------------------------
+
+func TestCharacterize_ImageInspect_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, ImageInfo{
+		Image:  "bitcoin/bitcoin:29.0",
+		Digest: "sha256:abc",
+		Tags:   []string{"29.0"},
+		Labels: map[string]string{"org.opencontainers.image.version": "29.0"},
+	})
+	info, err := c.ImageInspect("bitcoind")
+	if err != nil {
+		t.Fatalf("image inspect: %v", err)
+	}
+	if info.Image != "bitcoin/bitcoin:29.0" || info.Digest != "sha256:abc" {
+		t.Errorf("info = %+v", info)
+	}
+	if len(info.Tags) != 1 || info.Tags[0] != "29.0" {
+		t.Errorf("tags = %v", info.Tags)
+	}
+	if info.Labels["org.opencontainers.image.version"] != "29.0" {
+		t.Errorf("labels = %v", info.Labels)
+	}
+	if rec.path != "/v1/image/inspect" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"container": "bitcoind"})
+}
+
+func TestCharacterize_ImageInspect_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	info, err := c.ImageInspect("bitcoind")
+	assertContains(t, err, "agent image inspect: ")
+	assertContains(t, err, diagnosisMarker)
+	if info != nil {
+		t.Errorf("info = %+v, want nil", info)
+	}
+}
+
+// A 200 with an unparseable body is reported separately from an agent failure,
+// with its own "decode" suffix.
+func TestCharacterize_ImageInspect_DecodeFailure(t *testing.T) {
+	c := newRawAgent(t, 200, "not json")
+	_, err := c.ImageInspect("bitcoind")
+	assertContains(t, err, "agent image inspect decode: ")
+}
+
+func TestCharacterize_ImageInspect_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().ImageInspect("bitcoind")
+	assertContains(t, err, "agent image inspect: ")
+}
+
+func TestCharacterize_ImageInspectByName_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, ImageInfo{Image: "truffels-api:v0.3.0", Digest: "sha256:def"})
+	info, err := c.ImageInspectByName("truffels-api:v0.3.0")
+	if err != nil {
+		t.Fatalf("inspect by name: %v", err)
+	}
+	if info.Digest != "sha256:def" {
+		t.Errorf("info = %+v", info)
+	}
+	if rec.path != "/v1/image/inspect-by-name" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"image": "truffels-api:v0.3.0"})
+}
+
+// Its error prefix differs from ImageInspect's — "by name" is part of the text.
+func TestCharacterize_ImageInspectByName_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	_, err := c.ImageInspectByName("img")
+	assertContains(t, err, "agent image inspect by name: ")
+	assertContains(t, err, diagnosisMarker)
+}
+
+func TestCharacterize_ImageInspectByName_DecodeFailure(t *testing.T) {
+	c := newRawAgent(t, 200, "{{{")
+	_, err := c.ImageInspectByName("img")
+	assertContains(t, err, "agent image inspect by name decode: ")
+}
+
+func TestCharacterize_ImageInspectByName_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().ImageInspectByName("img")
+	assertContains(t, err, "agent image inspect by name: ")
+}
+
+// --- GET endpoints ----------------------------------------------------------
+
+func TestCharacterize_SystemInfoGet_Success(t *testing.T) {
+	want := SystemInfo{
+		Hostname: "truffels", OS: "Debian", Kernel: "6.12", Model: "Raspberry Pi 5",
+		CPUCores: 4, MemTotal: "8G", MemFree: "2G", Uptime: "3d",
+		Networks: []NetworkIfInfo{{Name: "wlan0", IP: "192.168.0.196", MAC: "aa:bb"}},
+		Storage:  []StorageInfo{{Device: "/dev/nvme0n1p2", Mount: "/", UsePct: "53%"}},
+		DockerStorage: []DockerStorageItem{
+			{Type: "Images", Count: 13, TotalSize: "8GB", Reclaimable: "2GB", ReclaimableRaw: 2147483648},
+		},
+		ServiceData: []ServiceDataItem{{Path: "/srv/truffels/data/bitcoin", Size: "700G", SizeRaw: 751619276800}},
+	}
+	c, rec := newFakeAgent(t, 200, want)
+	got, err := c.SystemInfoGet()
+	if err != nil {
+		t.Fatalf("system info: %v", err)
+	}
+	if got.Hostname != "truffels" || got.CPUCores != 4 {
+		t.Errorf("got = %+v", got)
+	}
+	if len(got.Networks) != 1 || got.Networks[0].IP != "192.168.0.196" {
+		t.Errorf("networks = %+v", got.Networks)
+	}
+	if len(got.DockerStorage) != 1 || got.DockerStorage[0].ReclaimableRaw != 2147483648 {
+		t.Errorf("docker storage = %+v", got.DockerStorage)
+	}
+	if len(got.ServiceData) != 1 || got.ServiceData[0].SizeRaw != 751619276800 {
+		t.Errorf("service data = %+v", got.ServiceData)
+	}
+	// This one is a GET with no request body.
+	if rec.method != http.MethodGet {
+		t.Errorf("method = %s, want GET", rec.method)
+	}
+	if rec.path != "/v1/system/info" {
+		t.Errorf("path = %s", rec.path)
+	}
+	if len(rec.body) != 0 {
+		t.Errorf("GET must not carry a body, got %q", rec.body)
+	}
+}
+
+// SystemInfoGet never looks at the status code. A 500 carrying a decodable body
+// is reported as success. Preserved deliberately — changing it would alter what
+// the system tab shows when the agent is degraded.
+func TestCharacterize_SystemInfoGet_IgnoresStatusCode(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, SystemInfo{Hostname: "degraded"})
+	got, err := c.SystemInfoGet()
+	if err != nil {
+		t.Fatalf("status code is not checked today, want nil error, got %v", err)
+	}
+	if got.Hostname != "degraded" {
+		t.Errorf("hostname = %q", got.Hostname)
+	}
+}
+
+func TestCharacterize_SystemInfoGet_DecodeFailure(t *testing.T) {
+	c := newRawAgent(t, 200, "nope")
+	_, err := c.SystemInfoGet()
+	assertContains(t, err, "agent system info decode: ")
+}
+
+func TestCharacterize_SystemInfoGet_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().SystemInfoGet()
+	assertContains(t, err, "agent system info: ")
+}
+
+func TestCharacterize_HostDirSize_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"size_bytes": 751619276800, "fresh": true})
+	size, fresh, err := c.HostDirSize("/srv/truffels/data/bitcoin")
+	if err != nil {
+		t.Fatalf("dir size: %v", err)
+	}
+	if size != 751619276800 || !fresh {
+		t.Errorf("size = %d, fresh = %v", size, fresh)
+	}
+	if rec.method != http.MethodGet || rec.path != "/v1/host/dir-size" {
+		t.Errorf("%s %s", rec.method, rec.path)
+	}
+	if rec.rawQuery != "path=%2Fsrv%2Ftruffels%2Fdata%2Fbitcoin" {
+		t.Errorf("query = %q", rec.rawQuery)
+	}
+}
+
+// The path is query-escaped, so spaces and separators survive intact.
+func TestCharacterize_HostDirSize_EscapesPath(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"size_bytes": 0, "fresh": false})
+	if _, _, err := c.HostDirSize("/srv/a b&c=d"); err != nil {
+		t.Fatalf("dir size: %v", err)
+	}
+	if rec.rawQuery != "path=%2Fsrv%2Fa+b%26c%3Dd" {
+		t.Errorf("query = %q", rec.rawQuery)
+	}
+}
+
+// A path the agent has not walked yet comes back as (-1, false, nil).
+func TestCharacterize_HostDirSize_NotYetWalked(t *testing.T) {
+	c, _ := newFakeAgent(t, 200, map[string]any{"size_bytes": -1, "fresh": false})
+	size, fresh, err := c.HostDirSize("/srv/truffels/data/electrs")
+	if err != nil {
+		t.Fatalf("dir size: %v", err)
+	}
+	if size != -1 || fresh {
+		t.Errorf("size = %d, fresh = %v, want -1/false", size, fresh)
+	}
+}
+
+// Like SystemInfoGet, the status code is not consulted.
+func TestCharacterize_HostDirSize_IgnoresStatusCode(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, map[string]any{"size_bytes": 42, "fresh": true})
+	size, fresh, err := c.HostDirSize("/srv/x")
+	if err != nil {
+		t.Fatalf("status code is not checked today, want nil error, got %v", err)
+	}
+	if size != 42 || !fresh {
+		t.Errorf("size = %d, fresh = %v", size, fresh)
+	}
+}
+
+func TestCharacterize_HostDirSize_DecodeFailure(t *testing.T) {
+	c := newRawAgent(t, 200, "nope")
+	_, _, err := c.HostDirSize("/srv/x")
+	assertContains(t, err, "agent dir-size decode: ")
+}
+
+func TestCharacterize_HostDirSize_TransportFailure(t *testing.T) {
+	_, _, err := unreachableAgent().HostDirSize("/srv/x")
+	assertContains(t, err, "agent dir-size: ")
+}
+
+func TestCharacterize_SystemTuningGet_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, SystemTuningInfo{
+		PersistentJournal: true,
+		Swappiness:        10,
+		JournalDiskUsage:  "112M",
+		Boots:             []BootEntry{{Index: 0, ID: "abc", First: "t0", Last: "t1"}},
+	})
+	got, err := c.SystemTuningGet()
+	if err != nil {
+		t.Fatalf("tuning get: %v", err)
+	}
+	if !got.PersistentJournal || got.Swappiness != 10 || got.JournalDiskUsage != "112M" {
+		t.Errorf("got = %+v", got)
+	}
+	if len(got.Boots) != 1 || got.Boots[0].ID != "abc" {
+		t.Errorf("boots = %+v", got.Boots)
+	}
+	if rec.method != http.MethodGet || rec.path != "/v1/system/tuning" {
+		t.Errorf("%s %s", rec.method, rec.path)
+	}
+}
+
+// Unlike the other two GETs, tuning DOES check the status code and routes
+// through agentError.
+func TestCharacterize_SystemTuningGet_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	got, err := c.SystemTuningGet()
+	assertContains(t, err, "agent tuning get: ")
+	assertContains(t, err, diagnosisMarker)
+	if got != nil {
+		t.Errorf("got = %+v, want nil", got)
+	}
+}
+
+func TestCharacterize_SystemTuningGet_DecodeFailure(t *testing.T) {
+	c := newRawAgent(t, 200, "nope")
+	_, err := c.SystemTuningGet()
+	assertContains(t, err, "agent tuning decode: ")
+}
+
+func TestCharacterize_SystemTuningGet_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().SystemTuningGet()
+	assertContains(t, err, "agent tuning get: ")
+}
+
+// --- the reconcile / prune / read family ------------------------------------
+//
+// These do NOT use agentError: they report ar.Error only and drop the agent's
+// output. Asserting the absence of the marker is intentional — it is what keeps
+// a refactor from quietly folding them into the agentError path and changing
+// every one of these messages.
+
+func TestCharacterize_FileReconcile_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "changed": true})
+	changed, err := c.FileReconcile("/srv/truffels/config/Caddyfile", "content")
+	if err != nil {
+		t.Fatalf("file reconcile: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true")
+	}
+	if rec.path != "/v1/file/reconcile" || rec.method != http.MethodPost {
+		t.Errorf("%s %s", rec.method, rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"path": "/srv/truffels/config/Caddyfile", "expected_content": "content",
+	})
+}
+
+func TestCharacterize_FileReconcile_Unchanged(t *testing.T) {
+	c, _ := newFakeAgent(t, 200, map[string]any{"status": "ok", "changed": false})
+	changed, err := c.FileReconcile("/p", "c")
+	if err != nil {
+		t.Fatalf("file reconcile: %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false")
+	}
+}
+
+func TestCharacterize_FileReconcile_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	changed, err := c.FileReconcile("/p", "c")
+	assertContains(t, err, "agent file reconcile: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("this method does not use agentError; output must not appear: %v", err)
+	}
+	if changed {
+		t.Error("changed must be false on error")
+	}
+}
+
+func TestCharacterize_FileReconcile_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().FileReconcile("/p", "c")
+	assertContains(t, err, "agent file reconcile: ")
+}
+
+// ReconcileFile hits the same endpoint with the same payload keys and the same
+// error text as FileReconcile; only the parameter name differs.
+func TestCharacterize_ReconcileFile_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "changed": true})
+	changed, err := c.ReconcileFile("ckstats/Dockerfile", "FROM node")
+	if err != nil {
+		t.Fatalf("reconcile file: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true")
+	}
+	if rec.path != "/v1/file/reconcile" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"path": "ckstats/Dockerfile", "expected_content": "FROM node",
+	})
+}
+
+func TestCharacterize_ReconcileFile_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	_, err := c.ReconcileFile("ckstats/Dockerfile", "x")
+	assertContains(t, err, "agent file reconcile: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("output must not appear: %v", err)
+	}
+}
+
+func TestCharacterize_ReconcileFile_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().ReconcileFile("p", "c")
+	assertContains(t, err, "agent file reconcile: ")
+}
+
+func TestCharacterize_ComposeReconcile_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "changed": true})
+	changed, err := c.ComposeReconcile("mempool", "services: {}")
+	if err != nil {
+		t.Fatalf("compose reconcile: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true")
+	}
+	if rec.path != "/v1/compose/reconcile" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{
+		"service_id": "mempool", "expected_content": "services: {}",
+	})
+}
+
+func TestCharacterize_ComposeReconcile_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	changed, err := c.ComposeReconcile("mempool", "x")
+	assertContains(t, err, "agent compose reconcile: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("output must not appear: %v", err)
+	}
+	if changed {
+		t.Error("changed must be false on error")
+	}
+}
+
+func TestCharacterize_ComposeReconcile_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().ComposeReconcile("mempool", "x")
+	assertContains(t, err, "agent compose reconcile: ")
+}
+
+func TestCharacterize_ComposeRead_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "content": "services:\n  a: {}\n"})
+	content, err := c.ComposeRead("mempool")
+	if err != nil {
+		t.Fatalf("compose read: %v", err)
+	}
+	if content != "services:\n  a: {}\n" {
+		t.Errorf("content = %q", content)
+	}
+	if rec.path != "/v1/compose/read" {
+		t.Errorf("path = %s", rec.path)
+	}
+	assertJSONBody(t, rec.body, map[string]any{"service_id": "mempool"})
+}
+
+func TestCharacterize_ComposeRead_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	content, err := c.ComposeRead("mempool")
+	assertContains(t, err, "agent compose read: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("output must not appear: %v", err)
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+}
+
+func TestCharacterize_ComposeRead_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().ComposeRead("mempool")
+	assertContains(t, err, "agent compose read: ")
+}
+
+func TestCharacterize_DockerPrune_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "reclaimed": "4.2GB"})
+	reclaimed, err := c.DockerPrune()
+	if err != nil {
+		t.Fatalf("docker prune: %v", err)
+	}
+	if reclaimed != "4.2GB" {
+		t.Errorf("reclaimed = %q", reclaimed)
+	}
+	if rec.path != "/v1/docker/prune" || rec.method != http.MethodPost {
+		t.Errorf("%s %s", rec.method, rec.path)
+	}
+	// An empty JSON object, not an empty body.
+	if strings.TrimSpace(string(rec.body)) != "{}" {
+		t.Errorf("body = %q, want {}", rec.body)
+	}
+}
+
+func TestCharacterize_DockerPrune_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	reclaimed, err := c.DockerPrune()
+	assertContains(t, err, "agent docker prune: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("output must not appear: %v", err)
+	}
+	if reclaimed != "" {
+		t.Errorf("reclaimed = %q, want empty", reclaimed)
+	}
+}
+
+func TestCharacterize_DockerPrune_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().DockerPrune()
+	assertContains(t, err, "agent docker prune: ")
+}
+
+func TestCharacterize_DockerPruneBuildCache_Success(t *testing.T) {
+	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "reclaimed": "1.1GB"})
+	reclaimed, err := c.DockerPruneBuildCache()
+	if err != nil {
+		t.Fatalf("prune buildcache: %v", err)
+	}
+	if reclaimed != "1.1GB" {
+		t.Errorf("reclaimed = %q", reclaimed)
+	}
+	if rec.path != "/v1/docker/prune-buildcache" {
+		t.Errorf("path = %s", rec.path)
+	}
+	if strings.TrimSpace(string(rec.body)) != "{}" {
+		t.Errorf("body = %q, want {}", rec.body)
+	}
+}
+
+// Its error prefix carries "buildcache" and is distinct from DockerPrune's.
+func TestCharacterize_DockerPruneBuildCache_AgentFailure(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, failureBody())
+	_, err := c.DockerPruneBuildCache()
+	assertContains(t, err, "agent docker prune buildcache: op failed: exit status 1")
+	if strings.Contains(err.Error(), diagnosisMarker) {
+		t.Errorf("output must not appear: %v", err)
+	}
+}
+
+func TestCharacterize_DockerPruneBuildCache_TransportFailure(t *testing.T) {
+	_, err := unreachableAgent().DockerPruneBuildCache()
+	assertContains(t, err, "agent docker prune buildcache: ")
+}
+
+// --- agentError itself ------------------------------------------------------
+
+func TestCharacterize_AgentError_KeepsOutputTail(t *testing.T) {
+	long := strings.Repeat("x", 4000) + "THE-ACTUAL-CAUSE"
+	err := agentError("agent op", agentResponse{Error: "boom", Output: long})
+	assertContains(t, err, "agent op: boom")
+	assertContains(t, err, "THE-ACTUAL-CAUSE")
+	// 500 chars of tail plus the ellipsis, the prefix and the error line.
+	if len(err.Error()) > 700 {
+		t.Errorf("output was not truncated: %d chars", len(err.Error()))
+	}
+	if !strings.Contains(err.Error(), "...") {
+		t.Errorf("truncation marker missing: %v", err)
+	}
+}
+
+func TestCharacterize_AgentError_NoOutput(t *testing.T) {
+	err := agentError("agent op", agentResponse{Error: "boom"})
+	if err.Error() != "agent op: boom" {
+		t.Errorf("err = %q, want %q", err, "agent op: boom")
+	}
+}
+
+// Short output is appended whole, on its own line, with no ellipsis.
+func TestCharacterize_AgentError_ShortOutputNotTruncated(t *testing.T) {
+	err := agentError("agent op", agentResponse{Error: "boom", Output: "short cause"})
+	if err.Error() != "agent op: boom\nshort cause" {
+		t.Errorf("err = %q", err)
+	}
+}
+
+// An empty Error field with output still produces a message carrying the cause.
+func TestCharacterize_AgentError_EmptyErrorField(t *testing.T) {
+	err := agentError("agent op", agentResponse{Output: "only output"})
+	if err.Error() != "agent op: \nonly output" {
+		t.Errorf("err = %q", err)
+	}
+}

--- a/truffels-api/internal/docker/compose_characterization_test.go
+++ b/truffels-api/internal/docker/compose_characterization_test.go
@@ -646,7 +646,7 @@ func TestCharacterize_SystemInfoGet_Success(t *testing.T) {
 	want := SystemInfo{
 		Hostname: "truffels", OS: "Debian", Kernel: "6.12", Model: "Raspberry Pi 5",
 		CPUCores: 4, MemTotal: "8G", MemFree: "2G", Uptime: "3d",
-		Networks: []NetworkIfInfo{{Name: "wlan0", IP: "192.168.0.196", MAC: "aa:bb"}},
+		Networks: []NetworkIfInfo{{Name: "wlan0", IP: "192.0.2.10", MAC: "aa:bb"}},
 		Storage:  []StorageInfo{{Device: "/dev/nvme0n1p2", Mount: "/", UsePct: "53%"}},
 		DockerStorage: []DockerStorageItem{
 			{Type: "Images", Count: 13, TotalSize: "8GB", Reclaimable: "2GB", ReclaimableRaw: 2147483648},
@@ -661,7 +661,7 @@ func TestCharacterize_SystemInfoGet_Success(t *testing.T) {
 	if got.Hostname != "truffels" || got.CPUCores != 4 {
 		t.Errorf("got = %+v", got)
 	}
-	if len(got.Networks) != 1 || got.Networks[0].IP != "192.168.0.196" {
+	if len(got.Networks) != 1 || got.Networks[0].IP != "192.0.2.10" {
 		t.Errorf("networks = %+v", got.Networks)
 	}
 	if len(got.DockerStorage) != 1 || got.DockerStorage[0].ReclaimableRaw != 2147483648 {

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -31,6 +31,9 @@ type mockAgentOpts struct {
 	unhealthy   bool // if true, inspect returns unhealthy containers
 	imageInspectFail bool   // if true, /v1/image/inspect returns 500
 	tagFail          bool   // if true, /v1/image/tag returns 500 (no staged rollback image)
+	rewriteFail      bool   // if true, /v1/compose/rewrite-tags returns 500
+	gitCheckoutFail  bool   // if true, /v1/git/checkout returns 500
+	detachedFail     bool   // if true, /v1/compose/up-detached returns 500
 	composeDirs      map[string]string // service_id -> compose dir path for rewrite-tags
 	imageLabels      map[string]string // labels returned by /v1/image/inspect (NeedsBuild verification)
 	tags             *tagRecorder      // records /v1/image/tag calls when set
@@ -126,7 +129,20 @@ func newMockAgent(opts mockAgentOpts) *httptest.Server {
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
+		case "/v1/git/checkout":
+			if opts.gitCheckoutFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "git checkout failed"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+
 		case "/v1/compose/rewrite-tags":
+			if opts.rewriteFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "write compose file: read-only file system"})
+				return
+			}
 			var req struct {
 				ServiceID string   `json:"service_id"`
 				Images    []string `json:"images"`
@@ -869,6 +885,11 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/git/checkout":
+			if opts.gitCheckoutFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "git checkout failed"})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case "/v1/compose/build":
@@ -882,6 +903,11 @@ func newSelfUpdateMockAgent(opts mockAgentOpts) *httptest.Server {
 		case "/v1/compose/up-detached":
 			if opts.detached != nil {
 				opts.detached.inc()
+			}
+			if opts.detachedFail {
+				w.WriteHeader(500)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "nsenter failed"})
+				return
 			}
 			w.WriteHeader(202)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "accepted"})

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -264,6 +264,26 @@ func versionLabel(v string) string {
 // replaces it.
 var statfs = syscall.Statfs
 
+// A preflight check is only ever recorded in one of three shapes, and one of
+// them carries an obligation: a blocking failure has to clear CanProceed too, or
+// the API offers to start an update its own checks just rejected. These three
+// helpers make that pairing structural instead of a line every new check has to
+// remember to repeat.
+func preflightPass(r *model.PreflightResult, name, msg string) {
+	r.Checks = append(r.Checks, model.PreflightCheck{Name: name, Status: "pass", Message: msg, Blocking: true})
+}
+
+func preflightFail(r *model.PreflightResult, name, msg string) {
+	r.Checks = append(r.Checks, model.PreflightCheck{Name: name, Status: "fail", Message: msg, Blocking: true})
+	r.CanProceed = false
+}
+
+// preflightWarn records what the user should know before starting but that is
+// not a fault — a dependent that will be disrupted, not a reason to refuse.
+func preflightWarn(r *model.PreflightResult, name, msg string) {
+	r.Checks = append(r.Checks, model.PreflightCheck{Name: name, Status: "warn", Message: msg, Blocking: false})
+}
+
 // RunPreflight checks whether a service is safe to update and returns detailed results.
 func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) {
 	result := &model.PreflightResult{
@@ -274,30 +294,19 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 	// 1. Service exists and has UpdateSource
 	tmpl, ok := e.registry.Get(serviceID)
 	if !ok {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "service_exists", Status: "fail", Message: "unknown service", Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "service_exists", "unknown service")
 		return result, nil
 	}
 	if tmpl.UpdateSource == nil {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "update_source", Status: "fail", Message: "service has no update source configured", Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "update_source", "service has no update source configured")
 		return result, nil
 	}
-	result.Checks = append(result.Checks, model.PreflightCheck{
-		Name: "service_exists", Status: "pass", Message: "service found with update source", Blocking: true,
-	})
+	preflightPass(result, "service_exists", "service found with update source")
 
 	// 2. Update available
 	check, _ := e.store.GetLatestUpdateCheck(serviceID)
 	if check == nil || !check.HasUpdate {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "update_available", Status: "fail", Message: "no update available", Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "update_available", "no update available")
 	} else {
 		result.FromVersion = check.CurrentVersion
 		result.ToVersion = check.LatestVersion
@@ -310,60 +319,34 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 		if check.CurrentVersion == "" {
 			msg = fmt.Sprintf("update available: running version unknown (the image carries no source ref) → %s; rebuilding stamps it", check.LatestVersion)
 		}
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "update_available", Status: "pass",
-			Message:  msg,
-			Blocking: true,
-		})
+		preflightPass(result, "update_available", msg)
 	}
 
 	// 3. Not already updating
 	if e.IsUpdating(serviceID) {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "not_updating", Status: "fail", Message: "update already in progress", Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "not_updating", "update already in progress")
 	} else {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "not_updating", Status: "pass", Message: "no update in progress", Blocking: true,
-		})
+		preflightPass(result, "not_updating", "no update in progress")
 	}
 
 	// 4. Compose file accessible
 	composePath := tmpl.ComposeDir + "/docker-compose.yml"
 	if _, err := os.Stat(composePath); err != nil {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "compose_file", Status: "fail", Message: "compose file not accessible: " + err.Error(), Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "compose_file", "compose file not accessible: "+err.Error())
 	} else {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "compose_file", Status: "pass", Message: "compose file accessible", Blocking: true,
-		})
+		preflightPass(result, "compose_file", "compose file accessible")
 	}
 
 	// 5. Disk space (require at least 2GB free)
 	var stat syscall.Statfs_t
 	if err := statfs("/srv/truffels", &stat); err != nil {
-		result.Checks = append(result.Checks, model.PreflightCheck{
-			Name: "disk_space", Status: "fail", Message: "cannot check disk space: " + err.Error(), Blocking: true,
-		})
-		result.CanProceed = false
+		preflightFail(result, "disk_space", "cannot check disk space: "+err.Error())
 	} else {
 		availGB := float64(stat.Bavail*uint64(stat.Bsize)) / (1 << 30)
 		if availGB < 2.0 {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "disk_space", Status: "fail",
-				Message:  fmt.Sprintf("insufficient disk space: %.1f GB available (need 2 GB)", availGB),
-				Blocking: true,
-			})
-			result.CanProceed = false
+			preflightFail(result, "disk_space", fmt.Sprintf("insufficient disk space: %.1f GB available (need 2 GB)", availGB))
 		} else {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "disk_space", Status: "pass",
-				Message:  fmt.Sprintf("%.1f GB available", availGB),
-				Blocking: true,
-			})
+			preflightPass(result, "disk_space", fmt.Sprintf("%.1f GB available", availGB))
 		}
 	}
 
@@ -371,11 +354,7 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 	for _, dep := range tmpl.Dependencies {
 		depTmpl, depOK := e.registry.Get(dep)
 		if !depOK {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "dependency_" + dep, Status: "fail",
-				Message: "dependency not found in registry", Blocking: true,
-			})
-			result.CanProceed = false
+			preflightFail(result, "dependency_"+dep, "dependency not found in registry")
 			continue
 		}
 		allHealthy := true
@@ -391,16 +370,9 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 			}
 		}
 		if !allHealthy {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "dependency_" + dep, Status: "fail",
-				Message: dep + " is not healthy", Blocking: true,
-			})
-			result.CanProceed = false
+			preflightFail(result, "dependency_"+dep, dep+" is not healthy")
 		} else {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "dependency_" + dep, Status: "pass",
-				Message: dep + " is healthy", Blocking: true,
-			})
+			preflightPass(result, "dependency_"+dep, dep+" is healthy")
 		}
 	}
 
@@ -420,11 +392,7 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 			}
 		}
 		if running {
-			result.Checks = append(result.Checks, model.PreflightCheck{
-				Name: "dependent_" + depID, Status: "warn",
-				Message:  depID + " depends on this service and may be temporarily disrupted",
-				Blocking: false,
-			})
+			preflightWarn(result, "dependent_"+depID, depID+" depends on this service and may be temporarily disrupted")
 		}
 	}
 
@@ -458,6 +426,26 @@ func (e *Engine) alertUpdateFailed(serviceID, msg string) {
 		ServiceID: serviceID,
 		Message:   msg,
 	})
+}
+
+// failUpdate ends a failed update step: it records msg on the update log, raises
+// the update_failed alert and hands msg back as the error. The three belong
+// together — a step that logs without alerting leaves the UI quiet about a
+// service that is down — and writing them as one call is what makes forgetting
+// one impossible. rollbackVersion is the version the service can still be
+// returned to; empty when the step failed before anything was staged.
+//
+// Not every failure fits this shape, and the ones that do not are left written
+// out on purpose. Several paths word the log, the alert and the returned error
+// differently — a failed pull during a rollback logs "pull failed" but alerts
+// "rollback pull failed", so the alert names the flow that broke — and folding
+// them in would mean a helper taking three separate strings, which reads worse
+// than the lines it replaces. One path, the github_release refusal in
+// RollbackService, deliberately raises no alert at all.
+func (e *Engine) failUpdate(logID int64, serviceID, msg, rollbackVersion string) error {
+	_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, rollbackVersion)
+	e.alertUpdateFailed(serviceID, msg)
+	return &UpdateError{Msg: msg}
 }
 
 // ApplyUpdate performs the update for a single service with automatic rollback on health failure.
@@ -541,9 +529,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		for _, img := range src.Images {
 			pullRef := img + ":" + src.TagFilter
 			if _, err := e.compose.Pull(pullRef); err != nil {
-				_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "pull failed: "+err.Error(), "")
-				e.alertUpdateFailed(serviceID, "pull failed: "+err.Error())
-				return &UpdateError{Msg: "pull failed: " + err.Error()}
+				return e.failUpdate(logID, serviceID, "pull failed: "+err.Error(), "")
 			}
 		}
 		// No compose file rewrite needed — tag stays the same
@@ -572,9 +558,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 	// here.
 	if !src.NeedsBuild && !tmpl.FloatingTag {
 		if err := e.compose.RewriteTags(serviceID, src.Images, check.CurrentVersion, check.LatestVersion); err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "compose rewrite failed: "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "compose rewrite failed: "+err.Error())
-			return &UpdateError{Msg: "compose rewrite failed: " + err.Error()}
+			return e.failUpdate(logID, serviceID, "compose rewrite failed: "+err.Error(), "")
 		}
 	}
 
@@ -582,9 +566,7 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 	_ = e.store.UpdateLogStatus(logID, model.UpdateRestarting, "", check.CurrentVersion)
 
 	if err := e.compose.Down(serviceID); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "stop failed: "+err.Error(), check.CurrentVersion)
-		e.alertUpdateFailed(serviceID, "stop failed: "+err.Error())
-		return &UpdateError{Msg: "stop failed: " + err.Error()}
+		return e.failUpdate(logID, serviceID, "stop failed: "+err.Error(), check.CurrentVersion)
 	}
 	if err := e.compose.Up(serviceID); err != nil {
 		if tmpl.FloatingTag {
@@ -595,10 +577,8 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		}
 		slog.Error("update: start failed, rolling back", "service", serviceID, "err", err)
 		if rbErr := e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion); rbErr != nil {
-			msg := "start failed: " + err.Error() + "; rollback incomplete: " + rbErr.Error()
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, check.CurrentVersion)
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+			return e.failUpdate(logID, serviceID,
+				"start failed: "+err.Error()+"; rollback incomplete: "+rbErr.Error(), check.CurrentVersion)
 		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "start failed: "+err.Error(), check.CurrentVersion)
 		e.alertUpdateFailed(serviceID, "start failed, rolled back to "+versionLabel(check.CurrentVersion))
@@ -617,10 +597,8 @@ func (e *Engine) ApplyUpdateToVersion(serviceID, targetVersion string) error {
 		}
 		slog.Error("update: service unhealthy after update, rolling back", "service", serviceID)
 		if rbErr := e.rollback(serviceID, tmpl, src, check.CurrentVersion, check.LatestVersion); rbErr != nil {
-			msg := "unhealthy after update; rollback incomplete: " + rbErr.Error()
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, check.CurrentVersion)
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+			return e.failUpdate(logID, serviceID,
+				"unhealthy after update; rollback incomplete: "+rbErr.Error(), check.CurrentVersion)
 		}
 		_ = e.store.UpdateLogStatus(logID, model.UpdateRolledBack, "unhealthy after update", check.CurrentVersion)
 		e.alertUpdateFailed(serviceID, "unhealthy after update, rolled back to "+versionLabel(check.CurrentVersion))
@@ -725,6 +703,10 @@ func (e *Engine) RollbackService(serviceID string) error {
 		// Without this guard the retag path below chases an image that does not
 		// exist and ends in a misleading "no rollback image available" plus an
 		// alert. Keep the honest message this path had before retag rollbacks.
+		//
+		// Deliberately not failUpdate: nothing was started, so nothing is broken,
+		// and an update_failed alert would report a fault that does not exist.
+		// TestRollbackService_SelfUpdateIsRefusedHonestly asserts the absence.
 		if src.Type == model.SourceGitHubRelease {
 			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "rollback not supported for custom-built services", "")
 			return &UpdateError{Msg: "rollback not supported for custom-built services"}
@@ -746,10 +728,7 @@ func (e *Engine) RollbackService(serviceID string) error {
 		rollbackRef := rollbackImageRef(serviceID)
 		info, inspectErr := e.compose.ImageInspectByName(rollbackRef)
 		if inspectErr != nil {
-			msg := "cannot verify the staged rollback image: " + inspectErr.Error()
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+			return e.failUpdate(logID, serviceID, "cannot verify the staged rollback image: "+inspectErr.Error(), "")
 		}
 		staged := info.Labels[SourceRefLabel]
 		switch {
@@ -762,15 +741,11 @@ func (e *Engine) RollbackService(serviceID string) error {
 			// dev.24 also has "unknown" in update_log.from_version, so a raw
 			// comparison found staged == prevVersion and restored an
 			// unidentifiable image while reporting the version it went back to.
-			msg := fmt.Sprintf("no rollback image available: %s carries no source ref, so it cannot be shown to hold %s", rollbackRef, prevVersion)
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+			return e.failUpdate(logID, serviceID, fmt.Sprintf(
+				"no rollback image available: %s carries no source ref, so it cannot be shown to hold %s", rollbackRef, prevVersion), "")
 		case staged != prevVersion:
-			msg := fmt.Sprintf("staged rollback image holds ref %q, not %q — only one generation is kept, so this version is gone", staged, prevVersion)
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-			e.alertUpdateFailed(serviceID, msg)
-			return &UpdateError{Msg: msg}
+			return e.failUpdate(logID, serviceID, fmt.Sprintf(
+				"staged rollback image holds ref %q, not %q — only one generation is kept, so this version is gone", staged, prevVersion), "")
 		}
 
 		// The update that got us here moved the compose tag to the version we
@@ -1001,9 +976,7 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 			refScheme = model.RefSchemeCommit
 		}
 		if err := e.compose.GitCheckout(src.RepoDir, check.LatestVersion, refScheme); err != nil {
-			_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "git checkout failed: "+err.Error(), "")
-			e.alertUpdateFailed(serviceID, "git checkout failed: "+err.Error())
-			return &UpdateError{Msg: "git checkout failed: " + err.Error()}
+			return e.failUpdate(logID, serviceID, "git checkout failed: "+err.Error(), "")
 		}
 	}
 
@@ -1074,10 +1047,7 @@ func (e *Engine) applyNeedsBuild(serviceID string, tmpl model.ServiceTemplate, s
 		return ""
 	}
 	fail := func(msg string) error {
-		msg += restoreComposeTag()
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-		e.alertUpdateFailed(serviceID, msg)
-		return &UpdateError{Msg: msg}
+		return e.failUpdate(logID, serviceID, msg+restoreComposeTag(), "")
 	}
 
 	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
@@ -1267,17 +1237,13 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 	// Step 1: Git checkout the new tag
 	_ = e.store.UpdateLogStatus(logID, model.UpdatePulling, "", "")
 	if err := e.compose.GitCheckout("/repo", check.LatestVersion, model.RefSchemeTag); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "git checkout failed: "+err.Error(), "")
-		e.alertUpdateFailed(serviceID, "git checkout failed: "+err.Error())
-		return &UpdateError{Msg: "git checkout failed: " + err.Error()}
+		return e.failUpdate(logID, serviceID, "git checkout failed: "+err.Error(), "")
 	}
 
 	// Step 2: Rewrite compose image tags BEFORE building so the build
 	// creates images tagged with the new version (not the old one).
 	if err := e.compose.RewriteTags(serviceID, tmpl.UpdateSource.Images, "", check.LatestVersion); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "compose rewrite failed: "+err.Error(), "")
-		e.alertUpdateFailed(serviceID, "compose rewrite failed: "+err.Error())
-		return &UpdateError{Msg: "compose rewrite failed: " + err.Error()}
+		return e.failUpdate(logID, serviceID, "compose rewrite failed: "+err.Error(), "")
 	}
 
 	// Step 3: Build with VERSION arg — build each service sequentially to avoid
@@ -1287,10 +1253,7 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 	// first: step 2 already moved it, and a file naming a version that was just
 	// rejected is a loaded gun for the next `up` from any source.
 	fail := func(msg string) error {
-		msg += e.restoreSelfComposeTags(serviceID, tmpl, check)
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, msg, "")
-		e.alertUpdateFailed(serviceID, msg)
-		return &UpdateError{Msg: msg}
+		return e.failUpdate(logID, serviceID, msg+e.restoreSelfComposeTags(serviceID, tmpl, check), "")
 	}
 
 	_ = e.store.UpdateLogStatus(logID, model.UpdateBuilding, "", "")
@@ -1309,9 +1272,7 @@ func (e *Engine) applySelfUpdate(serviceID string, tmpl model.ServiceTemplate, c
 	_ = e.store.UpdateLogStatus(logID, model.UpdateRestarting, "", check.CurrentVersion)
 
 	if err := e.compose.ComposeUpDetached("truffels-agent"); err != nil {
-		_ = e.store.UpdateLogStatus(logID, model.UpdateFailed, "detached restart failed: "+err.Error(), "")
-		e.alertUpdateFailed(serviceID, "detached restart failed: "+err.Error())
-		return &UpdateError{Msg: "detached restart failed: " + err.Error()}
+		return e.failUpdate(logID, serviceID, "detached restart failed: "+err.Error(), "")
 	}
 
 	// The API will be replaced shortly. The "restarting" status will be reconciled

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -257,6 +257,13 @@ func versionLabel(v string) string {
 	return v
 }
 
+// statfs is syscall.Statfs behind a package variable so the preflight disk-space
+// check can be exercised in both directions. It reads a fixed path under
+// /srv/truffels, which does not exist in a test container, so without the seam
+// only the "cannot check disk space" arm is ever reached. Production never
+// replaces it.
+var statfs = syscall.Statfs
+
 // RunPreflight checks whether a service is safe to update and returns detailed results.
 func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) {
 	result := &model.PreflightResult{
@@ -337,7 +344,7 @@ func (e *Engine) RunPreflight(serviceID string) (*model.PreflightResult, error) 
 
 	// 5. Disk space (require at least 2GB free)
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs("/srv/truffels", &stat); err != nil {
+	if err := statfs("/srv/truffels", &stat); err != nil {
 		result.Checks = append(result.Checks, model.PreflightCheck{
 			Name: "disk_space", Status: "fail", Message: "cannot check disk space: " + err.Error(), Blocking: true,
 		})

--- a/truffels-api/internal/updates/failpaths_test.go
+++ b/truffels-api/internal/updates/failpaths_test.go
@@ -1,0 +1,395 @@
+package updates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"truffels-api/internal/model"
+	"truffels-api/internal/store"
+)
+
+// These tests pin the failure paths of the update engine that write an update
+// log, raise the update_failed alert and return an error. All three belong
+// together — a path that logs but forgets the alert leaves the UI quiet about a
+// broken service — so every case asserts all three.
+
+// assertFailedWithAlert checks the three things a failed step must produce: the
+// returned error, the failed update log with its message, and the active alert.
+func assertFailedWithAlert(t *testing.T, st *store.Store, serviceID string, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error containing %q", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("expected %q in returned error, got: %v", want, err)
+	}
+
+	logs, _ := st.GetUpdateLogs(serviceID, 5)
+	if len(logs) == 0 {
+		t.Fatalf("expected an update log for %s", serviceID)
+	}
+	if logs[0].Status != model.UpdateFailed {
+		t.Errorf("expected status failed, got %s", logs[0].Status)
+	}
+	if !strings.Contains(logs[0].Error, want) {
+		t.Errorf("expected %q in the update log error, got: %s", want, logs[0].Error)
+	}
+
+	alerts, _ := st.GetActiveAlerts()
+	found := false
+	for _, a := range alerts {
+		if a.Type == "update_failed" && a.ServiceID == serviceID {
+			found = true
+			if a.Severity != model.SeverityCritical {
+				t.Errorf("expected a critical alert, got %s", a.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected an active update_failed alert for %s, got %+v", serviceID, alerts)
+	}
+}
+
+// mempoolTemplate is a plain registry-pulled service: no build, no floating tag.
+func mempoolTemplate(t *testing.T, composeDir string) model.ServiceTemplate {
+	t.Helper()
+	body := `services:
+  backend:
+    image: mempool/backend:v3.2.0
+`
+	if err := os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(body), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	return model.ServiceTemplate{
+		ID:             "mempool",
+		DisplayName:    "mempool.space",
+		ComposeDir:     composeDir,
+		ContainerNames: []string{"truffels-mempool-backend"},
+		UpdateSource: &model.UpdateSource{
+			Type:   model.SourceDockerHub,
+			Images: []string{"mempool/backend"},
+		},
+	}
+}
+
+// ckpoolTemplate is a custom-built service. repoDir empty means the build clones
+// inside its own Dockerfile and no git checkout happens.
+func ckpoolTemplate(t *testing.T, composeDir, repoDir string) model.ServiceTemplate {
+	t.Helper()
+	body := `services:
+  ckpool:
+    build: .
+    image: truffels/ckpool:v1.0.0
+`
+	if err := os.WriteFile(filepath.Join(composeDir, "docker-compose.yml"), []byte(body), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	return model.ServiceTemplate{
+		ID:             "ckpool",
+		DisplayName:    "ckpool",
+		ComposeDir:     composeDir,
+		ContainerNames: []string{"truffels-ckpool"},
+		UpdateSource: &model.UpdateSource{
+			Type:       model.SourceBitbucket,
+			Repo:       "ckolivas/ckpool",
+			Branch:     "master",
+			RepoDir:    repoDir,
+			NeedsBuild: true,
+		},
+	}
+}
+
+// --- ApplyUpdate: standard (pull) failures ---
+
+func TestApplyUpdate_Standard_ComposeRewriteFails(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{rewriteFail: true})
+	defer agent.Close()
+
+	tmpl := mempoolTemplate(t, t.TempDir())
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "mempool", CurrentVersion: "v3.2.0", LatestVersion: "v3.2.1", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("mempool")
+	assertFailedWithAlert(t, st, "mempool", err, "compose rewrite failed")
+}
+
+func TestApplyUpdate_Standard_StopFails(t *testing.T) {
+	cd := t.TempDir()
+	agent := newMockAgent(mockAgentOpts{
+		downFail:    true,
+		composeDirs: map[string]string{"mempool": cd},
+	})
+	defer agent.Close()
+
+	tmpl := mempoolTemplate(t, cd)
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "mempool", CurrentVersion: "v3.2.0", LatestVersion: "v3.2.1", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("mempool")
+	assertFailedWithAlert(t, st, "mempool", err, "stop failed")
+
+	// The version to go back to is recorded on the log, not left empty.
+	logs, _ := st.GetUpdateLogs("mempool", 5)
+	if logs[0].RollbackVersion != "v3.2.0" {
+		t.Errorf("expected rollback_version v3.2.0, got %q", logs[0].RollbackVersion)
+	}
+}
+
+// --- ApplyUpdate: custom build failures ---
+
+func TestApplyUpdate_BuildService_GitCheckoutFails(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{gitCheckoutFail: true})
+	defer agent.Close()
+
+	tmpl := ckpoolTemplate(t, t.TempDir(), "/repo/ckpool")
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "abc123def456", LatestVersion: "def789abc012", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	assertFailedWithAlert(t, st, "ckpool", err, "git checkout failed")
+}
+
+// The build succeeds, the restart does not, and the rollback cannot put the old
+// image back either — the caller must say so rather than claim a rollback.
+func TestApplyUpdate_BuildService_StartFails_RollbackIncomplete(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{
+		upFail:      true,
+		tagFail:     true,
+		imageLabels: map[string]string{SourceRefLabel: "def789abc012"},
+	})
+	defer agent.Close()
+
+	tmpl := ckpoolTemplate(t, t.TempDir(), "")
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "abc123def456", LatestVersion: "def789abc012", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("ckpool")
+	assertFailedWithAlert(t, st, "ckpool", err, "rollback incomplete")
+
+	logs, _ := st.GetUpdateLogs("ckpool", 5)
+	if !strings.Contains(logs[0].Error, "start failed") {
+		t.Errorf("expected the start failure to survive into the log, got: %s", logs[0].Error)
+	}
+	if logs[0].RollbackVersion != "abc123def456" {
+		t.Errorf("expected rollback_version abc123def456, got %q", logs[0].RollbackVersion)
+	}
+}
+
+// --- RollbackService ---
+
+// The staged image cannot even be inspected: refuse before moving any tag.
+func TestRollbackService_StagedImageInspectFails(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{imageInspectFail: true})
+	defer agent.Close()
+
+	tmpl := ckpoolTemplate(t, t.TempDir(), "")
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+
+	_, _ = st.CreateUpdateLog(&model.UpdateLog{
+		ServiceID: "ckpool", FromVersion: "abc123", ToVersion: "def456", Status: model.UpdateDone,
+	})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "ckpool", CurrentVersion: "def456", LatestVersion: "def456",
+	})
+
+	err := eng.RollbackService("ckpool")
+	assertFailedWithAlert(t, st, "ckpool", err, "cannot verify the staged rollback image")
+}
+
+// --- Self-update ---
+
+func TestApplySelfUpdate_GitCheckoutFails(t *testing.T) {
+	cd := t.TempDir()
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs:     map[string]string{"truffels": cd},
+		gitCheckoutFail: true,
+	})
+	defer agent.Close()
+
+	composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "truffels", CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	assertFailedWithAlert(t, st, "truffels", err, "git checkout failed")
+
+	// Nothing was rewritten yet, so the file must still sit at the old version.
+	assertComposeTags(t, composePath, "v0.1.0")
+}
+
+func TestApplySelfUpdate_ComposeRewriteFails(t *testing.T) {
+	cd := t.TempDir()
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs:     map[string]string{"truffels": cd},
+		rewriteFailFrom: 1,
+	})
+	defer agent.Close()
+
+	composePath := writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "truffels", CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	assertFailedWithAlert(t, st, "truffels", err, "compose rewrite failed")
+
+	// The rewrite is fatal before anything is built: the file never moved.
+	assertComposeTags(t, composePath, "v0.1.0")
+}
+
+func TestApplySelfUpdate_DetachedRestartFails(t *testing.T) {
+	cd := t.TempDir()
+	agent := newSelfUpdateMockAgent(mockAgentOpts{
+		composeDirs:  map[string]string{"truffels": cd},
+		labelsByRef:  selfUpdateLabels("v0.2.0"),
+		detachedFail: true,
+	})
+	defer agent.Close()
+
+	writeSelfUpdateCompose(t, cd, "v0.1.0")
+	eng, st := newTestEngine(t, agent, selfUpdateTemplates(cd))
+
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "truffels", CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0", HasUpdate: true,
+	})
+
+	err := eng.ApplyUpdate("truffels")
+	assertFailedWithAlert(t, st, "truffels", err, "detached restart failed")
+}
+
+// --- RunPreflight ---
+
+func TestRunPreflight_DependencyNotRegistered(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{})
+	defer agent.Close()
+
+	tmpl := mempoolTemplate(t, t.TempDir())
+	tmpl.Dependencies = []string{"ghost"}
+
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "mempool", CurrentVersion: "v3.2.0", LatestVersion: "v3.2.1", HasUpdate: true,
+	})
+
+	result, err := eng.RunPreflight("mempool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CanProceed {
+		t.Error("expected CanProceed false when a dependency is not in the registry")
+	}
+	assertCheck(t, result, "dependency_ghost", "fail", "dependency not found in registry", true)
+}
+
+func TestRunPreflight_DependencyHealthy(t *testing.T) {
+	agent := newMockAgent(mockAgentOpts{})
+	defer agent.Close()
+
+	dep := model.ServiceTemplate{
+		ID:             "bitcoind",
+		DisplayName:    "Bitcoin Core",
+		ComposeDir:     t.TempDir(),
+		ContainerNames: []string{"truffels-bitcoind"},
+	}
+	tmpl := mempoolTemplate(t, t.TempDir())
+	tmpl.Dependencies = []string{"bitcoind"}
+
+	eng, st := newTestEngine(t, agent, []model.ServiceTemplate{dep, tmpl})
+	_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+		ServiceID: "mempool", CurrentVersion: "v3.2.0", LatestVersion: "v3.2.1", HasUpdate: true,
+	})
+
+	result, err := eng.RunPreflight("mempool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCheck(t, result, "dependency_bitcoind", "pass", "bitcoind is healthy", true)
+}
+
+// The disk check reads a fixed path that does not exist in a test container, so
+// both arms are reached through the statfs seam rather than the real filesystem.
+func TestRunPreflight_DiskSpace(t *testing.T) {
+	cases := []struct {
+		name       string
+		bavail     uint64
+		wantStatus string
+		wantMsg    string
+		wantCan    bool
+	}{
+		{"enough", 1 << 20, "pass", "4.0 GB available", true},
+		{"too little", 1 << 17, "fail", "insufficient disk space: 0.5 GB available (need 2 GB)", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := statfs
+			t.Cleanup(func() { statfs = orig })
+			statfs = func(_ string, buf *syscall.Statfs_t) error {
+				*buf = syscall.Statfs_t{Bsize: 4096, Bavail: tc.bavail}
+				return nil
+			}
+
+			agent := newMockAgent(mockAgentOpts{})
+			defer agent.Close()
+
+			tmpl := mempoolTemplate(t, t.TempDir())
+			eng, st := newTestEngine(t, agent, []model.ServiceTemplate{tmpl})
+			_ = st.UpsertUpdateCheck(&model.UpdateCheck{
+				ServiceID: "mempool", CurrentVersion: "v3.2.0", LatestVersion: "v3.2.1", HasUpdate: true,
+			})
+
+			result, err := eng.RunPreflight("mempool")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertCheck(t, result, "disk_space", tc.wantStatus, tc.wantMsg, true)
+			if result.CanProceed != tc.wantCan {
+				t.Errorf("expected CanProceed %v, got %v", tc.wantCan, result.CanProceed)
+			}
+		})
+	}
+}
+
+// assertCheck asserts that exactly one check by that name exists and carries the
+// expected status, message and blocking flag.
+func assertCheck(t *testing.T, r *model.PreflightResult, name, status, msg string, blocking bool) {
+	t.Helper()
+	var found []model.PreflightCheck
+	for _, c := range r.Checks {
+		if c.Name == name {
+			found = append(found, c)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one %q check, got %d (%+v)", name, len(found), r.Checks)
+	}
+	c := found[0]
+	if c.Status != status {
+		t.Errorf("%s: expected status %q, got %q", name, status, c.Status)
+	}
+	if c.Message != msg {
+		t.Errorf("%s: expected message %q, got %q", name, msg, c.Message)
+	}
+	if c.Blocking != blocking {
+		t.Errorf("%s: expected blocking %v, got %v", name, blocking, c.Blocking)
+	}
+}


### PR DESCRIPTION
A simplification pass over the three largest hot spots, measured before it was
attempted and verified after. Production code shrinks by 169 lines; test code
grows by 1744 and nothing existing was deleted.

Every refactor is two commits: one that pins the current behaviour with tests,
one that changes the code. The tests written in the first commit are not touched
by the second — that they still pass is the evidence the change preserved
behaviour, rather than a claim that it did.

## What was measured first

| | before | after |
|---|---|---|
| `internal/docker` coverage | 30.1 % | 84.5 % |
| `internal/updates` coverage | 80.0 % | 83.1 % |
| `truffels-agent` coverage | 63.6 % | 68.7 % |
| `docker/compose.go` | 703 lines | 627 |
| `updates/engine.go` | 1430 lines | 1398 |
| `agent/main.go` | 2544 lines | 2483 |

The two coverage figures that dip after a refactor are arithmetic, not
regression: in both cases the set of uncovered statements is identical before
and after, and only covered statements were deleted, so the same remainder
weighs more in the ratio.

## The compose client

`compose.go` held 30 methods that all made the same request. Counted:
26 body-closes, 24 status comparisons, 21 marshals, 18 posts. Now: 4, 0, 0, 1.

The client had 30.1 % coverage, so the tests came first — a full characterization
of path, payload, success shape, non-200 handling and transport failure for every
method that the refactor would touch.

Two behaviours the tests pinned rather than fixed, because a cleanup that quietly
changes behaviour is worse than one that leaves a known defect and names it:

- `SystemInfoGet` and `HostDirSize` never check the response status. A 500 with a
  parseable body is reported as success — the same shape of untruth the last six
  releases were about. They route through a decode-only helper now, preserving
  that exactly. **This should be fixed, in its own change with its own test.**
- Six methods still drop the agent's diagnostic output on failure. Unifying them
  is a behaviour change and belongs in its own commit.

`FileReconcile` and `ReconcileFile` turned out to be exact duplicates; one now
delegates to the other.

## The update engine

24 sites write a failed-update log, and 23 alert next to it — but only 14 of them
use the same string three times. The other nine deliberately word the log, the
alert and the returned error differently, and folding those into a helper would
mean three string parameters and a worse read. Only the 14 were folded.

Nine of those fourteen had no test at all before this branch.

`RunPreflight` dropped from 165 lines to 113: it built fifteen four-field struct
literals, and every blocking result had to separately remember to set
`CanProceed = false`. Three named constructors make that coupling structural
instead of a thing to remember.

`RollbackService` (204 lines) and `ApplyUpdateToVersion` (174) were examined and
deliberately left alone. The obvious extraction in each needs roughly six
parameters — nearly the whole local state — which produces a jump label, not an
abstraction. In `RollbackService` the ordering *is* the correctness (verify before
tagging, image before compose file), and splitting it across two functions means
that order can no longer be read in one place.

## The agent

31 of 33 command invocations went through the same five lines of mechanics.
Two shared helpers replace them: one for combined output, one for stdout only —
kept separate because the inspect calls parse their output as JSON, and merging
stderr into it would be a real behaviour change.

Two sites were left explicit: one needs stderr alone, the other needs the streams
separated because its stdout is a NUL-separated path list whose entries are then
deleted, and a git warning in the same buffer would become a path.

This file holds every security boundary in the system, and the process runs as
root with the docker socket. So the constraint was that none of it moves:

- No validation function, call site, or position in the control flow changed.
  Verified by checking every added and removed line in the diff against all
  fourteen security identifiers: zero hits, they appear only as unchanged
  context, and the reference count is 47 before and 47 after.
- The status codes and the error text literals are byte-identical before and
  after, compared as sorted sets.
- The timeout values are byte-identical, compared the same way.

## Architecture

The package graph was checked and is not the problem: it is acyclic and cleanly
layered, `model` at the bottom, `store`/`docker`/`service` in the middle,
`api`/`updates`/`alerts`/`compose` above. No layering violations. What is
oversized is individual files inside otherwise healthy packages, which is a
different fix — splitting, not simplifying — and it is not in this change.

`agent/main.go` at 2483 lines is the main candidate. It would be a pure-movement
diff and belongs on its own. Worth knowing before doing it: everything stays in
`package main`, so a split buys navigability, not encapsulation — and the four
allowlists that a reviewer can find with one grep today would end up spread over
four files unless they move together into one.

## Two findings that are not fixed here

- 21 files are not `gofmt`-clean, an 818-line formatting diff. There is no
  `.golangci.yml`, so lint runs the default set, which excludes `gofmt` — which
  is why nobody saw it. Enabling it and running the formatter once is the fix,
  and it must be its own pull request or it buries everything else.
- `handleStats` discarded stderr into a buffer nobody read; it now goes to
  `/dev/null`. Output is bit-identical, the mechanism differs slightly. Named
  because it is the one micro-change that is not purely mechanical.

Both Go suites pass, `go vet` is clean, and golangci-lint reports nothing on
either module.
