### PR TITLE
Enforce gofmt, and format the files that had drifted

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+# golangci-lint runs its default set unless told otherwise, and gofmt is not in
+# it. That is why 21 files had drifted out of gofmt shape without anyone
+# noticing — the linter was green the whole time.
+#
+# This adds gofmt to the defaults rather than replacing them: errcheck, gosimple,
+# govet, ineffassign, staticcheck and unused stay on.
+#
+# Found in both module directories because golangci-lint searches upwards from
+# its working directory, and CI sets working-directory per module.
+linters:
+  enable:
+    - gofmt

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -21,35 +21,35 @@ import (
 
 // Allowlisted service IDs and their compose directory names.
 var allowedServices = map[string]string{
-	"bitcoind":        "bitcoin",
-	"electrs":         "electrs",
-	"ckpool":          "ckpool",
-	"mempool":         "mempool",
-	"ckstats":         "ckstats",
-	"proxy":           "proxy",
-	"mempool-db":      "mempool",
-	"ckstats-db":      "ckstats",
-	"truffels":        "truffels",
-	"truffels-agent":  "truffels",
-	"truffels-api":    "truffels",
-	"truffels-web":    "truffels",
+	"bitcoind":       "bitcoin",
+	"electrs":        "electrs",
+	"ckpool":         "ckpool",
+	"mempool":        "mempool",
+	"ckstats":        "ckstats",
+	"proxy":          "proxy",
+	"mempool-db":     "mempool",
+	"ckstats-db":     "ckstats",
+	"truffels":       "truffels",
+	"truffels-agent": "truffels",
+	"truffels-api":   "truffels",
+	"truffels-web":   "truffels",
 }
 
 // Allowlisted container names for inspection.
 var allowedContainers = map[string]bool{
-	"truffels-bitcoind":          true,
-	"truffels-electrs":           true,
-	"truffels-ckpool":            true,
-	"truffels-mempool-backend":   true,
-	"truffels-mempool-frontend":  true,
-	"truffels-mempool-db":        true,
-	"truffels-ckstats":           true,
-	"truffels-ckstats-cron":      true,
-	"truffels-ckstats-db":        true,
-	"truffels-proxy":             true,
-	"truffels-agent":             true,
-	"truffels-api":               true,
-	"truffels-web":               true,
+	"truffels-bitcoind":         true,
+	"truffels-electrs":          true,
+	"truffels-ckpool":           true,
+	"truffels-mempool-backend":  true,
+	"truffels-mempool-frontend": true,
+	"truffels-mempool-db":       true,
+	"truffels-ckstats":          true,
+	"truffels-ckstats-cron":     true,
+	"truffels-ckstats-db":       true,
+	"truffels-proxy":            true,
+	"truffels-agent":            true,
+	"truffels-api":              true,
+	"truffels-web":              true,
 }
 
 var composeRoot string
@@ -692,14 +692,14 @@ func handleImageTag(w http.ResponseWriter, r *http.Request) {
 // --- Container Stats ---
 
 type containerStats struct {
-	Name           string  `json:"name"`
-	CPUPercent     float64 `json:"cpu_percent"`
-	MemUsageMB     float64 `json:"mem_usage_mb"`
-	MemLimitMB     float64 `json:"mem_limit_mb"`
-	NetRxBytes     int64   `json:"net_rx_bytes"`
-	NetTxBytes     int64   `json:"net_tx_bytes"`
-	BlockReadBytes  int64  `json:"block_read_bytes"`
-	BlockWriteBytes int64  `json:"block_write_bytes"`
+	Name            string  `json:"name"`
+	CPUPercent      float64 `json:"cpu_percent"`
+	MemUsageMB      float64 `json:"mem_usage_mb"`
+	MemLimitMB      float64 `json:"mem_limit_mb"`
+	NetRxBytes      int64   `json:"net_rx_bytes"`
+	NetTxBytes      int64   `json:"net_tx_bytes"`
+	BlockReadBytes  int64   `json:"block_read_bytes"`
+	BlockWriteBytes int64   `json:"block_write_bytes"`
 }
 
 type dockerStatsJSON struct {
@@ -2405,17 +2405,17 @@ func handleClearDir(w http.ResponseWriter, r *http.Request) {
 
 // serviceContainers maps service IDs to their container names for fallback log retrieval.
 var serviceContainers = map[string][]string{
-	"bitcoind":        {"truffels-bitcoind"},
-	"electrs":         {"truffels-electrs"},
-	"ckpool":          {"truffels-ckpool"},
-	"mempool":         {"truffels-mempool-backend", "truffels-mempool-frontend"},
-	"ckstats":         {"truffels-ckstats", "truffels-ckstats-cron"},
-	"proxy":           {"truffels-proxy"},
-	"mempool-db":      {"truffels-mempool-db"},
-	"ckstats-db":      {"truffels-ckstats-db"},
-	"truffels-agent":  {"truffels-agent"},
-	"truffels-api":    {"truffels-api"},
-	"truffels-web":    {"truffels-web"},
+	"bitcoind":       {"truffels-bitcoind"},
+	"electrs":        {"truffels-electrs"},
+	"ckpool":         {"truffels-ckpool"},
+	"mempool":        {"truffels-mempool-backend", "truffels-mempool-frontend"},
+	"ckstats":        {"truffels-ckstats", "truffels-ckstats-cron"},
+	"proxy":          {"truffels-proxy"},
+	"mempool-db":     {"truffels-mempool-db"},
+	"ckstats-db":     {"truffels-ckstats-db"},
+	"truffels-agent": {"truffels-agent"},
+	"truffels-api":   {"truffels-api"},
+	"truffels-web":   {"truffels-web"},
 }
 
 // fallbackContainerLogs uses `docker logs` directly when `docker compose logs` returns empty.

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -786,8 +786,8 @@ func TestHandleSystemInfo_EmitsTopLevelServiceDataPath(t *testing.T) {
 		gotPaths[sd.Path] = true
 	}
 	mustHave := []string{
-		filepath.Join(tmpRoot, "ckpool"),              // 1-level template path
-		filepath.Join(tmpRoot, "truffels"),            // 1-level + no child dirs
+		filepath.Join(tmpRoot, "ckpool"),                // 1-level template path
+		filepath.Join(tmpRoot, "truffels"),              // 1-level + no child dirs
 		filepath.Join(tmpRoot, "bitcoin", "blockchain"), // 2-level template path
 	}
 	for _, p := range mustHave {
@@ -1048,15 +1048,15 @@ func TestIsValidCommitHash(t *testing.T) {
 	}
 
 	invalid := []string{
-		"",                                          // leer
-		"4bcced",                                    // 6 Zeichen, zu kurz
+		"",       // leer
+		"4bcced", // 6 Zeichen, zu kurz
 		"4bccedb1234567890abcdef1234567890abcdef12", // 41 Zeichen, zu lang
-		"4BCCEDB",                                   // Großbuchstaben
-		"v1.2.0",                                    // Tag, kein Hash
-		"4bccedb; rm -rf /",                         // Shell-Metazeichen
-		"../../../etc/passwd",                       // Pfad-Traversal
-		"4bccedb\n--upload-pack=evil",               // Newline-Injection
-		"-4bccedb",                                  // führender Bindestrich, sieht wie ein Flag aus
+		"4BCCEDB",                     // Großbuchstaben
+		"v1.2.0",                      // Tag, kein Hash
+		"4bccedb; rm -rf /",           // Shell-Metazeichen
+		"../../../etc/passwd",         // Pfad-Traversal
+		"4bccedb\n--upload-pack=evil", // Newline-Injection
+		"-4bccedb",                    // führender Bindestrich, sieht wie ein Flag aus
 	}
 	for _, s := range invalid {
 		if isValidCommitHash(s) {

--- a/truffels-api/internal/alerts/reclaim_test.go
+++ b/truffels-api/internal/alerts/reclaim_test.go
@@ -10,15 +10,15 @@ import (
 func baseInput() reclaimInput {
 	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
 	return reclaimInput{
-		SizeBytes:       950 * 1024 * 1024,
-		CriticalBytes:   900 * 1024 * 1024,
-		Enabled:         true,
-		MinInterval:     24 * time.Hour,
-		LastReclaim:     now.Add(-48 * time.Hour),
-		HasLastReclaim:  true,
-		Now:             now,
-		ServiceRunning:  true,
-		TargetClearable: true,
+		SizeBytes:          950 * 1024 * 1024,
+		CriticalBytes:      900 * 1024 * 1024,
+		Enabled:            true,
+		MinInterval:        24 * time.Hour,
+		LastReclaim:        now.Add(-48 * time.Hour),
+		HasLastReclaim:     true,
+		Now:                now,
+		ServiceRunning:     true,
+		TargetClearable:    true,
 		TargetRequiresStop: true,
 	}
 }

--- a/truffels-api/internal/api/backup.go
+++ b/truffels-api/internal/api/backup.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	backupDir    = "/srv/truffels/backups"
-	maxBackups   = 5
+	backupDir  = "/srv/truffels/backups"
+	maxBackups = 5
 )
 
 func (s *Server) handleBackupExport(w http.ResponseWriter, r *http.Request) {

--- a/truffels-api/internal/api/dashboard.go
+++ b/truffels-api/internal/api/dashboard.go
@@ -18,15 +18,15 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 type dashboardResponse struct {
-	Host     model.HostMetrics     `json:"host"`
-	Services []dashboardService    `json:"services"`
-	Alerts   dashboardAlerts       `json:"alerts"`
+	Host     model.HostMetrics  `json:"host"`
+	Services []dashboardService `json:"services"`
+	Alerts   dashboardAlerts    `json:"alerts"`
 }
 
 type dashboardService struct {
-	ID          string               `json:"id"`
-	DisplayName string               `json:"display_name"`
-	State       model.ServiceState   `json:"state"`
+	ID          string                 `json:"id"`
+	DisplayName string                 `json:"display_name"`
+	State       model.ServiceState     `json:"state"`
 	Containers  []model.ContainerState `json:"containers"`
 }
 

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -275,8 +275,8 @@ func TestServiceAction_Stop_Success(t *testing.T) {
 	agentState := &mockAgentState{
 		containerStates: map[string]model.ContainerState{
 			// electrs (dependent of bitcoind) is stopped — safe to stop bitcoind
-			"truffels-electrs":  {Name: "truffels-electrs", Status: "exited", Health: ""},
-			"truffels-ckpool":   {Name: "truffels-ckpool", Status: "exited", Health: ""},
+			"truffels-electrs": {Name: "truffels-electrs", Status: "exited", Health: ""},
+			"truffels-ckpool":  {Name: "truffels-ckpool", Status: "exited", Health: ""},
 			// mempool containers also stopped
 			"truffels-mempool-backend":  {Name: "truffels-mempool-backend", Status: "exited", Health: ""},
 			"truffels-mempool-frontend": {Name: "truffels-mempool-frontend", Status: "exited", Health: ""},
@@ -1820,8 +1820,8 @@ func TestSystemTuningGet_Success(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	var body struct {
-		PersistentJournal bool `json:"persistent_journal"`
-		Swappiness        int  `json:"swappiness"`
+		PersistentJournal bool   `json:"persistent_journal"`
+		Swappiness        int    `json:"swappiness"`
 		JournalDiskUsage  string `json:"journal_disk_usage"`
 		Boots             []struct {
 			Index int    `json:"index"`

--- a/truffels-api/internal/api/settings.go
+++ b/truffels-api/internal/api/settings.go
@@ -11,25 +11,25 @@ import (
 
 // settingsDefaults are the default values for all configurable settings.
 var settingsDefaults = map[string]string{
-	"restart_loop_count":      "5",
-	"restart_loop_window_min": "10",
-	"restart_loop_max_retries": "10",
-	"dep_handling_mode":       "flag_only",
-	"temp_warning":            "75",
-	"temp_critical":           "80",
-	"admission_disk_min_gb":          "10",
-	"admission_temp_max":             "80",
-	"update_check_interval_hours":    "24",
-	"update_check_enabled":           "true",
-	"update_channel":                 "stable",
-	"services_show_memory":           "false",
-	"services_show_ports":            "true",
-	"update_keep_old_images":         "false",
-	"trend_alert_enabled":            "true",
-	"trend_alert_horizon_hours":      "6",
-	"trend_alert_lookback_hours":     "6",
-	"trend_alert_min_data_hours":     "2",
-	"allow_downgrade":                "false",
+	"restart_loop_count":                      "5",
+	"restart_loop_window_min":                 "10",
+	"restart_loop_max_retries":                "10",
+	"dep_handling_mode":                       "flag_only",
+	"temp_warning":                            "75",
+	"temp_critical":                           "80",
+	"admission_disk_min_gb":                   "10",
+	"admission_temp_max":                      "80",
+	"update_check_interval_hours":             "24",
+	"update_check_enabled":                    "true",
+	"update_channel":                          "stable",
+	"services_show_memory":                    "false",
+	"services_show_ports":                     "true",
+	"update_keep_old_images":                  "false",
+	"trend_alert_enabled":                     "true",
+	"trend_alert_horizon_hours":               "6",
+	"trend_alert_lookback_hours":              "6",
+	"trend_alert_min_data_hours":              "2",
+	"allow_downgrade":                         "false",
 	"dir_size_warning_mb":                     "700",
 	"dir_size_critical_mb":                    "900",
 	"dir_size_autoreclaim_enabled":            "true",
@@ -37,52 +37,52 @@ var settingsDefaults = map[string]string{
 }
 
 type settingsResponse struct {
-	RestartLoopCount      int     `json:"restart_loop_count"`
-	RestartLoopWindowMin  int     `json:"restart_loop_window_min"`
-	RestartLoopMaxRetries int     `json:"restart_loop_max_retries"`
-	DepHandlingMode       string  `json:"dep_handling_mode"`
-	TempWarning           float64 `json:"temp_warning"`
-	TempCritical          float64 `json:"temp_critical"`
-	AdmissionDiskMinGB        float64 `json:"admission_disk_min_gb"`
-	AdmissionTempMax          float64 `json:"admission_temp_max"`
-	UpdateCheckIntervalHours int     `json:"update_check_interval_hours"`
-	UpdateCheckEnabled       bool    `json:"update_check_enabled"`
-	UpdateChannel            string  `json:"update_channel"`
-	ServicesShowMemory       bool    `json:"services_show_memory"`
-	ServicesShowPorts         bool    `json:"services_show_ports"`
-	UpdateKeepOldImages      bool    `json:"update_keep_old_images"`
-	TrendAlertEnabled        bool    `json:"trend_alert_enabled"`
-	TrendAlertHorizonHours   int     `json:"trend_alert_horizon_hours"`
-	TrendAlertLookbackHours  int     `json:"trend_alert_lookback_hours"`
-	TrendAlertMinDataHours   int     `json:"trend_alert_min_data_hours"`
-	AllowDowngrade           bool    `json:"allow_downgrade"`
-	DirSizeWarningMB                   int  `json:"dir_size_warning_mb"`
-	DirSizeCriticalMB                  int  `json:"dir_size_critical_mb"`
-	DirSizeAutoreclaimEnabled          bool `json:"dir_size_autoreclaim_enabled"`
-	DirSizeAutoreclaimMinIntervalHours int  `json:"dir_size_autoreclaim_min_interval_hours"`
+	RestartLoopCount                   int     `json:"restart_loop_count"`
+	RestartLoopWindowMin               int     `json:"restart_loop_window_min"`
+	RestartLoopMaxRetries              int     `json:"restart_loop_max_retries"`
+	DepHandlingMode                    string  `json:"dep_handling_mode"`
+	TempWarning                        float64 `json:"temp_warning"`
+	TempCritical                       float64 `json:"temp_critical"`
+	AdmissionDiskMinGB                 float64 `json:"admission_disk_min_gb"`
+	AdmissionTempMax                   float64 `json:"admission_temp_max"`
+	UpdateCheckIntervalHours           int     `json:"update_check_interval_hours"`
+	UpdateCheckEnabled                 bool    `json:"update_check_enabled"`
+	UpdateChannel                      string  `json:"update_channel"`
+	ServicesShowMemory                 bool    `json:"services_show_memory"`
+	ServicesShowPorts                  bool    `json:"services_show_ports"`
+	UpdateKeepOldImages                bool    `json:"update_keep_old_images"`
+	TrendAlertEnabled                  bool    `json:"trend_alert_enabled"`
+	TrendAlertHorizonHours             int     `json:"trend_alert_horizon_hours"`
+	TrendAlertLookbackHours            int     `json:"trend_alert_lookback_hours"`
+	TrendAlertMinDataHours             int     `json:"trend_alert_min_data_hours"`
+	AllowDowngrade                     bool    `json:"allow_downgrade"`
+	DirSizeWarningMB                   int     `json:"dir_size_warning_mb"`
+	DirSizeCriticalMB                  int     `json:"dir_size_critical_mb"`
+	DirSizeAutoreclaimEnabled          bool    `json:"dir_size_autoreclaim_enabled"`
+	DirSizeAutoreclaimMinIntervalHours int     `json:"dir_size_autoreclaim_min_interval_hours"`
 }
 
 func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	resp := settingsResponse{
-		RestartLoopCount:      s.getSettingInt("restart_loop_count", 5),
-		RestartLoopWindowMin:  s.getSettingInt("restart_loop_window_min", 10),
-		RestartLoopMaxRetries: s.getSettingInt("restart_loop_max_retries", 10),
-		DepHandlingMode:       s.getSettingStr("dep_handling_mode", "flag_only"),
-		TempWarning:           s.getSettingFloat("temp_warning", 75),
-		TempCritical:          s.getSettingFloat("temp_critical", 80),
-		AdmissionDiskMinGB:        s.getSettingFloat("admission_disk_min_gb", 10),
-		AdmissionTempMax:          s.getSettingFloat("admission_temp_max", 80),
-		UpdateCheckIntervalHours: s.getSettingInt("update_check_interval_hours", 24),
-		UpdateCheckEnabled:       s.getSettingStr("update_check_enabled", "true") == "true",
-		UpdateChannel:            s.getSettingStr("update_channel", "stable"),
-		ServicesShowMemory:       s.getSettingStr("services_show_memory", "false") == "true",
-		ServicesShowPorts:         s.getSettingStr("services_show_ports", "true") == "true",
-		UpdateKeepOldImages:      s.getSettingStr("update_keep_old_images", "false") == "true",
-		TrendAlertEnabled:        s.getSettingStr("trend_alert_enabled", "true") == "true",
-		TrendAlertHorizonHours:   s.getSettingInt("trend_alert_horizon_hours", 6),
-		TrendAlertLookbackHours:  s.getSettingInt("trend_alert_lookback_hours", 6),
-		TrendAlertMinDataHours:   s.getSettingInt("trend_alert_min_data_hours", 2),
-		AllowDowngrade:           s.getSettingStr("allow_downgrade", "false") == "true",
+		RestartLoopCount:                   s.getSettingInt("restart_loop_count", 5),
+		RestartLoopWindowMin:               s.getSettingInt("restart_loop_window_min", 10),
+		RestartLoopMaxRetries:              s.getSettingInt("restart_loop_max_retries", 10),
+		DepHandlingMode:                    s.getSettingStr("dep_handling_mode", "flag_only"),
+		TempWarning:                        s.getSettingFloat("temp_warning", 75),
+		TempCritical:                       s.getSettingFloat("temp_critical", 80),
+		AdmissionDiskMinGB:                 s.getSettingFloat("admission_disk_min_gb", 10),
+		AdmissionTempMax:                   s.getSettingFloat("admission_temp_max", 80),
+		UpdateCheckIntervalHours:           s.getSettingInt("update_check_interval_hours", 24),
+		UpdateCheckEnabled:                 s.getSettingStr("update_check_enabled", "true") == "true",
+		UpdateChannel:                      s.getSettingStr("update_channel", "stable"),
+		ServicesShowMemory:                 s.getSettingStr("services_show_memory", "false") == "true",
+		ServicesShowPorts:                  s.getSettingStr("services_show_ports", "true") == "true",
+		UpdateKeepOldImages:                s.getSettingStr("update_keep_old_images", "false") == "true",
+		TrendAlertEnabled:                  s.getSettingStr("trend_alert_enabled", "true") == "true",
+		TrendAlertHorizonHours:             s.getSettingInt("trend_alert_horizon_hours", 6),
+		TrendAlertLookbackHours:            s.getSettingInt("trend_alert_lookback_hours", 6),
+		TrendAlertMinDataHours:             s.getSettingInt("trend_alert_min_data_hours", 2),
+		AllowDowngrade:                     s.getSettingStr("allow_downgrade", "false") == "true",
 		DirSizeWarningMB:                   s.getSettingInt("dir_size_warning_mb", 700),
 		DirSizeCriticalMB:                  s.getSettingInt("dir_size_critical_mb", 900),
 		DirSizeAutoreclaimEnabled:          s.getSettingStr("dir_size_autoreclaim_enabled", "true") == "true",

--- a/truffels-api/internal/bitcoin/rpc.go
+++ b/truffels-api/internal/bitcoin/rpc.go
@@ -96,21 +96,21 @@ type BlockchainInfo struct {
 }
 
 type NetworkInfo struct {
-	Version        int    `json:"version"`
-	SubVersion     string `json:"subversion"`
-	ProtocolVersion int   `json:"protocolversion"`
-	Connections    int    `json:"connections"`
-	ConnectionsIn  int    `json:"connections_in"`
-	ConnectionsOut int    `json:"connections_out"`
+	Version         int    `json:"version"`
+	SubVersion      string `json:"subversion"`
+	ProtocolVersion int    `json:"protocolversion"`
+	Connections     int    `json:"connections"`
+	ConnectionsIn   int    `json:"connections_in"`
+	ConnectionsOut  int    `json:"connections_out"`
 }
 
 type MempoolInfo struct {
-	Size           int     `json:"size"`
-	Bytes          int     `json:"bytes"`
-	Usage          int     `json:"usage"`
-	TotalFee       float64 `json:"total_fee"`
-	MempoolMinFee  float64 `json:"mempoolminfee"`
-	MinRelayTxFee  float64 `json:"minrelaytxfee"`
+	Size          int     `json:"size"`
+	Bytes         int     `json:"bytes"`
+	Usage         int     `json:"usage"`
+	TotalFee      float64 `json:"total_fee"`
+	MempoolMinFee float64 `json:"mempoolminfee"`
+	MinRelayTxFee float64 `json:"minrelaytxfee"`
 }
 
 func (c *Client) GetBlockchainInfo() (*BlockchainInfo, error) {

--- a/truffels-api/internal/compose/templates.go
+++ b/truffels-api/internal/compose/templates.go
@@ -459,7 +459,6 @@ networks:
     external: true
 `
 
-
 const truffelsTemplate = `# Project Truffels — Control Plane (agent + api + web)
 # Managed by truffels. Do not edit manually.
 

--- a/truffels-api/internal/compose/templates_test.go
+++ b/truffels-api/internal/compose/templates_test.go
@@ -125,7 +125,7 @@ func TestRender_Mempool(t *testing.T) {
 func TestRender_Ckstats(t *testing.T) {
 	got, err := Render("ckstats", CkstatsParams{
 		CkstatsImageTag: "truffels/ckstats:latest",
-		DBImageTag:       "postgres:16.13-alpine",
+		DBImageTag:      "postgres:16.13-alpine",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/truffels-api/internal/config/config.go
+++ b/truffels-api/internal/config/config.go
@@ -3,15 +3,15 @@ package config
 import "os"
 
 type Config struct {
-	Listen       string
-	DBPath       string
-	ComposeRoot  string
-	ConfigRoot   string
-	SecretsRoot  string
-	HostProc     string
-	HostSys      string
-	DataRoot     string
-	GitHubRepo   string // owner/repo for self-update checks (e.g. "bandrewk/truffels")
+	Listen      string
+	DBPath      string
+	ComposeRoot string
+	ConfigRoot  string
+	SecretsRoot string
+	HostProc    string
+	HostSys     string
+	DataRoot    string
+	GitHubRepo  string // owner/repo for self-update checks (e.g. "bandrewk/truffels")
 }
 
 func Load() *Config {

--- a/truffels-api/internal/model/host.go
+++ b/truffels-api/internal/model/host.go
@@ -1,26 +1,26 @@
 package model
 
 type HostMetrics struct {
-	CPUPercent    float64     `json:"cpu_percent"`
-	MemTotalMB    int64       `json:"mem_total_mb"`
-	MemUsedMB     int64       `json:"mem_used_mb"`
-	MemPercent    float64     `json:"mem_percent"`
-	Temperature   float64     `json:"temperature_c"`
-	FanRPM        int         `json:"fan_rpm"`
-	FanPercent    int         `json:"fan_percent"`
-	Disks         []DiskUsage `json:"disks"`
-	UptimeSeconds float64     `json:"uptime_seconds"`
-	NetRxBytes    int64       `json:"net_rx_bytes"`
-	NetTxBytes    int64       `json:"net_tx_bytes"`
-	DiskReadBytes  int64      `json:"disk_read_bytes"`
-	DiskWriteBytes int64      `json:"disk_write_bytes"`
-	DiskIOPercent  float64    `json:"disk_io_percent"`
+	CPUPercent     float64     `json:"cpu_percent"`
+	MemTotalMB     int64       `json:"mem_total_mb"`
+	MemUsedMB      int64       `json:"mem_used_mb"`
+	MemPercent     float64     `json:"mem_percent"`
+	Temperature    float64     `json:"temperature_c"`
+	FanRPM         int         `json:"fan_rpm"`
+	FanPercent     int         `json:"fan_percent"`
+	Disks          []DiskUsage `json:"disks"`
+	UptimeSeconds  float64     `json:"uptime_seconds"`
+	NetRxBytes     int64       `json:"net_rx_bytes"`
+	NetTxBytes     int64       `json:"net_tx_bytes"`
+	DiskReadBytes  int64       `json:"disk_read_bytes"`
+	DiskWriteBytes int64       `json:"disk_write_bytes"`
+	DiskIOPercent  float64     `json:"disk_io_percent"`
 }
 
 type DiskUsage struct {
-	Path       string  `json:"path"`
-	TotalGB    float64 `json:"total_gb"`
-	UsedGB     float64 `json:"used_gb"`
-	AvailGB    float64 `json:"avail_gb"`
+	Path        string  `json:"path"`
+	TotalGB     float64 `json:"total_gb"`
+	UsedGB      float64 `json:"used_gb"`
+	AvailGB     float64 `json:"avail_gb"`
 	UsedPercent float64 `json:"used_percent"`
 }

--- a/truffels-api/internal/model/monitoring.go
+++ b/truffels-api/internal/model/monitoring.go
@@ -86,9 +86,9 @@ type MonitoringResponse struct {
 // DirSizeSeries is the time series for one watched data dir, used by the
 // monitoring chart that warns about runaway caches (mempool rbfcache.json).
 type DirSizeSeries struct {
-	Label  string           `json:"label"`
-	Path   string           `json:"path"`
-	Points []DirSizePoint   `json:"points"`
+	Label  string         `json:"label"`
+	Path   string         `json:"path"`
+	Points []DirSizePoint `json:"points"`
 }
 
 type DirSizePoint struct {

--- a/truffels-api/internal/model/service.go
+++ b/truffels-api/internal/model/service.go
@@ -8,21 +8,21 @@ const (
 	StateRunning  ServiceState = "running"
 	StateStopped  ServiceState = "stopped"
 	StateDegraded ServiceState = "degraded"
-	StateUnknown   ServiceState = "unknown"
-	StateDisabled  ServiceState = "disabled"
+	StateUnknown  ServiceState = "unknown"
+	StateDisabled ServiceState = "disabled"
 )
 
 type ServiceTemplate struct {
-	ID             string   `json:"id"`
-	DisplayName    string   `json:"display_name"`
-	Description    string   `json:"description"`
-	ComposeDir     string   `json:"-"`
-	ContainerNames []string `json:"container_names"`
-	Dependencies   []string `json:"dependencies"`
-	MemoryLimit    string   `json:"memory_limit"`
-	ConfigPath     string   `json:"-"`
-	Port           string        `json:"port,omitempty"`
-	ReadOnly       bool          `json:"read_only,omitempty"`
+	ID               string        `json:"id"`
+	DisplayName      string        `json:"display_name"`
+	Description      string        `json:"description"`
+	ComposeDir       string        `json:"-"`
+	ContainerNames   []string      `json:"container_names"`
+	Dependencies     []string      `json:"dependencies"`
+	MemoryLimit      string        `json:"memory_limit"`
+	ConfigPath       string        `json:"-"`
+	Port             string        `json:"port,omitempty"`
+	ReadOnly         bool          `json:"read_only,omitempty"`
 	FloatingTag      bool          `json:"floating_tag,omitempty"`
 	RequiresUnpruned bool          `json:"requires_unpruned,omitempty"`
 	RequiresSynced   bool          `json:"requires_synced,omitempty"`
@@ -54,7 +54,7 @@ type EnsureDir struct {
 type DataDir struct {
 	Path         string `json:"path"`
 	Label        string `json:"label"`
-	Description  string `json:"description"`            // shown as warning text in Clear confirmation
+	Description  string `json:"description"` // shown as warning text in Clear confirmation
 	Clearable    bool   `json:"clearable"`
 	RequiresStop bool   `json:"requires_stop,omitempty"` // service must be stopped before clear
 }

--- a/truffels-api/internal/model/update.go
+++ b/truffels-api/internal/model/update.go
@@ -17,11 +17,11 @@ const (
 type SourceType string
 
 const (
-	SourceDockerHub       SourceType = "dockerhub"
-	SourceDockerDigest    SourceType = "docker_digest"
-	SourceGitHub          SourceType = "github"
-	SourceBitbucket       SourceType = "bitbucket"
-	SourceGitHubRelease   SourceType = "github_release"
+	SourceDockerHub     SourceType = "dockerhub"
+	SourceDockerDigest  SourceType = "docker_digest"
+	SourceGitHub        SourceType = "github"
+	SourceBitbucket     SourceType = "bitbucket"
+	SourceGitHubRelease SourceType = "github_release"
 )
 
 // UpdateSource defines where a service gets its updates from.
@@ -32,8 +32,8 @@ type UpdateSource struct {
 	Branch     string     `json:"branch,omitempty"`     // github/bitbucket: "main" or "master"
 	NeedsBuild bool       `json:"needs_build"`          // true for custom-built images (ckpool, ckstats)
 	TagFilter  string     `json:"tag_filter,omitempty"` // dockerhub: only consider tags matching this prefix (e.g. "2.9-alpine", "16-alpine")
-	RefScheme  string     `json:"ref_scheme,omitempty"`  // "tag" | "commit"; leer = "commit"
-	RepoDir    string     `json:"repo_dir,omitempty"`    // Arbeitskopie auf Platte, wenn das Dockerfile nicht selbst klont
+	RefScheme  string     `json:"ref_scheme,omitempty"` // "tag" | "commit"; leer = "commit"
+	RepoDir    string     `json:"repo_dir,omitempty"`   // Arbeitskopie auf Platte, wenn das Dockerfile nicht selbst klont
 }
 
 // RefScheme bestimmt, was die Discovery für einen NeedsBuild-Service anbietet.
@@ -46,13 +46,13 @@ const (
 
 // UpdateCheck represents the latest known version info for a service.
 type UpdateCheck struct {
-	ID             int64      `json:"id"`
-	ServiceID      string     `json:"service_id"`
-	CurrentVersion string     `json:"current_version"`  // current tag or commit hash
-	LatestVersion  string     `json:"latest_version"`   // latest tag or commit hash
-	HasUpdate      bool       `json:"has_update"`
-	CheckedAt      time.Time  `json:"checked_at"`
-	Error          string     `json:"error,omitempty"`
+	ID             int64     `json:"id"`
+	ServiceID      string    `json:"service_id"`
+	CurrentVersion string    `json:"current_version"` // current tag or commit hash
+	LatestVersion  string    `json:"latest_version"`  // latest tag or commit hash
+	HasUpdate      bool      `json:"has_update"`
+	CheckedAt      time.Time `json:"checked_at"`
+	Error          string    `json:"error,omitempty"`
 }
 
 // PreflightResult holds the outcome of pre-update checks for a service.
@@ -67,7 +67,7 @@ type PreflightResult struct {
 // PreflightCheck is a single pass/fail/warn check within a preflight result.
 type PreflightCheck struct {
 	Name     string `json:"name"`
-	Status   string `json:"status"`   // "pass", "fail", "warn"
+	Status   string `json:"status"` // "pass", "fail", "warn"
 	Message  string `json:"message"`
 	Blocking bool   `json:"blocking"`
 }

--- a/truffels-api/internal/service/templates/electrs.go
+++ b/truffels-api/internal/service/templates/electrs.go
@@ -3,13 +3,13 @@ package templates
 import "truffels-api/internal/model"
 
 var Electrs = model.ServiceTemplate{
-	ID:             "electrs",
-	DisplayName:    "electrs",
-	Description:    "Electrum Rust Server — Bitcoin address index for wallets and block explorers",
-	ContainerNames: []string{"truffels-electrs"},
-	Dependencies:   []string{"bitcoind"},
-	Port:           "50001 (Electrum)",
-	MemoryLimit:    "2048M",
+	ID:               "electrs",
+	DisplayName:      "electrs",
+	Description:      "Electrum Rust Server — Bitcoin address index for wallets and block explorers",
+	ContainerNames:   []string{"truffels-electrs"},
+	Dependencies:     []string{"bitcoind"},
+	Port:             "50001 (Electrum)",
+	MemoryLimit:      "2048M",
 	ConfigPath:       "electrs/electrs.toml",
 	RequiresUnpruned: true,
 	UpdateSource: &model.UpdateSource{

--- a/truffels-api/internal/service/templates/mempool.go
+++ b/truffels-api/internal/service/templates/mempool.go
@@ -3,15 +3,15 @@ package templates
 import "truffels-api/internal/model"
 
 var Mempool = model.ServiceTemplate{
-	ID:             "mempool",
-	DisplayName:    "mempool.space",
-	Description:    "Bitcoin block explorer and mempool visualizer",
-	ContainerNames: []string{"truffels-mempool-backend", "truffels-mempool-frontend"},
-	Dependencies:   []string{"bitcoind", "electrs", "mempool-db"},
-	MemoryLimit:    "3328M",
+	ID:               "mempool",
+	DisplayName:      "mempool.space",
+	Description:      "Bitcoin block explorer and mempool visualizer",
+	ContainerNames:   []string{"truffels-mempool-backend", "truffels-mempool-frontend"},
+	Dependencies:     []string{"bitcoind", "electrs", "mempool-db"},
+	MemoryLimit:      "3328M",
 	ConfigPath:       "",
 	RequiresUnpruned: true,
-	Port:           "80 (via proxy)",
+	Port:             "80 (via proxy)",
 	UpdateSource: &model.UpdateSource{
 		Type:   model.SourceDockerHub,
 		Images: []string{"mempool/backend", "mempool/frontend"},
@@ -24,10 +24,10 @@ var Mempool = model.ServiceTemplate{
 	},
 	DataDirs: []model.DataDir{
 		{
-			Path:        "/srv/truffels/data/mempool/cache",
-			Label:       "Mempool cache",
-			Description: "RBF + mempool state cache. Safe to clear — rebuilt from electrs on next start. The mempool backend will be briefly stopped during clear.",
-			Clearable:   true,
+			Path:         "/srv/truffels/data/mempool/cache",
+			Label:        "Mempool cache",
+			Description:  "RBF + mempool state cache. Safe to clear — rebuilt from electrs on next start. The mempool backend will be briefly stopped during clear.",
+			Clearable:    true,
 			RequiresStop: true,
 		},
 		{

--- a/truffels-api/internal/updates/apply_test.go
+++ b/truffels-api/internal/updates/apply_test.go
@@ -24,16 +24,16 @@ import (
 // downHandler is called for /v1/compose/down requests.
 // inspectHandler is called for /v1/inspect requests.
 type mockAgentOpts struct {
-	pullFail    bool
-	upFail      bool
-	downFail    bool
-	buildFail   bool
-	unhealthy   bool // if true, inspect returns unhealthy containers
-	imageInspectFail bool   // if true, /v1/image/inspect returns 500
-	tagFail          bool   // if true, /v1/image/tag returns 500 (no staged rollback image)
-	rewriteFail      bool   // if true, /v1/compose/rewrite-tags returns 500
-	gitCheckoutFail  bool   // if true, /v1/git/checkout returns 500
-	detachedFail     bool   // if true, /v1/compose/up-detached returns 500
+	pullFail         bool
+	upFail           bool
+	downFail         bool
+	buildFail        bool
+	unhealthy        bool              // if true, inspect returns unhealthy containers
+	imageInspectFail bool              // if true, /v1/image/inspect returns 500
+	tagFail          bool              // if true, /v1/image/tag returns 500 (no staged rollback image)
+	rewriteFail      bool              // if true, /v1/compose/rewrite-tags returns 500
+	gitCheckoutFail  bool              // if true, /v1/git/checkout returns 500
+	detachedFail     bool              // if true, /v1/compose/up-detached returns 500
 	composeDirs      map[string]string // service_id -> compose dir path for rewrite-tags
 	imageLabels      map[string]string // labels returned by /v1/image/inspect (NeedsBuild verification)
 	tags             *tagRecorder      // records /v1/image/tag calls when set

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -18,14 +18,14 @@ import (
 )
 
 type Engine struct {
-	store    *store.Store
-	registry *service.Registry
-	compose  *docker.ComposeClient
-	stopCh   chan struct{}
-	triggerCh chan struct{}
-	mu       sync.Mutex
-	updating map[string]bool // services currently being updated
-	healthWait time.Duration  // wait before health check (default 30s)
+	store      *store.Store
+	registry   *service.Registry
+	compose    *docker.ComposeClient
+	stopCh     chan struct{}
+	triggerCh  chan struct{}
+	mu         sync.Mutex
+	updating   map[string]bool // services currently being updated
+	healthWait time.Duration   // wait before health check (default 30s)
 }
 
 func NewEngine(s *store.Store, r *service.Registry, c *docker.ComposeClient) *Engine {

--- a/truffels-api/internal/updates/engine_test.go
+++ b/truffels-api/internal/updates/engine_test.go
@@ -1614,7 +1614,9 @@ func TestPruneOldImages_KeepsCurrentAndN1(t *testing.T) {
 	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/image/remove":
-			var req struct{ Image string `json:"image"` }
+			var req struct {
+				Image string `json:"image"`
+			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			removedImages = append(removedImages, req.Image)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
@@ -1666,7 +1668,9 @@ func TestPruneOldImages_RespectsSetting(t *testing.T) {
 	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/image/remove":
-			var req struct{ Image string `json:"image"` }
+			var req struct {
+				Image string `json:"image"`
+			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			removedImages = append(removedImages, req.Image)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})

--- a/truffels-api/internal/updates/registry.go
+++ b/truffels-api/internal/updates/registry.go
@@ -640,8 +640,8 @@ func matchTagFilter(tag, filter string) bool {
 		return tag == filter
 	}
 
-	prefix := filter[:idx]  // e.g. "2" or "16"
-	suffix := filter[idx:]  // e.g. "-alpine"
+	prefix := filter[:idx] // e.g. "2" or "16"
+	suffix := filter[idx:] // e.g. "-alpine"
 
 	if !strings.HasPrefix(tag, prefix) {
 		return false


### PR DESCRIPTION
`golangci-lint` runs its default set when a repository has no config, and `gofmt`
is not in that set. There was no config here, so the linter reported nothing
while 21 files drifted out of gofmt shape — one of them `model/update.go`, whose
misaligned struct tags were spotted in a review months ago and filed away as a
minor because "lint is green".

The config sits at the repository root rather than in each module. golangci-lint
searches upward from its working directory, and CI sets `working-directory` per
module, so one file covers both. That was verified rather than assumed: a
deliberately misformatted file planted in `internal/config` is reported as
`File is not properly formatted (gofmt)` when the linter runs from inside
`truffels-api` with no command-line flag.

The formatting diff carries no behaviour. Twenty of the files differ only in
whitespace — proven by stripping all whitespace from each and comparing. The
twenty-first, `truffels-agent/main.go`, additionally had its import block sorted,
which Go treats as a set, so the order has no effect.

Both modules build and vet clean.