### PR TITLE
Reject a failure status before decoding the body

### DIFF
--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -178,16 +178,25 @@ func (c *ComposeClient) callInto(op string, r agentReq, out any) error {
 	return nil
 }
 
-// callDecode sends r and decodes the body into out without consulting the
-// status code. The two host-info endpoints have always behaved this way: an
-// agent that answers with a parseable body is treated as a success even when it
-// reports a failure status.
+// callDecode sends r, rejects a failure status, and decodes the body into out.
+//
+// The status check is the point. Without it a 500 whose body happens to parse
+// was reported as a success carrying zero values — and HostDirSize feeds the
+// directory-size watch, so a failing agent produced "0 bytes" rather than an
+// error, the watch read that as a real measurement, and the warning that exists
+// because of the dev.20 OOM went quiet.
 func (c *ComposeClient) callDecode(op string, r agentReq, out any) error {
 	resp, err := c.send(op, r)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if !r.accepts(resp.StatusCode) {
+		var ar agentResponse
+		_ = json.NewDecoder(resp.Body).Decode(&ar)
+		return agentError(op, ar)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return fmt.Errorf("%s: %w", r.decodeOpFor(op), err)

--- a/truffels-api/internal/docker/compose_characterization_test.go
+++ b/truffels-api/internal/docker/compose_characterization_test.go
@@ -10,10 +10,12 @@ package docker
 // That means a few of the assertions below deliberately pin behaviour that
 // looks wrong:
 //
-//   - SystemInfoGet and HostDirSize never inspect the status code, so a 500 that
-//     still carries a JSON body is reported as success.
 //   - Logs and SystemJournal return the agent's partial log text alongside the
 //     error; Pull and ComposeRead return "" in the same situation.
+//
+// SystemInfoGet and HostDirSize used to be on that list — they ignored the
+// status code entirely. That was a defect rather than a quirk and is fixed;
+// their tests now assert the rejection.
 //   - The reconcile/prune/read family reports only ar.Error and drops the
 //     agent's output, while everything else routes through agentError and keeps
 //     it.
@@ -685,14 +687,14 @@ func TestCharacterize_SystemInfoGet_Success(t *testing.T) {
 // SystemInfoGet never looks at the status code. A 500 carrying a decodable body
 // is reported as success. Preserved deliberately — changing it would alter what
 // the system tab shows when the agent is degraded.
-func TestCharacterize_SystemInfoGet_IgnoresStatusCode(t *testing.T) {
+func TestSystemInfoGet_RejectsFailureStatus(t *testing.T) {
 	c, _ := newFakeAgent(t, 500, SystemInfo{Hostname: "degraded"})
 	got, err := c.SystemInfoGet()
-	if err != nil {
-		t.Fatalf("status code is not checked today, want nil error, got %v", err)
+	if err == nil {
+		t.Fatalf("a 500 must not read as success, got info %+v", got)
 	}
-	if got.Hostname != "degraded" {
-		t.Errorf("hostname = %q", got.Hostname)
+	if got != nil {
+		t.Errorf("no info may be handed out on failure, got %+v", got)
 	}
 }
 
@@ -748,14 +750,16 @@ func TestCharacterize_HostDirSize_NotYetWalked(t *testing.T) {
 }
 
 // Like SystemInfoGet, the status code is not consulted.
-func TestCharacterize_HostDirSize_IgnoresStatusCode(t *testing.T) {
-	c, _ := newFakeAgent(t, 500, map[string]any{"size_bytes": 42, "fresh": true})
+// A failing agent used to yield size 0 with a nil error here. The directory-size
+// watch in internal/alerts treats a negative size as "not measured yet" and
+// anything else as real, so 0 read as an empty directory and the warning that
+// exists because of the dev.20 OOM stopped firing. The error is what makes the
+// watch skip the round instead.
+func TestHostDirSize_RejectsFailureStatus(t *testing.T) {
+	c, _ := newFakeAgent(t, 500, map[string]any{"size_bytes": 0, "fresh": false})
 	size, fresh, err := c.HostDirSize("/srv/x")
-	if err != nil {
-		t.Fatalf("status code is not checked today, want nil error, got %v", err)
-	}
-	if size != 42 || !fresh {
-		t.Errorf("size = %d, fresh = %v", size, fresh)
+	if err == nil {
+		t.Fatalf("a 500 must not read as a measurement, got size=%d fresh=%v", size, fresh)
 	}
 }
 


### PR DESCRIPTION
`callDecode` read the response body and never looked at the status, so a 500
whose body happened to parse was reported as a success carrying zero values.
The characterization tests added in #26 pinned that behaviour rather than fixing
it, because a cleanup that quietly changes behaviour is worse than one that
leaves a known defect and names it. This is the change that fixes it.

It is not cosmetic. `HostDirSize` feeds the directory-size watch in
`internal/alerts`, which treats a negative size as "not measured yet" and
anything else as a real measurement. A failing agent produced size 0 with a nil
error, the watch read that as an empty directory, and the warning that exists
because of the dev.20 mempool OOM stopped firing — silently, for as long as the
agent kept failing.

Red first: against the unchanged client both new tests fail, and the failure
message is the defect stated plainly — `got size=0 fresh=false`.

Both callers already have an error path. `alerts/engine.go` logs at debug level
and skips the round; the settings endpoint surfaces it. Nothing new has to cope
with the change.

The two tests that pinned the old behaviour now assert the rejection, and the
file header no longer lists these two methods among the deliberate quirks.

Full `truffels-api` suite green.