### PR TITLE
Tighten the agent's boundary, and stop a silent git checkout from passing as one

### DIFF
--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -59,10 +59,34 @@ var allowedContainers = map[string]bool{
 
 // --- Container images ---
 
-// allowedImagePrefixes controls which images can be removed via /v1/image/remove.
+// allowedImagePrefixes names the image namespaces this appliance manages: the
+// images it builds itself plus the upstream images of the services it runs.
+// btcpayserver/ is Bitcoin Core and getumbrel/ is electrs — both are live, and
+// neither is a leftover.
 var allowedImagePrefixes = []string{
 	"truffels/", "mempool/", "btcpayserver/", "getumbrel/",
 	"caddy:", "postgres:", "mariadb:",
+}
+
+// isAllowedManagedImage gates both /v1/image/pull and /v1/image/remove.
+//
+// One predicate for both on purpose. They take the same kind of input — a
+// reference to an image on this appliance — and hand it to the same root-level
+// docker CLI; the only difference is the verb. An image this box may not delete
+// is an image it has no reason to fetch, and a `docker pull` of an attacker's
+// choosing on a machine holding a Bitcoin node is a worse outcome than a stray
+// `docker rmi`, not a milder one. Splitting the two checks is how /v1/image/pull
+// came to have none at all.
+//
+// Distinct from isAllowedImageRef below: that one covers the *locally built*
+// images only, and is stricter for reasons documented there.
+func isAllowedManagedImage(ref string) bool {
+	for _, prefix := range allowedImagePrefixes {
+		if strings.HasPrefix(ref, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // isAllowedImageRef restricts image operations to images this appliance builds

--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -272,9 +272,43 @@ func isValidCommitHash(s string) bool {
 // escapes. Returns ("", error) otherwise. The path's parent must exist for
 // EvalSymlinks to resolve cleanly; if the parent doesn't exist yet, the check
 // walks upward until it finds an existing ancestor and validates that one.
+//
+// KNOWN LIMIT — this is not a defence against a racing attacker.
+//
+// The symlink check resolves the nearest ancestor that exists *at the time of
+// the call*. Every component created afterwards is unexamined, and so is any
+// component swapped for a symlink between this returning and the caller's
+// os.MkdirAll / os.WriteFile / os.RemoveAll running. That is a plain
+// time-of-check/time-of-use gap and it cannot be closed from here: closing it
+// means the file operations themselves must not traverse a symlink — openat2
+// with RESOLVE_BENEATH, or an fd-anchored walk — which is a rewrite of every
+// caller, not a change to this function.
+//
+// It is stated rather than papered over because the callers' safety arguments
+// have to be able to lean on what this actually promises. What it does promise:
+// no relative escape, and no symlink escape via a component that already
+// existed. What it does not: atomicity with the operation that follows. The
+// exposure is bounded elsewhere — /srv/truffels is root-owned, the endpoints
+// take service-shaped inputs, and clear-dir carries its own basename and depth
+// checks — not by this.
 func validateUnderRoot(p, root string) (string, error) {
 	if p == "" {
 		return "", fmt.Errorf("empty path")
+	}
+	// Normalise and check the root before using it as a prefix. It is a
+	// parameter like any other, and nothing verified it: a root with a trailing
+	// slash made root+"/" a double slash that no cleaned path can match, so
+	// every request under it was silently refused, and an empty root made the
+	// prefix "/", which matches every absolute path there is — the boundary
+	// inverted, in both directions, from a caller's typo. "/" is refused for the
+	// same reason as "": a root containing the whole filesystem bounds nothing.
+	//
+	// Today's callers pass clean absolute values (composeRoot, configRoot,
+	// dataRoot and repoDir), so this changes no live behaviour. That was luck,
+	// and luck is not a check.
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(root) || root == "/" {
+		return "", fmt.Errorf("invalid root %q", root)
 	}
 	cleaned := filepath.Clean(p)
 	if !strings.HasPrefix(cleaned, root+"/") {

--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -68,6 +68,48 @@ var allowedImagePrefixes = []string{
 	"caddy:", "postgres:", "mariadb:",
 }
 
+// Image references reach docker as a single argv element — exec.Command takes
+// an argv and no path here goes through a shell — so a metacharacter cannot
+// start a second command today. The charset check is what keeps that true if
+// the execution path ever changes, and it is the reasoning isAllowedImageRef
+// has carried since it was written. The same reasoning now covers the same kind
+// of input on the other two endpoints.
+//
+// Two alphabets, not one, and the difference is load-bearing:
+//
+//   - managedImageRefChars covers upstream references. Every upstream image in
+//     this project is digest-pinned — install.sh writes
+//     "mariadb:lts@sha256:8164f18…" — so '@' and hex must pass or every
+//     pull-based service stops updating.
+//   - localImageRefChars covers the images this appliance builds itself. Those
+//     are only ever "truffels/<repo>:<tag>"; nothing in truffels-api ever
+//     constructs a digest for one (composeImageRe does not even match a ref
+//     carrying '@'). Handing them the upstream alphabet would widen
+//     isAllowedImageRef with no caller asking for it.
+//
+// So the loop is shared and the alphabet is not. A single merged set could only
+// be the union, and the union is the looser of the two.
+//
+// Charset only — deliberately not a reference parser. A parser normalises, and
+// this file's whole premise is that nothing here normalises before deciding.
+// It would also reject shapes that are real: pruneOldImages builds
+// "<image>:<version>", and for the digest-tracked mempool-db that yields
+// "mariadb:sha256:b1c7…" — two colons, no '@', not a well-formed reference, and
+// today answered with a best-effort 200 rather than a 403.
+const (
+	localImageRefChars   = "abcdefghijklmnopqrstuvwxyz0123456789/:._-"
+	managedImageRefChars = localImageRefChars + "@"
+)
+
+func hasOnlyChars(s, allowed string) bool {
+	for _, c := range s {
+		if !strings.ContainsRune(allowed, c) {
+			return false
+		}
+	}
+	return true
+}
+
 // isAllowedManagedImage gates both /v1/image/pull and /v1/image/remove.
 //
 // One predicate for both on purpose. They take the same kind of input — a
@@ -81,6 +123,9 @@ var allowedImagePrefixes = []string{
 // Distinct from isAllowedImageRef below: that one covers the *locally built*
 // images only, and is stricter for reasons documented there.
 func isAllowedManagedImage(ref string) bool {
+	if !hasOnlyChars(ref, managedImageRefChars) {
+		return false
+	}
 	for _, prefix := range allowedImagePrefixes {
 		if strings.HasPrefix(ref, prefix) {
 			return true
@@ -98,13 +143,7 @@ func isAllowedImageRef(ref string) bool {
 	if !strings.HasPrefix(ref, "truffels/") {
 		return false
 	}
-	for _, c := range ref {
-		if (c < '0' || c > '9') && (c < 'a' || c > 'z') &&
-			c != '/' && c != ':' && c != '.' && c != '-' && c != '_' {
-			return false
-		}
-	}
-	return true
+	return hasOnlyChars(ref, localImageRefChars)
 }
 
 // --- Journal queries ---

--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -134,16 +134,55 @@ func isAllowedManagedImage(ref string) bool {
 	return false
 }
 
+// allowedLocalImageRepos are the image repositories this appliance builds
+// itself. Five, and they are enumerated rather than matched by the "truffels/"
+// prefix, because the prefix is a namespace an attacker may name freely: with
+// it alone, /v1/image/tag would happily move any tag onto truffels/anything and
+// /v1/image/inspect-by-name would report on it.
+//
+// NOT derivable from allowedServices, and it must not be generated from it. The
+// service is "truffels-agent"; the image it runs is "truffels/agent". The
+// service "ckstats" runs both the truffels-ckstats and truffels-ckstats-cron
+// containers off the single truffels/ckstats image, so there is no
+// truffels/ckstats-cron. And the "truffels" service has no image of its own at
+// all — it is the stack of the three below.
+//
+// The five: agent, api and web are the self-update targets, built and tagged
+// truffels/<name>:<release>. ckpool and ckstats are the NeedsBuild services,
+// built from vendored sources and tagged with a version, a commit hash, :latest
+// or :rollback. Verified against `docker images` on the device.
+//
+// Adding one means a sixth image exists. Check that before adding it.
+var allowedLocalImageRepos = map[string]bool{
+	"truffels/agent":   true,
+	"truffels/api":     true,
+	"truffels/web":     true,
+	"truffels/ckpool":  true,
+	"truffels/ckstats": true,
+}
+
 // isAllowedImageRef restricts image operations to images this appliance builds
-// itself. Anything else — upstream images, anything with shell metacharacters —
-// is refused; the agent runs as root against the docker socket. Exact charset
-// check, no normalising: a cleaned or lowercased ref would let something that
+// itself. Anything else — upstream images, an unknown repository in our own
+// namespace, anything with shell metacharacters — is refused; the agent runs as
+// root against the docker socket. Exact charset check and an exact repository
+// match, no normalising: a cleaned or lowercased ref would let something that
 // should fail slip through.
+//
+// The tag is split off at the last ':' and then deliberately not inspected
+// beyond the charset. Tags legitimately take four unrelated shapes here
+// (:v0.3.1-dev.29, :v1.0.0, :latest, :rollback, and a bare commit hash for
+// ckstats), and a pattern covering all of them would say nothing a charset
+// check does not already say. A ref with no tag keeps passing, exactly as
+// before: the repository is what this decides on.
 func isAllowedImageRef(ref string) bool {
-	if !strings.HasPrefix(ref, "truffels/") {
+	if !hasOnlyChars(ref, localImageRefChars) {
 		return false
 	}
-	return hasOnlyChars(ref, localImageRefChars)
+	repo := ref
+	if idx := strings.LastIndex(repo, ":"); idx >= 0 {
+		repo = repo[:idx]
+	}
+	return allowedLocalImageRepos[repo]
 }
 
 // --- Journal queries ---

--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -101,9 +101,14 @@ func TestHandleImageInspect_AllowedContainerReachesDocker(t *testing.T) {
 func TestHandleImageTag_AllowedRefsReachDockerTag(t *testing.T) {
 	// Both refs pass isAllowedImageRef; the source image does not exist, so the
 	// tag fails with or without a docker CLI.
+	//
+	// The repository has to be a real one now that isAllowedImageRef enumerates
+	// them — the guard, not the missing image, would otherwise be what this
+	// test observes. Nonexistence moved into the tag, which is unconstrained
+	// beyond its charset.
 	body, _ := json.Marshal(map[string]string{
-		"source": "truffels/agent-test-nonexistent:src",
-		"target": "truffels/agent-test-nonexistent:dst",
+		"source": "truffels/ckpool:agent-test-nonexistent-src",
+		"target": "truffels/ckpool:agent-test-nonexistent-dst",
 	})
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/v1/image/tag", bytes.NewReader(body))

--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -251,5 +253,95 @@ func TestHandleGitCheckout_ChecksOutTagFromLocalRemote(t *testing.T) {
 	tagged := strings.TrimSpace(git(t, upstream, "rev-parse", "v0.0.1^{commit}"))
 	if head != tagged {
 		t.Errorf("HEAD = %s, want the tagged commit %s", head, tagged)
+	}
+}
+
+// A ref and a pathspec are not the same kind of argument, and `git checkout`
+// accepts both in the same position. Without the `--` terminator, a request for
+// a ref that does not exist but happens to name a tracked *file* is answered by
+// restoring that file — exit status 0, HEAD unmoved, and this endpoint replying
+// {"status":"ok"}. The update engine takes that at its word and builds, labels
+// and ships an image from the wrong commit.
+//
+// The validators do not help here: "v0.0.9" passes isValidTag. Nothing about
+// this is exotic; it is the ordinary meaning of the argv git was given.
+func TestHandleGitCheckout_RefusesARefThatOnlyNamesAFile(t *testing.T) {
+	upstream := t.TempDir()
+	git(t, upstream, "init", "-q", "-b", "main")
+	git(t, upstream, "config", "user.email", "t@example.invalid")
+	git(t, upstream, "config", "user.name", "t")
+	write(t, upstream, "README.md", "one\n")
+	// A tracked file whose name is a valid tag, and no tag of that name.
+	write(t, upstream, "v0.0.9", "committed\n")
+	git(t, upstream, "add", "README.md", "v0.0.9")
+	git(t, upstream, "commit", "-q", "-m", "first")
+
+	work := t.TempDir()
+	git(t, work, "clone", "-q", upstream, work)
+	allowRepoDir(t, work)
+	head := strings.TrimSpace(git(t, work, "rev-parse", "HEAD"))
+
+	// Local content that a path-checkout would silently discard.
+	write(t, work, "v0.0.9", "local\n")
+
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: work, Tag: "v0.0.9"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500 for a ref that does not exist, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(resp["error"], "git checkout failed: ") {
+		t.Errorf("error = %q, want the 'git checkout failed: ' prefix", resp["error"])
+	}
+	if got := strings.TrimSpace(git(t, work, "rev-parse", "HEAD")); got != head {
+		t.Errorf("HEAD moved to %s; a refused checkout must change nothing", got)
+	}
+	content, err := os.ReadFile(filepath.Join(work, "v0.0.9"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "local\n" {
+		t.Errorf("v0.0.9 = %q; the refused checkout overwrote it as a pathspec", content)
+	}
+}
+
+// The commit-hash scheme end to end, with a real 40-char object name. The `--`
+// terminator has to leave this working too — it is the ref form every ckstats
+// update uses.
+func TestHandleGitCheckout_ChecksOutCommitUnderCommitScheme(t *testing.T) {
+	upstream := t.TempDir()
+	git(t, upstream, "init", "-q", "-b", "main")
+	git(t, upstream, "config", "user.email", "t@example.invalid")
+	git(t, upstream, "config", "user.name", "t")
+	write(t, upstream, "README.md", "one\n")
+	git(t, upstream, "add", "README.md")
+	git(t, upstream, "commit", "-q", "-m", "first")
+	first := strings.TrimSpace(git(t, upstream, "rev-parse", "HEAD"))
+	write(t, upstream, "README.md", "two\n")
+	git(t, upstream, "add", "README.md")
+	git(t, upstream, "commit", "-q", "-m", "second")
+
+	work := t.TempDir()
+	git(t, work, "clone", "-q", upstream, work)
+	allowRepoDir(t, work)
+
+	body, _ := json.Marshal(gitCheckoutRequest{RepoDir: work, Tag: first, RefScheme: "commit"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/git/checkout", bytes.NewReader(body))
+
+	handleGitCheckout(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := strings.TrimSpace(git(t, work, "rev-parse", "HEAD")); got != first {
+		t.Errorf("HEAD = %s, want %s", got, first)
 	}
 }

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1694,7 +1694,13 @@ func removeUntrackedCollisionsForCheckout(ctx context.Context, repoDir, ref stri
 		return "", nil
 	}
 
-	inTarget, err := gitPathList(ctx, repoDir, "ls-tree", "-r", "--name-only", "-z", ref)
+	// The same terminator as the checkout below it, for the same reason and in
+	// the same position: ls-tree reads <tree-ish> [<path>...], so "--" states
+	// that the ref is the tree and the path list is empty. Unlike the checkout
+	// this changes no outcome — ls-tree resolves its first positional as a
+	// tree-ish either way — but it is the other git call site taking a variable
+	// ref, and the two should not have to be reasoned about differently.
+	inTarget, err := gitPathList(ctx, repoDir, "ls-tree", "-r", "--name-only", "-z", ref, "--")
 	if err != nil {
 		return "", err
 	}
@@ -1822,8 +1828,26 @@ func handleGitCheckout(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Checkout tag
-	checkoutOut, err := runCapture(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "checkout", req.Tag)
+	// Checkout tag.
+	//
+	// The trailing "--" terminates the revision and declares that no pathspec
+	// follows. `git checkout <arg>` accepts a revision OR a path in that
+	// position, and resolves a path when no such revision exists: a request for
+	// a ref that happens to name a tracked file was answered by restoring that
+	// file — exit 0, HEAD unmoved, and this handler replying {"status":"ok"} to
+	// an update engine that then builds and labels an image from the wrong
+	// commit. With the terminator that request fails, which is the honest
+	// answer. TestHandleGitCheckout_RefusesARefThatOnlyNamesAFile pins it.
+	//
+	// It goes AFTER the ref, not before. `git checkout -- <arg>` means the
+	// opposite — <arg> is a pathspec — and would break every checkout this
+	// endpoint performs.
+	//
+	// It is not protection against option injection: `git checkout --foo --`
+	// still parses --foo as an option. That remains the job of isValidTag and
+	// isValidCommitHash, which reject a leading dash, and this does not license
+	// loosening them.
+	checkoutOut, err := runCapture(ctx, "git", "-c", "safe.directory=*", "-C", req.RepoDir, "checkout", req.Tag, "--")
 	if err != nil {
 		writeJSON(w, 500, map[string]string{
 			"error":  "git checkout failed: " + err.Error(),

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -374,6 +374,11 @@ func handleImagePull(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]string{"error": "image required"})
 		return
 	}
+	// Same gate as /v1/image/remove: see isAllowedManagedImage.
+	if !isAllowedManagedImage(req.Image) {
+		writeJSON(w, 403, map[string]string{"error": "image not allowed"})
+		return
+	}
 
 	slog.Info("pulling image", "image", req.Image)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
@@ -400,15 +405,7 @@ func handleImageRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Allowlist check
-	allowed := false
-	for _, prefix := range allowedImagePrefixes {
-		if strings.HasPrefix(req.Image, prefix) {
-			allowed = true
-			break
-		}
-	}
-	if !allowed {
+	if !isAllowedManagedImage(req.Image) {
 		writeJSON(w, 403, map[string]string{"error": "image not allowed"})
 		return
 	}

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -500,6 +500,83 @@ func TestHandleImagePull_EmptyImage(t *testing.T) {
 	}
 }
 
+// pullRefsInProduction is every image reference that really reaches
+// /v1/image/pull on this appliance. Fetching an image is not less privileged
+// than deleting one, so the endpoint now applies the same allowlist as
+// /v1/image/remove — and this list is the proof that the tightening does not
+// abandon a single service.
+//
+// The values are not invented. They come from:
+//   - install.sh, which pins bitcoind and electrs by digest;
+//   - the live compose files under /srv/truffels/compose;
+//   - updates.Engine, which builds pull refs as <image>:<version> from the
+//     registry's Images (btcpayserver/bitcoin, getumbrel/electrs,
+//     mempool/backend, mempool/frontend, mariadb, postgres, caddy,
+//     truffels/{agent,api,web}) — see engine.go applyUpdate/rollback;
+//   - api.services "pull-restart", which pulls the running image ref with the
+//     digest stripped.
+//
+// A change that turns any of these into a 403 stops updates for that service.
+var pullRefsInProduction = []string{
+	// install.sh pins — digest-carrying, and the reason no charset filter here
+	// may reject '@' or hex.
+	"btcpayserver/bitcoin:30.2@sha256:cff45bbc8e166bb3403675baea73cf597c7373f20a87a76101e3d849f766d61e",
+	"getumbrel/electrs:v0.11.0@sha256:0a2c6f573abfd8d724651c6ba1c1f3a9c740219c1cf0f4468043c3342170d8a5",
+	"mariadb:lts@sha256:8164f184d16c30e2f159e30518113667b796306dff0fe558876ab1ff521a682f",
+	"postgres:16.13-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416",
+	"caddy:2.11.2-alpine@sha256:fce4f15aad23222c0ac78a1220adf63bae7b94355d5ea28eee53910624acedfa",
+	"mempool/backend:v3.2.1@sha256:d3531090e3bdd9a3dd38151349c5027768c3b7132438db267df8d8f026e15e61",
+	"mempool/frontend:v3.2.1@sha256:dd126cf383bd425ad46710925697c6a7925675a535c1026c206f2c092231e106",
+	// The refs the live compose files name today.
+	"btcpayserver/bitcoin:31.0",
+	"getumbrel/electrs:v0.11.1",
+	"mempool/backend:v3.3.1",
+	"mempool/frontend:v3.3.1",
+	"caddy:2.11.4-alpine",
+	"postgres:16.14-alpine",
+	"mariadb:lts",
+	"truffels/agent:v0.3.1-dev.29",
+	"truffels/api:v0.3.1-dev.29",
+	"truffels/web:v0.3.1-dev.29",
+}
+
+func TestHandleImagePull_AllowsEveryRefProductionReallyPulls(t *testing.T) {
+	for _, img := range pullRefsInProduction {
+		reqBody, _ := json.Marshal(imagePullRequest{Image: img})
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(reqBody))
+
+		handleImagePull(w, r)
+
+		// docker is absent in the test container, so the pull itself fails with
+		// 500. What must never happen is the guard refusing the ref.
+		if w.Code == 403 {
+			t.Errorf("pull of %q was refused; that stops updates for this service: %s", img, w.Body.String())
+		}
+	}
+}
+
+func TestHandleImagePull_RefusesImagesOutsideTheAllowlist(t *testing.T) {
+	// Same inputs /v1/image/remove refuses. An image this appliance may not
+	// delete is an image it has no reason to fetch either.
+	for _, img := range []string{"nginx:latest", "alpine:3", "evil/miner:latest", "bitcoin/bitcoin:29.0"} {
+		reqBody, _ := json.Marshal(imagePullRequest{Image: img})
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(reqBody))
+
+		handleImagePull(w, r)
+
+		if w.Code != 403 {
+			t.Errorf("expected 403 for %q, got %d: %s", img, w.Code, w.Body.String())
+		}
+		var body map[string]string
+		_ = json.Unmarshal(w.Body.Bytes(), &body)
+		if body["error"] != "image not allowed" {
+			t.Errorf("error for %q = %q, want the same text /v1/image/remove uses", img, body["error"])
+		}
+	}
+}
+
 // --- handleImageInspect ---
 
 func TestHandleImageInspect_DeniedContainer(t *testing.T) {

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -2255,6 +2255,76 @@ func TestValidateUnderRoot_AllowsNestedUnderExistingRoot(t *testing.T) {
 	}
 }
 
+// The root was used as a raw prefix, so a caller passing a trailing slash built
+// root+"/" as a double slash and every path under it was rejected. No caller
+// does that today; that is the callers being careful, not a property this
+// function had.
+func TestValidateUnderRoot_NormalisesTheRoot(t *testing.T) {
+	base := t.TempDir()
+	target := base + "/mempool/cache"
+
+	for _, root := range []string{base + "/", base + "//", base + "/."} {
+		cleaned, err := validateUnderRoot(target, root)
+		if err != nil {
+			t.Errorf("root %q rejected a path under it: %v", root, err)
+			continue
+		}
+		if cleaned != target {
+			t.Errorf("root %q: cleaned = %q, want %q", root, cleaned, target)
+		}
+	}
+}
+
+// A root that is not an absolute directory is not a boundary, and every value
+// here used to be accepted as one: "" and "." make root+"/" match relative
+// paths, and "/" would have to allow the entire filesystem to be consistent.
+// The one caller that can pass an empty root (handleFileReconcile, when
+// TRUFFELS_CONFIG_ROOT is unset) already refuses first; this is the backstop.
+func TestValidateUnderRoot_RejectsUnusableRoots(t *testing.T) {
+	for _, root := range []string{"", ".", "/", "//", "relative/dir", "./x"} {
+		if _, err := validateUnderRoot("/srv/truffels/data/mempool/cache", root); err == nil {
+			t.Errorf("root %q was accepted; it does not bound anything", root)
+		}
+	}
+}
+
+// The production roots with the paths the API really sends. None of them exist
+// inside the test container, which is also true of the agent container for
+// parts of the tree — the walk to the nearest existing ancestor has to keep
+// answering for them.
+func TestValidateUnderRoot_AcceptsProductionPaths(t *testing.T) {
+	cases := []struct{ path, root string }{
+		{"/srv/truffels/data/mempool/cache", "/srv/truffels/data"},
+		{"/srv/truffels/data/ckstats/postgres", "/srv/truffels/data"},
+		{"/srv/truffels/data/bitcoin/blockchain", "/srv/truffels/data"},
+		{"/srv/truffels/compose/truffels/docker-compose.yml", "/srv/truffels/compose"},
+		{"/srv/truffels/compose/mempool/docker-compose.yml", "/srv/truffels/compose"},
+		{"/srv/truffels/config/bitcoin/bitcoin.conf", "/srv/truffels/config"},
+		{"/srv/truffels/config/proxy/Caddyfile", "/srv/truffels/config"},
+	}
+	for _, c := range cases {
+		cleaned, err := validateUnderRoot(c.path, c.root)
+		if err != nil {
+			t.Errorf("validateUnderRoot(%q, %q) = %v, want accept", c.path, c.root, err)
+		}
+		if cleaned != c.path {
+			t.Errorf("cleaned = %q, want %q", cleaned, c.path)
+		}
+	}
+}
+
+func TestValidateUnderRoot_StillRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	for _, p := range []string{
+		"", "/etc/passwd", root, root + "/../etc", root + "/x/../../etc",
+		filepath.Dir(root), "/",
+	} {
+		if _, err := validateUnderRoot(p, root); err == nil {
+			t.Errorf("path %q under root %q was accepted", p, root)
+		}
+	}
+}
+
 // --- dirSizeCache ---
 
 func TestDirSizeCache_HitMiss(t *testing.T) {

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1640,6 +1640,85 @@ func TestHandleImageRemove_AllowedPrefixes(t *testing.T) {
 	}
 }
 
+func TestHandleImageRemove_AllowsEveryRefProductionReallyRemoves(t *testing.T) {
+	// The prefix allowlist gained a charset check. These are the shapes the
+	// pruner and the update engine really hand to /v1/image/remove; a charset
+	// that rejects one of them leaves old images on a 1.8 TB disk forever.
+	refs := append([]string{
+		// updates.Engine.pruneOldImages builds "<image>:<version>", and for a
+		// digest-tracked service (mempool-db) the version *is* a digest, so the
+		// ref carries two colons and no '@'. Odd, but real.
+		"mariadb:sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b",
+		// rollbackImageRef and the compose fallback.
+		"truffels/ckpool:rollback",
+		"truffels/ckstats:rollback",
+		"truffels/ckstats:latest",
+	}, pullRefsInProduction...)
+
+	for _, img := range refs {
+		reqBody, _ := json.Marshal(map[string]string{"image": img})
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/v1/image/remove", bytes.NewReader(reqBody))
+		handleImageRemove(w, r)
+		if w.Code == 403 {
+			t.Errorf("removal of %q was refused: %s", img, w.Body.String())
+		}
+	}
+}
+
+// The gap this closes: the prefix list said nothing about the characters after
+// the prefix, so "mempool/x; rm -rf /" reached `docker rmi` as an argument.
+// Not exploitable — exec.Command takes an argv, there is no shell — but
+// isAllowedImageRef has refused exactly these bytes since it was written, and
+// the same input type deserves the same answer.
+func TestIsAllowedManagedImage_Charset(t *testing.T) {
+	for _, ref := range []string{
+		"mempool/x; rm -rf /", "mempool/backend:latest; id",
+		"mariadb:lts $(id)", "caddy:2`id`", "postgres:16&&id",
+		"truffels/api:v1|id", "mempool/backend:v3\nid",
+		"mempool/back end:v3", "caddy:*", "mariadb:lts'", `mariadb:lts"`,
+		"mariadb:lts\\", "truffels/api:v1>x", "postgres:16<x",
+		"Mempool/backend:v3", "mempool/BACKEND:v3",
+	} {
+		if isAllowedManagedImage(ref) {
+			t.Errorf("ref %q must be rejected", ref)
+		}
+	}
+
+	for _, ref := range append([]string{
+		"mariadb:sha256:b1c7bf836e64ed9406a8984af29509f40089d55cea14b32f12c4726a1f17104b",
+		"truffels/ckpool:rollback", "truffels/ckstats:latest",
+	}, pullRefsInProduction...) {
+		if !isAllowedManagedImage(ref) {
+			t.Errorf("ref %q is a real production reference and must be allowed", ref)
+		}
+	}
+}
+
+func TestHandleImageRemove_RefusesShellMetacharacters(t *testing.T) {
+	reqBody, _ := json.Marshal(map[string]string{"image": "mempool/x; rm -rf /"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/remove", bytes.NewReader(reqBody))
+
+	handleImageRemove(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImagePull_RefusesShellMetacharacters(t *testing.T) {
+	reqBody, _ := json.Marshal(imagePullRequest{Image: "mempool/x; rm -rf /"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(reqBody))
+
+	handleImagePull(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // --- formatSize ---
 
 func TestFormatSize(t *testing.T) {

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -2454,10 +2454,78 @@ func TestImageTagRejectsForeignImages(t *testing.T) {
 	}
 }
 
+// localRefsInProduction is every "truffels/…" reference the API really sends to
+// /v1/image/inspect-by-name and /v1/image/tag. Like pullRefsInProduction, the
+// values are read off the system rather than invented:
+//
+//   - truffels/{agent,api,web}:<version> — updates.selfUpdateImage and
+//     verifySelfBuild during a self-update; the live compose files name
+//     v0.3.1-dev.29 today.
+//   - truffels/{ckpool,ckstats}:<tag> — updates.composeImageRef, read out of
+//     the compose file (truffels/ckpool:v1.0.0, truffels/ckstats:latest), plus
+//     its conventional :latest fallback.
+//   - truffels/{ckpool,ckstats}:rollback — updates.rollbackImageRef, the single
+//     staged generation. Both exist on the device right now.
+//   - a bare commit hash as a tag: ckstats builds from a git commit, and
+//     RewriteTags moves the compose ref onto it.
+var localRefsInProduction = []string{
+	"truffels/agent:v0.3.1-dev.29",
+	"truffels/api:v0.3.1-dev.29",
+	"truffels/web:v0.3.1-dev.29",
+	"truffels/agent:v1.0.0",
+	"truffels/api:rollback",
+	"truffels/ckpool:v1.0.0",
+	"truffels/ckpool:rollback",
+	"truffels/ckpool:latest",
+	"truffels/ckstats:latest",
+	"truffels/ckstats:rollback",
+	"truffels/ckstats:8f2e7c2f8403",
+}
+
+// The prefix "truffels/" alone let the agent inspect and retag any repository
+// in the namespace. Exactly five exist, and they are not derivable from
+// allowedServices: the service is "truffels-agent", the image is
+// "truffels/agent".
+func TestIsAllowedImageRef_OnlyRealRepositories(t *testing.T) {
+	for _, ref := range localRefsInProduction {
+		if !isAllowedImageRef(ref) {
+			t.Errorf("ref %q is used in production and must be allowed", ref)
+		}
+	}
+
+	denied := map[string]string{
+		// No such image and no such service: the ckstats-cron *container* runs
+		// the truffels/ckstats image. `docker images` on the device lists five
+		// truffels repositories and this is not one of them.
+		"truffels/ckstats-cron:rollback": "container name, not an image repository",
+		// rollbackImageRef would produce this for the truffels stack, but
+		// ApplyUpdateToVersion routes github_release sources to applySelfUpdate
+		// and RollbackService refuses them before the ref is built. Nothing
+		// stages it, so nothing may act on it.
+		"truffels/truffels:rollback": "never staged",
+		// Service IDs that name no image of ours.
+		"truffels/bitcoind:latest": "upstream service, not built here",
+		"truffels/mempool:latest":  "upstream service, not built here",
+		"truffels/proxy:latest":    "upstream service, not built here",
+		// Near-misses on the real names.
+		"truffels/agent-x:v1": "not a repository",
+		"truffels/ap:v1":      "not a repository",
+		"truffels/apix:v1":    "not a repository",
+		"truffels/:latest":    "empty repository",
+		"truffels/evil:v1":    "attacker-chosen repository",
+		"truffels/agent/x:v1": "extra path segment",
+	}
+	for ref, why := range denied {
+		if isAllowedImageRef(ref) {
+			t.Errorf("ref %q must be rejected (%s)", ref, why)
+		}
+	}
+}
+
 func TestIsAllowedImageRef_Charset(t *testing.T) {
 	allowed := []string{
 		"truffels/ckpool:v1.0.0", "truffels/ckstats:latest",
-		"truffels/ckstats-cron:rollback", "truffels/api:v0.3.1-dev.23",
+		"truffels/api:v0.3.1-dev.23",
 		"truffels/web:sha256_abc",
 	}
 	for _, ref := range allowed {


### PR DESCRIPTION
Collecting the agent's thirteen guards into one file in #29 made five places
visible where the strictness falls apart for no reason. Four are defense in
depth. The fifth turned out to be a live correctness bug.

## The one that is not defense in depth

`git checkout <ref>` was called without a terminator. When the ref does not
exist but a tracked **file** of that name does, git checks out the file, leaves
HEAD where it is, and exits 0:

```
$ git checkout v0.0.9        # no such ref; a file v0.0.9 is tracked
Updated 1 path from the index
$ echo $?
0                            # HEAD unmoved, file silently reverted

$ git checkout v0.0.9 --
fatal: invalid reference: v0.0.9
$ echo $?
128
```

The agent reported that as a completed checkout. For ckstats the consequence
runs all the way through: the working copy stays on the old commit, the build
uses the old code, and because `SOURCE_REF` is only a stamp there, the image
carries the label of the ref that was *asked for*. The verification added in
dev.24 then compares the requested ref against the requested ref and agrees.
A wrongly built image would have shipped with the whole chain confirming it.
`"v0.0.9"` passes `isValidTag` without trouble.

The terminator goes **after** the ref. `git checkout -- <ref>` is the opposite
mistake: it makes the ref a pathspec and breaks every checkout. That was checked
against git 2.39.5 rather than assumed, along with the fact that `--` is not an
option-injection guard in either position — `git checkout --version --` still
parses the option, so the validators remain the only thing rejecting a leading
dash, and the comment says so instead of implying otherwise.

The same terminator was added to the `ls-tree` in
`removeUntrackedCollisionsForCheckout`, the only other git call taking a
variable ref.

## The other four

- `/v1/image/pull` validated nothing at all — only that the string was
  non-empty — while `/v1/image/remove` checked the same kind of input against an
  allowlist. Both now go through the same gate. An image that may not be removed
  should not be fetchable either.
- Neither of those two checked a character set. `isAllowedImageRef` does, for the
  same kind of input, and its comment explains why. They now do too, with two
  alphabets rather than one merged set: locally built refs keep
  `a-z0-9/:._-`, upstream refs additionally allow `@`, because the digest pins in
  `install.sh:44-50` are real and a single merged alphabet could only be the
  looser of the two.
- `isAllowedImageRef` accepted any `truffels/*`. It now names the five images
  this project actually builds. The list is written out rather than derived from
  `allowedServices`, because the keys there do not match the image names —
  `truffels-agent` is the service, `truffels/agent` is the image.
- `validateUnderRoot` compared against `root+"/"` and would have broken on a root
  with a trailing slash; the root is now normalised and a non-absolute root is
  rejected. Its symlink check only resolves up to the nearest existing ancestor,
  so a component created afterwards is not covered. That is not fixed — closing
  it means moving the call sites onto fd-anchored operations, not editing the
  validator — and it is now named as a known limit rather than left to look
  airtight.

## Verification

Every tightening is red-then-green. More importantly, each one has a test
proving the **real** values still pass, not only that hostile ones are rejected:
the seven digest pins from `install.sh`, all thirteen image lines from the live
compose files including `mariadb:lts@sha256:…`, the `mariadb:sha256:…` shape that
`pruneOldImages` actually emits, every `truffels/*` tag present on the device,
and the real `/srv/truffels/{data,compose,config}` paths.

Agent suite green, coverage 68.7 % → 69.2 %, both modules lint clean.

Known and deliberately not folded in: pull and remove still accept any
`truffels/*` through the prefix list rather than the narrowed one. Reconciling
that is a sixth change, not a smuggled one.