### PR TITLE
Stop a docker prune that never ran from reading as ok

### DIFF
--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -59,12 +59,25 @@ var allowedContainers = map[string]bool{
 
 // --- Container images ---
 
-// allowedImagePrefixes names the image namespaces this appliance manages: the
-// images it builds itself plus the upstream images of the services it runs.
-// btcpayserver/ is Bitcoin Core and getumbrel/ is electrs — both are live, and
-// neither is a leftover.
+// localImageNamespace is the namespace of the images this appliance builds
+// itself. It is the one namespace whose repositories we know, so it is the one
+// namespace that is never matched as a prefix — see isAllowedManagedImage and
+// allowedLocalImageRepos.
+const localImageNamespace = "truffels/"
+
+// allowedImagePrefixes names the *upstream* namespaces this appliance manages:
+// the images of the services it runs but does not build. btcpayserver/ is
+// Bitcoin Core and getumbrel/ is electrs — both are live, and neither is a
+// leftover.
+//
+// A prefix is the right shape here and the wrong shape for our own namespace.
+// We do not know mempool's or btcpayserver's repositories and have no business
+// pinning them: upstream renames one and that service stops updating. Our own
+// five we do know, and "truffels/" as a prefix accepts any repository an
+// attacker cares to name — so localImageNamespace is deliberately absent from
+// this list and decided by allowedLocalImageRepos instead.
 var allowedImagePrefixes = []string{
-	"truffels/", "mempool/", "btcpayserver/", "getumbrel/",
+	"mempool/", "btcpayserver/", "getumbrel/",
 	"caddy:", "postgres:", "mariadb:",
 }
 
@@ -120,11 +133,25 @@ func hasOnlyChars(s, allowed string) bool {
 // `docker rmi`, not a milder one. Splitting the two checks is how /v1/image/pull
 // came to have none at all.
 //
-// Distinct from isAllowedImageRef below: that one covers the *locally built*
-// images only, and is stricter for reasons documented there.
+// Inside localImageNamespace this defers to isAllowedImageRef outright rather
+// than matching the prefix. The two gates must not disagree about our own
+// images — one that may be retagged is one that may be deleted, and the reverse
+// — and "truffels/" as a prefix is a namespace an attacker names freely, so the
+// looser gate would simply be the way in. Delegating makes the agreement
+// structural instead of two lists that have to be kept in step.
+//
+// It also applies the narrower alphabet there, which is correct and not an
+// accident: nothing in truffels-api ever builds a digest for an image this
+// appliance built itself (see localImageRefChars), so no real reference in this
+// namespace carries an '@'. Only the upstream namespaces, whose repositories we
+// do not enumerate, are matched by prefix — allowedImagePrefixes no longer
+// carries "truffels/" at all, so there is no second, looser path into it.
 func isAllowedManagedImage(ref string) bool {
 	if !hasOnlyChars(ref, managedImageRefChars) {
 		return false
+	}
+	if strings.HasPrefix(ref, localImageNamespace) {
+		return isAllowedImageRef(ref)
 	}
 	for _, prefix := range allowedImagePrefixes {
 		if strings.HasPrefix(ref, prefix) {

--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Characterization tests for the handlers whose only untested part was the
@@ -343,5 +344,166 @@ func TestHandleGitCheckout_ChecksOutCommitUnderCommitScheme(t *testing.T) {
 	}
 	if got := strings.TrimSpace(git(t, work, "rev-parse", "HEAD")); got != first {
 		t.Errorf("HEAD = %s, want %s", got, first)
+	}
+}
+
+// --- handleDockerPrune ---
+
+// fakeDocker puts a stub `docker` on PATH for the duration of one test. The
+// suite runs without a docker CLI, so every prune fails and only the
+// everything-failed path was ever exercised; the partial and the fully
+// successful runs — the ones that decide what the caller is told — need a
+// command whose exit status the test chooses.
+//
+// script is the body of a /bin/sh script and receives the docker argv, so it
+// can branch on the subcommand ("$1" is builder/image/system).
+func fakeDocker(t *testing.T, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "docker"), []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	// Control: a missing stub would look exactly like the real docker being
+	// absent, which is the state every other assertion here is contrasted with.
+	if got, err := exec.LookPath("docker"); err != nil || got != filepath.Join(dir, "docker") {
+		t.Fatalf("stub docker not on PATH: %q, %v", got, err)
+	}
+}
+
+// withStorageCache installs a live cache so the handler's refresh runs. In the
+// binary it is set in main(); in tests it is nil, so the invalidate/set pair at
+// the end of the handler was never executed.
+func withStorageCache(t *testing.T) *dockerStorageCache {
+	t.Helper()
+	prev := storageCache
+	storageCache = newDockerStorageCache(5 * time.Minute)
+	t.Cleanup(func() { storageCache = prev })
+	return storageCache
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]string {
+	t.Helper()
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode %q: %v", w.Body.String(), err)
+	}
+	return resp
+}
+
+func postPrune(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	handleDockerPrune(w, httptest.NewRequest("POST", "/v1/docker/prune", bytes.NewReader([]byte("{}"))))
+	return w
+}
+
+// The all-succeeded path, which is what the endpoint is for: every "reclaimed"
+// line from all three runs is joined into the one field the API reads back.
+func TestHandleDockerPrune_ReportsWhatTheThreeRunsReclaimed(t *testing.T) {
+	fakeDocker(t, `echo "Total reclaimed space: 1.5GB"`)
+	cache := withStorageCache(t)
+
+	w := postPrune(t)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeJSON(t, w)
+	if resp["status"] != "ok" {
+		t.Errorf("status = %q, want ok", resp["status"])
+	}
+	if got := resp["reclaimed"]; strings.Count(got, "Total reclaimed space: 1.5GB") != 3 {
+		t.Errorf("reclaimed = %q, want one line per prune run", got)
+	}
+	// The refresh is the reason /system/info is right on the next request
+	// rather than up to five minutes later.
+	if _, fresh := cache.get(); !fresh {
+		t.Error("storage cache was not refreshed; /system/info would keep serving the pre-prune numbers")
+	}
+}
+
+// No line mentioning "reclaimed" — an older docker, or a run that printed
+// nothing — still answers with the placeholder rather than an empty field.
+func TestHandleDockerPrune_ReclaimedIsUnknownWhenNothingSaysSo(t *testing.T) {
+	fakeDocker(t, `echo "deleted: sha256:abc"`)
+
+	w := postPrune(t)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := decodeJSON(t, w)["reclaimed"]; got != "unknown" {
+		t.Errorf("reclaimed = %q, want \"unknown\"", got)
+	}
+}
+
+// Best-effort is about not aborting the run, not about hiding it. When every
+// one of the three failed, nothing was reclaimed and nothing was cleaned up,
+// and answering 200 {"status":"ok"} told the operator the opposite: the Settings
+// page printed "Pruned: unknown" and the audit row recorded a prune that never
+// happened. A docker socket the agent has lost, a daemon that is down, a
+// `docker` that is not on PATH all land here.
+func TestHandleDockerPrune_EveryRunFailingIsNotOK(t *testing.T) {
+	fakeDocker(t, `echo "Cannot connect to the Docker daemon" >&2; exit 1`)
+
+	w := postPrune(t)
+
+	if w.Code != 500 {
+		t.Fatalf("expected 500 when no prune ran, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeJSON(t, w)
+	if resp["status"] == "ok" {
+		t.Error(`response still claims "ok" after all three prunes failed`)
+	}
+	// Naming them is the point: "prune failed" alone does not distinguish a
+	// dead daemon from one subcommand a docker version dropped.
+	for _, name := range []string{"builder prune", "image prune", "system prune"} {
+		if !strings.Contains(resp["error"], name) {
+			t.Errorf("error %q does not name the failed %q run", resp["error"], name)
+		}
+	}
+}
+
+// A partial failure keeps its 200 — the runs that did work reclaimed real
+// space and the caller should see it — but the answer has to say that one
+// stage did not run. Same shape handleImageRemove already uses: status ok plus
+// a warning field, so a caller reading only "status" is no worse off than
+// before and one reading the body learns the truth.
+func TestHandleDockerPrune_PartialFailureIsNamedInTheResponse(t *testing.T) {
+	fakeDocker(t, `if [ "$1" = "image" ]; then echo "image prune is not supported" >&2; exit 1; fi
+echo "Total reclaimed space: 2.1GB"`)
+
+	w := postPrune(t)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200 when two of three prunes worked, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeJSON(t, w)
+	if resp["status"] != "ok" {
+		t.Errorf("status = %q, want ok — two runs did reclaim space", resp["status"])
+	}
+	if !strings.Contains(resp["reclaimed"], "2.1GB") {
+		t.Errorf("reclaimed = %q, want what the surviving runs reported", resp["reclaimed"])
+	}
+	if !strings.Contains(resp["warning"], "image prune") {
+		t.Errorf("warning = %q, want it to name the prune that failed", resp["warning"])
+	}
+	for _, name := range []string{"builder prune", "system prune"} {
+		if strings.Contains(resp["warning"], name) {
+			t.Errorf("warning = %q names %q, which succeeded", resp["warning"], name)
+		}
+	}
+}
+
+// The unchanged case, asserted directly: a fully successful prune must not
+// grow a warning field, or every UI that shows one shows it always.
+func TestHandleDockerPrune_SuccessCarriesNoWarning(t *testing.T) {
+	fakeDocker(t, `echo "Total reclaimed space: 1.5GB"`)
+
+	w := postPrune(t)
+
+	if _, ok := decodeJSON(t, w)["warning"]; ok {
+		t.Error("a prune where nothing failed must not report a warning")
 	}
 }

--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -53,10 +53,15 @@ func TestInspectContainer_ReportsNotFoundWhenTheCommandFails(t *testing.T) {
 // --- handleImagePull ---
 
 func TestHandleImagePull_SurfacesCommandFailure(t *testing.T) {
-	// A repository that cannot resolve, so the pull fails whether or not a
-	// docker CLI is present.
+	// A tag that cannot resolve, so the pull fails whether or not a docker CLI
+	// is present.
+	//
+	// The repository has to be a real one now that /v1/image/pull enumerates
+	// ours the same way /v1/image/tag does — the guard, not the failing pull,
+	// would otherwise be what this test observes. Same move handleImageTag's
+	// characterization test already had to make: nonexistence lives in the tag.
 	body, _ := json.Marshal(map[string]string{
-		"image": "truffels/agent-test-nonexistent:v0.0.0",
+		"image": "truffels/ckpool:agent-test-nonexistent",
 	})
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(body))

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -431,6 +431,14 @@ func handleDockerPrune(w http.ResponseWriter, r *http.Request) {
 
 	// Each prune is best-effort: a failure is logged and the next one still
 	// runs, and whatever it printed still counts towards the reclaimed total.
+	// One subcommand a docker version does not have must not cost the operator
+	// the other two.
+	//
+	// Best-effort is about not aborting, though, not about staying quiet. The
+	// failures are collected so the answer can name them, because "ok" used to
+	// come back even when all three had failed and nothing was reclaimed — the
+	// UI printed "Pruned: unknown" and the audit row recorded a cleanup that
+	// never ran.
 	prunes := []struct {
 		name string
 		args []string
@@ -440,10 +448,12 @@ func handleDockerPrune(w http.ResponseWriter, r *http.Request) {
 		{"system prune", []string{"system", "prune", "-f"}},
 	}
 	var totalReclaimed bytes.Buffer
+	var failures []string
 	for _, p := range prunes {
 		out, err := runCapture(ctx, "docker", p.args...)
 		if err != nil {
 			slog.Warn(p.name+" failed", "err", err)
+			failures = append(failures, p.name+": "+err.Error())
 		}
 		totalReclaimed.WriteString(out)
 	}
@@ -462,12 +472,30 @@ func handleDockerPrune(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Refresh storage immediately so /system/info reflects the prune result
-	// on the very next request, not 5 minutes later.
+	// on the very next request, not 5 minutes later. Done on the failure path
+	// too: a run that reclaimed nothing still leaves the cache correct.
 	if storageCache != nil {
 		storageCache.invalidate()
 		storageCache.set(fetchDockerStorage())
 	}
 
+	// Nothing ran, so nothing was reclaimed. Reporting that as a success is the
+	// one outcome this endpoint has no business claiming.
+	if len(failures) == len(prunes) {
+		writeJSON(w, 500, map[string]string{"error": "docker prune failed: " + strings.Join(failures, "; ")})
+		return
+	}
+	// Some ran. The 200 stays — the space they freed is real — and the warning
+	// field carries what did not, the same way handleImageRemove reports a
+	// removal it could not complete.
+	if len(failures) > 0 {
+		writeJSON(w, 200, map[string]string{
+			"status":    "ok",
+			"reclaimed": reclaimed,
+			"warning":   "prune incomplete: " + strings.Join(failures, "; "),
+		})
+		return
+	}
 	writeJSON(w, 200, map[string]string{"status": "ok", "reclaimed": reclaimed})
 }
 

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1695,6 +1695,100 @@ func TestIsAllowedManagedImage_Charset(t *testing.T) {
 	}
 }
 
+// "truffels/" is a namespace an attacker may name freely, and the two gates
+// disagreed about it: /v1/image/tag and /v1/image/inspect-by-name have required
+// one of the five repositories we actually build since the boundary was
+// tightened, while /v1/image/pull and /v1/image/remove matched the bare prefix
+// and took anything after it. So `docker pull truffels/<whatever>` was reachable
+// on a box holding a full node — a fetch of an attacker-named image is the worse
+// half of that pair, not the milder one.
+//
+// Foreign prefixes stay prefix-matched: we do not enumerate mempool's or
+// btcpayserver's repositories and pinning them here would break their updates
+// the first time upstream renames one.
+func TestIsAllowedManagedImage_TruffelsNamespaceIsNotAWildcard(t *testing.T) {
+	denied := map[string]string{
+		"truffels/evil:latest":           "attacker-chosen repository",
+		"truffels/nginx:latest":          "not one of ours",
+		"truffels/ckstats-cron:rollback": "container name, not an image repository",
+		"truffels/truffels:rollback":     "the stack has no image of its own",
+		"truffels/bitcoind:latest":       "upstream service, not built here",
+		"truffels/agent-x:v1":            "near-miss on a real name",
+		"truffels/:latest":               "empty repository",
+		"truffels/agent/x:v1":            "extra path segment",
+		"truffels/miner":                 "untagged, still not a repository of ours",
+		// '@' is in this endpoint's alphabet because every *upstream* image is
+		// digest-pinned. Nothing in truffels-api ever builds a digest for an
+		// image this appliance built itself — api.services strips the digest
+		// before pulling, pruneOldImages joins with ':' — so a digest here is
+		// not a shape we have to keep working.
+		"truffels/api@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416": "no digest is ever built for our own images",
+	}
+	for ref, why := range denied {
+		if isAllowedManagedImage(ref) {
+			t.Errorf("ref %q must be rejected (%s)", ref, why)
+		}
+	}
+
+	// Every truffels ref the API really pulls or removes. RemoveImage gets
+	// these from pruneOldImages (src.Images × old version) and from
+	// rollbackImageRef; the pull-restart action in api.services pulls the
+	// running ref of every container in a service, which for the truffels stack
+	// is truffels/{agent,api,web}:<version>.
+	for _, ref := range localRefsInProduction {
+		if !isAllowedManagedImage(ref) {
+			t.Errorf("ref %q is used in production and must be allowed", ref)
+		}
+	}
+}
+
+// Inside our own namespace the two gates must give the same answer: a
+// repository the appliance may retag is one it may delete, and the reverse. A
+// divergence is not a cosmetic inconsistency — it makes the looser of the two
+// the way in, which is exactly what the bare "truffels/" prefix was.
+//
+// Held structurally today (isAllowedManagedImage defers to isAllowedImageRef
+// here), which is why this asserts the property rather than a list of refs:
+// splitting the paths again has to fail here.
+func TestIsAllowedManagedImage_AgreesWithIsAllowedImageRefOnOurOwnImages(t *testing.T) {
+	refs := append([]string{
+		"truffels/evil:v1", "truffels/truffels:rollback", "truffels/ckstats-cron:latest",
+		"truffels/:latest", "truffels/agent/x:v1",
+		"truffels/api@sha256:abc", "truffels/ckpool:latest;id", "truffels/CKPOOL:latest",
+	}, localRefsInProduction...)
+
+	for _, ref := range refs {
+		if isAllowedManagedImage(ref) != isAllowedImageRef(ref) {
+			t.Errorf("ref %q: pull/remove says %v, tag/inspect says %v — the two gates must agree inside our namespace",
+				ref, isAllowedManagedImage(ref), isAllowedImageRef(ref))
+		}
+	}
+}
+
+func TestHandleImageRemove_RefusesAnUnknownRepositoryInOurNamespace(t *testing.T) {
+	reqBody, _ := json.Marshal(map[string]string{"image": "truffels/evil:latest"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/remove", bytes.NewReader(reqBody))
+
+	handleImageRemove(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImagePull_RefusesAnUnknownRepositoryInOurNamespace(t *testing.T) {
+	reqBody, _ := json.Marshal(imagePullRequest{Image: "truffels/evil:latest"})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/v1/image/pull", bytes.NewReader(reqBody))
+
+	handleImagePull(w, r)
+
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleImageRemove_RefusesShellMetacharacters(t *testing.T) {
 	reqBody, _ := json.Marshal(map[string]string{"image": "mempool/x; rm -rf /"})
 	w := httptest.NewRecorder()

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -1776,13 +1776,17 @@ func TestHandleDockerPrune_ReturnsJSON(t *testing.T) {
 	if ct != "application/json" {
 		t.Fatalf("expected application/json, got %q", ct)
 	}
-	// docker commands will fail in CI but should still return JSON
+	// Written to hold with and without a docker CLI. Where docker is missing
+	// all three prunes fail and the answer is an error — it used to be
+	// {"status":"ok"}, which is what this assertion no longer accepts. The
+	// exact-outcome cases live in exec_test.go, where the exit status is
+	// chosen rather than inherited from the container.
 	var body map[string]string
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
-	if body["status"] != "ok" {
-		t.Fatalf("expected status ok, got %q", body["status"])
+	if body["status"] != "ok" && body["error"] == "" {
+		t.Fatalf("expected status ok or an error field, got %v", body)
 	}
 }
 

--- a/truffels-api/internal/api/handlers_test.go
+++ b/truffels-api/internal/api/handlers_test.go
@@ -750,6 +750,50 @@ func TestDockerPrune_AuditLog(t *testing.T) {
 	}
 }
 
+// A prune where one of the agent's three runs failed is still a 200 — the other
+// two freed real space — but both surfaces the operator actually reads must say
+// so. Without this the response says "Total reclaimed space: 100MB" and the
+// audit row records an unqualified cleanup, while image prune never ran.
+func TestDockerPrune_PartialFailureIsVisibleInResponseAndAudit(t *testing.T) {
+	agentState := &mockAgentState{pruneWarning: "prune incomplete: image prune: exit status 1"}
+	srv, st, _ := newTestServerWithAgent(t, agentState)
+
+	req := authedReq(t, srv, "POST", "/api/truffels/system/docker-prune",
+		`{"password":"testpassword"}`)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if !strings.Contains(body["reclaimed"], "100MB") {
+		t.Errorf("reclaimed = %q, want what the surviving runs freed", body["reclaimed"])
+	}
+	if !strings.Contains(body["reclaimed"], "image prune") {
+		t.Errorf("reclaimed = %q, want the failed stage named", body["reclaimed"])
+	}
+
+	entries, err := st.GetAuditLog(50)
+	if err != nil {
+		t.Fatalf("get audit log: %v", err)
+	}
+	var detail string
+	for _, e := range entries {
+		if e.Action == "docker_prune" {
+			detail = e.Detail
+			break
+		}
+	}
+	if detail == "" {
+		t.Fatal("expected docker_prune audit entry")
+	}
+	if !strings.Contains(detail, "image prune") {
+		t.Errorf("audit detail = %q; a partial prune must not be recorded as a clean one", detail)
+	}
+}
+
 // --- Docker Build Cache Prune ---
 
 func TestDockerPruneBuildCache_WrongPassword(t *testing.T) {

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -27,6 +27,7 @@ import (
 type mockAgentState struct {
 	containerStates map[string]model.ContainerState // keyed by container name
 	composeErr      string                          // if set, compose actions return this error
+	pruneWarning    string                          // if set, /v1/docker/prune answers 200 with this warning
 	lastAction      string
 	lastServiceID   string
 	lastContainer   string
@@ -110,7 +111,13 @@ func newMockAgent(t *testing.T, state *mockAgentState) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 
 		case r.URL.Path == "/v1/docker/prune" && r.Method == "POST":
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "reclaimed": "Total reclaimed space: 100MB"})
+			// The agent runs three prunes best-effort. A partial run still
+			// answers 200 and names the stage that failed in a warning field.
+			resp := map[string]string{"status": "ok", "reclaimed": "Total reclaimed space: 100MB"}
+			if state.pruneWarning != "" {
+				resp["warning"] = state.pruneWarning
+			}
+			_ = json.NewEncoder(w).Encode(resp)
 
 		case r.URL.Path == "/v1/docker/prune-buildcache" && r.Method == "POST":
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "reclaimed": "Total reclaimed space: 50MB"})

--- a/truffels-api/internal/docker/compose.go
+++ b/truffels-api/internal/docker/compose.go
@@ -60,6 +60,13 @@ type agentResult struct {
 	Changed   bool   `json:"changed"`
 	Reclaimed string `json:"reclaimed"`
 	Content   string `json:"content"`
+	// Warning accompanies a 200 that only partly succeeded. The agent uses it
+	// where the work is made of several independent steps and some of them ran:
+	// refusing the whole call would throw away real results, and answering a
+	// bare "ok" would claim results that do not exist. Anything that decodes it
+	// has to pass it on, or the partial failure is lost exactly where the
+	// operator would have read it.
+	Warning string `json:"warning"`
 }
 
 // agentError builds an error from a failed agent response. ar.Error alone is
@@ -586,15 +593,38 @@ func (c *ComposeClient) ReconcileFile(relativePath, content string) (bool, error
 }
 
 // DockerPrune runs a full docker cleanup via the agent (builder + image + system prune).
+//
+// Three prunes run behind that one call and the agent keeps going when one
+// fails, so the result has a third state between success and error: some space
+// reclaimed, one stage that never ran. It arrives as a 200 carrying both a
+// reclaimed total and a warning, and both belong in the returned string —
+// that string is the audit row's detail and the line the Settings page prints,
+// and it is the only place the operator can learn the cleanup was incomplete.
+// Reporting the total on its own would keep the agent honest and lie here
+// instead.
 func (c *ComposeClient) DockerPrune() (string, error) {
 	res, err := c.callResult("agent docker prune", agentReq{
 		path:    "/v1/docker/prune",
 		payload: map[string]any{},
 	})
-	return res.Reclaimed, err
+	if err != nil {
+		return "", err
+	}
+	if res.Warning == "" {
+		return res.Reclaimed, nil
+	}
+	if res.Reclaimed == "" {
+		return res.Warning, nil
+	}
+	return res.Reclaimed + " — " + res.Warning, nil
 }
 
 // DockerPruneBuildCache runs only docker builder prune via the agent.
+//
+// No warning to fold in: this endpoint runs the single `docker builder prune`
+// and answers 200 or 500 on its exit status. There is no partial outcome to
+// report, which is why it does not need what DockerPrune does — not an
+// oversight. If it ever grows a second step, it grows this too.
 func (c *ComposeClient) DockerPruneBuildCache() (string, error) {
 	res, err := c.callResult("agent docker prune buildcache", agentReq{
 		path:    "/v1/docker/prune-buildcache",

--- a/truffels-api/internal/docker/compose_characterization_test.go
+++ b/truffels-api/internal/docker/compose_characterization_test.go
@@ -1005,6 +1005,66 @@ func TestCharacterize_DockerPrune_TransportFailure(t *testing.T) {
 	assertContains(t, err, "agent docker prune: ")
 }
 
+// The agent runs three prunes and keeps going when one fails, so a run can be
+// partly successful: 200, real space reclaimed, and one stage that did not run.
+// It reports that as a warning field alongside the reclaimed total.
+//
+// This string is the whole surface — it becomes the audit row's detail and the
+// text the Settings page prints. Dropping the warning here would move the lie
+// one layer up instead of removing it: the operator reads "2.1GB reclaimed" and
+// has no way to learn that image prune never ran.
+func TestCharacterize_DockerPrune_PartialFailureReachesTheReturnedString(t *testing.T) {
+	c, _ := newFakeAgent(t, 200, map[string]any{
+		"status":    "ok",
+		"reclaimed": "Total reclaimed space: 2.1GB",
+		"warning":   "prune incomplete: image prune: exit status 1",
+	})
+
+	reclaimed, err := c.DockerPrune()
+	if err != nil {
+		t.Fatalf("a partial prune is not a failed call: %v", err)
+	}
+	if !strings.Contains(reclaimed, "2.1GB") {
+		t.Errorf("reclaimed = %q, want what the surviving runs freed", reclaimed)
+	}
+	if !strings.Contains(reclaimed, "image prune") {
+		t.Errorf("reclaimed = %q, want the stage that did not run to be named", reclaimed)
+	}
+}
+
+// A prune where nothing failed must read exactly as it always did — no
+// separator, no empty warning clause. TestCharacterize_DockerPrune_Success pins
+// the string; this pins the absent-field case explicitly, since the agent omits
+// the key rather than sending an empty one.
+func TestCharacterize_DockerPrune_NoWarningLeavesTheStringAlone(t *testing.T) {
+	c, _ := newFakeAgent(t, 200, map[string]any{"status": "ok", "reclaimed": "4.2GB", "warning": ""})
+
+	reclaimed, err := c.DockerPrune()
+	if err != nil {
+		t.Fatalf("docker prune: %v", err)
+	}
+	if reclaimed != "4.2GB" {
+		t.Errorf("reclaimed = %q, want the untouched agent value", reclaimed)
+	}
+}
+
+// An agent that reports a warning but no reclaimed total must not produce a
+// string that opens with the separator. Defensive: today's agent always fills
+// reclaimed, with "unknown" if no line said otherwise.
+func TestCharacterize_DockerPrune_WarningWithoutReclaimedStandsAlone(t *testing.T) {
+	c, _ := newFakeAgent(t, 200, map[string]any{
+		"status": "ok", "warning": "prune incomplete: image prune: exit status 1",
+	})
+
+	reclaimed, err := c.DockerPrune()
+	if err != nil {
+		t.Fatalf("docker prune: %v", err)
+	}
+	if reclaimed != "prune incomplete: image prune: exit status 1" {
+		t.Errorf("reclaimed = %q, want the warning on its own", reclaimed)
+	}
+}
+
 func TestCharacterize_DockerPruneBuildCache_Success(t *testing.T) {
 	c, rec := newFakeAgent(t, 200, map[string]any{"status": "ok", "reclaimed": "1.1GB"})
 	reclaimed, err := c.DockerPruneBuildCache()


### PR DESCRIPTION
Stacked on #30 — review that one first; this shows only its own three commits.

## The prune reported success it had not earned

`handleDockerPrune` runs three prunes and deliberately keeps going when one
fails, which is right: a partial failure should not throw away the space the
other two freed. But the response was always `200 {"status":"ok"}`, the failures
went to `slog.Warn` and nowhere else. All three could fail and the operator read
"reclaimed: unknown, ok".

Now: all three failed is not a success and answers with an error naming them;
some failed still answers 200 but carries a `warning` field, the same shape
`handleImageRemove` already uses; none failed is byte-identical to before, with
no `warning` key at all.

That alone would have moved the lie one layer up rather than removing it.
`agentResult` had no `Warning` field, so the client decoded it away — the agent
told the truth and the operator still read `Total reclaimed space: 100MB` while
image prune never ran. The returned string is the whole surface here: it becomes
the audit row's detail and the line the Settings page prints. It now carries
both.

`DockerPruneBuildCache` needs none of this and the comment says why rather than
leaving it looking forgotten: one command, 200 or 500 on its exit status, no
partial outcome to report.

## Pull and remove now match tag and inspect

#30 narrowed `isAllowedImageRef` to the five images this project builds, but
`isAllowedManagedImage` — guarding pull and remove — still checked
`allowedImagePrefixes`, where `truffels/` is a prefix, so any `truffels/anything`
passed. Two strictness levels for the same kind of input.

`isAllowedManagedImage` now delegates everything under `truffels/` to
`isAllowedImageRef`, so the two gates agree by construction rather than by
keeping two lists in step. `"truffels/"` is removed from the prefix list rather
than left behind as a dead entry. Foreign prefixes are untouched — we do not
enumerate upstream images.

One correction to what I assumed when specifying this: `Pull` is **not** only
reached through `src.Images`. `api/services.go:319` pulls
`ImageInspect(container).Image` for every container of a template, which for the
truffels stack is `truffels/{agent,api,web}`. The outcome is the same because all
five are on the list, but the safety argument rests on the enumeration covering
it, not on that branch being unreachable.

## Verification

Red-then-green for each change. The tightening has tests proving the real values
still pass: the digest pins from `install.sh`, the image lines from the live
compose files, the `mariadb:sha256:…` shape `pruneOldImages` emits, and every
`truffels/*` tag on the device.

Two older tests had to change, both because they asserted the thing being fixed:
one claimed `status == "ok"` from a prune that never ran, the other used a
fictional repository inside our own namespace.

Agent and API suites green, both modules lint clean.