### PR TITLE
Move to Go 1.26 and golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: truffels-api/go.sum
       - run: go mod download
       - run: go vet ./...
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.12.2
           working-directory: truffels-api
       - run: go build -o /dev/null .
       - run: go test -v -count=1 -coverprofile=coverage.out ./...
@@ -44,12 +44,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: false
       - run: go vet ./...
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.12.2
           working-directory: truffels-agent
       - run: go build -o /dev/null .
       - run: go test -v -count=1 -coverprofile=coverage.out ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: truffels-api/go.sum
       - run: go mod download
       - run: go vet ./...
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
           working-directory: truffels-api
@@ -47,7 +47,7 @@ jobs:
           go-version: "1.26"
           cache: false
       - run: go vet ./...
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
           working-directory: truffels-agent

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,22 @@
-# golangci-lint runs its default set unless told otherwise, and gofmt is not in
-# it. That is why 21 files had drifted out of gofmt shape without anyone
-# noticing — the linter was green the whole time.
-#
-# This adds gofmt to the defaults rather than replacing them: errcheck, gosimple,
-# govet, ineffassign, staticcheck and unused stay on.
-#
-# Found in both module directories because golangci-lint searches upwards from
-# its working directory, and CI sets working-directory per module.
+version: "2"
 linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/truffels-agent/Dockerfile
+++ b/truffels-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /src
 COPY go.mod ./
 RUN go mod download || (sleep 10 && go mod download) || (sleep 30 && go mod download) || (sleep 60 && go mod download)

--- a/truffels-agent/go.mod
+++ b/truffels-agent/go.mod
@@ -1,3 +1,3 @@
 module truffels-agent
 
-go 1.24.0
+go 1.26.0

--- a/truffels-agent/main_test.go
+++ b/truffels-agent/main_test.go
@@ -622,12 +622,13 @@ func TestHandleStats_ReturnsJSONArray(t *testing.T) {
 		t.Fatalf("expected application/json, got %q", ct)
 	}
 
-	if w.Code == 200 {
+	switch w.Code {
+	case 200:
 		var stats []containerStats
 		if err := json.Unmarshal(w.Body.Bytes(), &stats); err != nil {
 			t.Fatalf("expected valid JSON array, got error: %v", err)
 		}
-	} else if w.Code == 500 {
+	case 500:
 		// Expected when docker is not available — verify error is valid JSON
 		var body map[string]string
 		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
@@ -636,7 +637,7 @@ func TestHandleStats_ReturnsJSONArray(t *testing.T) {
 		if body["error"] == "" {
 			t.Fatal("expected 'error' field in 500 response")
 		}
-	} else {
+	default:
 		t.Fatalf("expected 200 or 500, got %d", w.Code)
 	}
 }

--- a/truffels-api/Dockerfile
+++ b/truffels-api/Dockerfile
@@ -1,5 +1,5 @@
 # truffels-api — Go control plane backend
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum* ./

--- a/truffels-api/go.mod
+++ b/truffels-api/go.mod
@@ -1,6 +1,6 @@
 module truffels-api
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -383,20 +383,17 @@ func (e *Engine) recoverInterruptedReclaims() {
 			w.humanLabel, w.serviceID)
 
 		detail := "restart issued after an interrupted reclaim"
-		switch {
-		case e.compose == nil:
+		if e.compose == nil {
 			detail = "no compose client available to restart the service after an interrupted reclaim"
 			slog.Error("auto-reclaim recovery: no compose client", "service", w.serviceID)
-		default:
-			if err := e.compose.Up(w.serviceID); err != nil {
-				detail = "restart after an interrupted reclaim failed: " + err.Error()
-				slog.Error("auto-reclaim recovery: restart failed", "service", w.serviceID, "err", err)
-				e.upsert("auto_reclaim_interrupted", w.serviceID, model.SeverityCritical,
-					"An automatic %s reclaim was interrupted by a restart of truffels-api and the recovery restart failed: %s — start %s manually from Services.",
-					w.humanLabel, err.Error(), w.serviceID)
-			} else {
-				slog.Info("auto-reclaim recovery: service restarted", "service", w.serviceID)
-			}
+		} else if err := e.compose.Up(w.serviceID); err != nil {
+			detail = "restart after an interrupted reclaim failed: " + err.Error()
+			slog.Error("auto-reclaim recovery: restart failed", "service", w.serviceID, "err", err)
+			e.upsert("auto_reclaim_interrupted", w.serviceID, model.SeverityCritical,
+				"An automatic %s reclaim was interrupted by a restart of truffels-api and the recovery restart failed: %s — start %s manually from Services.",
+				w.humanLabel, err.Error(), w.serviceID)
+		} else {
+			slog.Info("auto-reclaim recovery: service restarted", "service", w.serviceID)
 		}
 
 		// Terminal row either way: the sequence is closed, and one recovery


### PR DESCRIPTION
`go 1.24.0` has been pinned since the commit that first added the agent. It was
current then and nobody revisited it — no deliberate reason, just inertia.

## Why now

`os.Root`. Closing the TOCTOU gap in `validateUnderRoot` means anchoring the file
operations so the kernel refuses to leave the root, instead of checking first and
hoping afterwards. Go 1.24's `os.Root` is missing exactly the methods the four
call sites need — `RemoveAll`, `Chown`, `Chmod`, `MkdirAll` — so the fix would
have meant hand-writing a recursive delete that runs as root against a live
Bitcoin appliance. From Go 1.25 they all exist. That change is the next PR; this
one only makes it possible.

## What had to move with it

golangci-lint v1.64.8 refuses to run at all against a 1.26 module:

```
can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.26.0)
```

v2 changed the configuration schema, so `.golangci.yml` here is the output of
`golangci-lint migrate` rather than something hand-written: `gofmt` is a
formatter rather than a linter in v2, and the exclusion presets v1 applied
implicitly are now spelled out.

v2 also runs staticcheck's `QF` checks, which v1 did not. That found two places
across the whole project, neither a bug:

- `alerts/engine.go` had a two-branch `switch { case … default: }`, which is an
  if/else in costume. staticcheck suggested a tagged switch on an interface
  value, which reads worse than either form, so it is a plain if/else now.
- A test used `if code == 200 / else if code == 500 / else`. That one is a real
  readability win as a `switch`.

## Verified

Both modules build, vet, test and lint clean on go1.26.5 with
golangci-lint v2.12.2 — the pinned tag, checked to exist rather than reached via
`latest`. Full suites: `truffels-api` all eleven packages, `truffels-agent` ok.