### PR TITLE
Anchor the agent's file operations so they cannot leave their root

### DIFF
--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -300,24 +300,17 @@ func isValidCommitHash(s string) bool {
 // EvalSymlinks to resolve cleanly; if the parent doesn't exist yet, the check
 // walks upward until it finds an existing ancestor and validates that one.
 //
-// KNOWN LIMIT — this is not a defence against a racing attacker.
+// This is the first of two layers and deliberately not the load-bearing one.
+// It answers cheaply and with a message a caller can act on — "path outside
+// root", "symlink redirects outside root" — which an anchored open cannot,
+// because to the kernel an escape and a missing file look much alike.
 //
-// The symlink check resolves the nearest ancestor that exists *at the time of
-// the call*. Every component created afterwards is unexamined, and so is any
-// component swapped for a symlink between this returning and the caller's
-// os.MkdirAll / os.WriteFile / os.RemoveAll running. That is a plain
-// time-of-check/time-of-use gap and it cannot be closed from here: closing it
-// means the file operations themselves must not traverse a symlink — openat2
-// with RESOLVE_BENEATH, or an fd-anchored walk — which is a rewrite of every
-// caller, not a change to this function.
-//
-// It is stated rather than papered over because the callers' safety arguments
-// have to be able to lean on what this actually promises. What it does promise:
-// no relative escape, and no symlink escape via a component that already
-// existed. What it does not: atomicity with the operation that follows. The
-// exposure is bounded elsewhere — /srv/truffels is root-owned, the endpoints
-// take service-shaped inputs, and clear-dir carries its own basename and depth
-// checks — not by this.
+// What it promises: no relative escape, and no symlink escape through a
+// component that existed when it ran. What it cannot promise is atomicity with
+// whatever the caller does next; a component swapped for a symlink in between
+// would not be seen. That gap is closed by the second layer rather than here —
+// see anchorUnderRoot, and note that every caller of this function performs its
+// file operations through that anchor.
 func validateUnderRoot(p, root string) (string, error) {
 	if p == "" {
 		return "", fmt.Errorf("empty path")
@@ -363,4 +356,40 @@ func validateUnderRoot(p, root string) (string, error) {
 		}
 	}
 	return cleaned, nil
+}
+
+// anchorUnderRoot opens root as an os.Root and returns it alongside the name of
+// cleaned relative to it. Every file operation this process performs on a
+// caller-supplied path goes through the returned root.
+//
+// This is the layer that actually holds. validateUnderRoot checks a path and
+// then hands it back as a string, and a string carries none of that checking
+// with it: between the check and the os.RemoveAll a component can become a
+// symlink pointing anywhere, and the operation follows it. os.Root closes that
+// by making the check and the use the same act — the kernel resolves each
+// component against the anchored directory and refuses one that leaves it, so
+// there is no interval in which anything can be swapped.
+//
+// It matters most for clear-dir, which runs RemoveAll as root against a tree
+// several containers mount read-write.
+//
+// Root methods take paths relative to the anchor, which is why the name comes
+// back with the root: passing the absolute path would resolve against the
+// anchor and land somewhere else entirely.
+func anchorUnderRoot(cleaned, root string) (*os.Root, string, error) {
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, cleaned)
+	if err != nil {
+		return nil, "", fmt.Errorf("path outside root")
+	}
+	// filepath.Rel is happy to return an escaping path; that it did means the
+	// caller handed us something validateUnderRoot should already have refused.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, "", fmt.Errorf("path outside root")
+	}
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, "", err
+	}
+	return r, rel, nil
 }

--- a/truffels-agent/anchor_test.go
+++ b/truffels-agent/anchor_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The TOCTOU gap these tests cover cannot be reproduced by racing it — a test
+// that plants a symlink in the microseconds between a check and a use is a test
+// that fails on a busy machine and passes on an idle one, which is worse than no
+// test.
+//
+// So they prove the property that makes the race irrelevant: the anchored
+// operation refuses to leave the root *on its own*, with no help from
+// validateUnderRoot. If that holds, it does not matter when the symlink appears,
+// because the kernel resolves every component against the anchor at the moment
+// of use. Each test therefore bypasses validateUnderRoot deliberately and hands
+// anchorUnderRoot exactly what a winning attacker would have arranged.
+//
+// Each also carries a control doing the same thing unanchored, so the setup is
+// shown to be a real trap rather than an inert one.
+
+// escapeTrap builds a root containing a service directory that is really a
+// symlink pointing outside it, with something worth destroying at the far end.
+// Returns the root, the path a caller would name, and the outside file that must
+// survive.
+func escapeTrap(t *testing.T) (root, named, mustSurvive string) {
+	t.Helper()
+	base := t.TempDir()
+
+	root = filepath.Join(base, "data")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	mustSurvive = filepath.Join(outside, "cache", "keepme")
+	if err := os.WriteFile(mustSurvive, []byte("not yours to delete"), 0o644); err != nil {
+		t.Fatalf("write bait: %v", err)
+	}
+
+	// The escape sits in an intermediate component, which is the shape that
+	// matters: os.RemoveAll on a final-component symlink unlinks the link
+	// itself, so that case was never dangerous. "svc" being the link is.
+	if err := os.Symlink(outside, filepath.Join(root, "svc")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	return root, filepath.Join(root, "svc", "cache"), mustSurvive
+}
+
+func TestAnchoredRemoveAll_RefusesToLeaveTheRoot(t *testing.T) {
+	root, named, mustSurvive := escapeTrap(t)
+
+	r, name, err := anchorUnderRoot(named, root)
+	if err != nil {
+		t.Fatalf("anchorUnderRoot: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if err := r.RemoveAll(name); err == nil {
+		t.Error("RemoveAll followed a symlink out of the root and reported success")
+	}
+	if _, err := os.Stat(mustSurvive); err != nil {
+		t.Fatalf("the file outside the root was destroyed: %v", err)
+	}
+}
+
+// The control. Same trap, the operation this code used to perform. It proves the
+// trap is real: without the anchor the outside file is gone.
+func TestUnanchoredRemoveAll_DestroysTheTargetOutsideTheRoot(t *testing.T) {
+	_, named, mustSurvive := escapeTrap(t)
+
+	if err := os.RemoveAll(named); err != nil {
+		t.Fatalf("control setup failed: %v", err)
+	}
+	if _, err := os.Stat(mustSurvive); err == nil {
+		t.Fatal("control did not reproduce the escape — the trap is inert and " +
+			"the anchored test above proves nothing")
+	}
+}
+
+func TestAnchoredMkdirAllAndChmod_RefuseToLeaveTheRoot(t *testing.T) {
+	root, named, _ := escapeTrap(t)
+
+	r, name, err := anchorUnderRoot(named, root)
+	if err != nil {
+		t.Fatalf("anchorUnderRoot: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if err := r.MkdirAll(name, 0o755); err == nil {
+		t.Error("MkdirAll created a directory outside the root")
+	}
+	if err := r.Chmod(name, 0o777); err == nil {
+		t.Error("Chmod changed the mode of something outside the root")
+	}
+}
+
+// A path that escapes by relative components never reaches os.Root at all.
+func TestAnchorUnderRoot_RejectsRelativeEscapes(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "data")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	for _, p := range []string{
+		filepath.Join(base, "elsewhere"),
+		"/etc",
+		base,
+	} {
+		if r, _, err := anchorUnderRoot(p, root); err == nil {
+			_ = r.Close()
+			t.Errorf("anchorUnderRoot(%q, %q) accepted a path outside the root", p, root)
+		}
+	}
+}
+
+// The everyday case has to keep working, or the guard is just an outage.
+func TestAnchoredOperations_AcceptTheRealShapes(t *testing.T) {
+	root := t.TempDir()
+	named := filepath.Join(root, "mempool", "cache")
+
+	r, name, err := anchorUnderRoot(named, root)
+	if err != nil {
+		t.Fatalf("anchorUnderRoot: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if name != filepath.Join("mempool", "cache") {
+		t.Errorf("relative name = %q, want mempool/cache", name)
+	}
+	if err := r.MkdirAll(name, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := r.Chmod(name, 0o750); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if err := r.RemoveAll(name); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if _, err := os.Stat(named); !os.IsNotExist(err) {
+		t.Errorf("directory should be gone, stat gave %v", err)
+	}
+}

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -1752,11 +1752,21 @@ func removeUntrackedCollisionsForCheckout(ctx context.Context, repoDir, ref stri
 		if err != nil {
 			return log.String(), fmt.Errorf("refusing to remove %q in %q: %w", rel, repoDir, err)
 		}
-		// os.Remove, never os.RemoveAll: ls-files --others lists files, so every
-		// candidate is a file. If one is somehow a non-empty directory, os.Remove
+		root, name, err := anchorUnderRoot(full, repoDir)
+		if err != nil {
+			return log.String(), fmt.Errorf("refusing to remove %q in %q: %w", rel, repoDir, err)
+		}
+		// Root.Remove, never RemoveAll: ls-files --others lists files, so every
+		// candidate is a file. If one is somehow a non-empty directory, Remove
 		// fails and this aborts — which is the correct outcome. A recursive
 		// delete here would turn one wrong path into an unbounded one.
-		if err := os.Remove(full); err != nil {
+		//
+		// The names come from git and the paths were checked above, but the
+		// removal still goes through the anchor: git listed them at one moment
+		// and we delete at another, and this runs as root.
+		err = root.Remove(name)
+		_ = root.Close()
+		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
@@ -2105,6 +2115,9 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 	} else {
 		fullPath = filepath.Clean(fullPath)
 	}
+	// Whichever root accepts the path is the one the operations below anchor in,
+	// so it has to be carried out of the check rather than recomputed after it.
+	chosenRoot := composeRoot
 	if _, err := validateUnderRoot(fullPath, composeRoot); err != nil {
 		// Fall back to configRoot only if it's non-empty — an empty root would
 		// match everything (HasPrefix(anything, "/") is true).
@@ -2118,11 +2131,19 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		chosenRoot = configRoot
 	}
 
 	slog.Info("file reconcile", "path", fullPath)
 
-	data, err := os.ReadFile(fullPath)
+	root, name, err := anchorUnderRoot(fullPath, chosenRoot)
+	if err != nil {
+		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+	defer func() { _ = root.Close() }()
+
+	data, err := root.ReadFile(name)
 	if err != nil && !os.IsNotExist(err) {
 		writeJSON(w, 500, map[string]string{"error": "read file: " + err.Error()})
 		return
@@ -2134,12 +2155,14 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
-		writeJSON(w, 500, map[string]string{"error": "create dir: " + err.Error()})
-		return
+	if dir := filepath.Dir(name); dir != "." {
+		if err := root.MkdirAll(dir, 0755); err != nil {
+			writeJSON(w, 500, map[string]string{"error": "create dir: " + err.Error()})
+			return
+		}
 	}
 
-	if err := os.WriteFile(fullPath, []byte(req.ExpectedContent), 0644); err != nil {
+	if err := root.WriteFile(name, []byte(req.ExpectedContent), 0644); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "write file: " + err.Error()})
 		return
 	}
@@ -2178,20 +2201,27 @@ func handleEnsureDir(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	root, name, err := anchorUnderRoot(cleaned, dataRoot)
+	if err != nil {
+		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+	defer func() { _ = root.Close() }()
+
 	existed := true
-	if _, err := os.Stat(cleaned); os.IsNotExist(err) {
+	if _, err := root.Stat(name); os.IsNotExist(err) {
 		existed = false
 	}
 
-	if err := os.MkdirAll(cleaned, mode); err != nil {
+	if err := root.MkdirAll(name, mode); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "mkdir: " + err.Error()})
 		return
 	}
-	if err := os.Chown(cleaned, req.UID, req.GID); err != nil {
+	if err := root.Chown(name, req.UID, req.GID); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "chown: " + err.Error()})
 		return
 	}
-	if err := os.Chmod(cleaned, mode); err != nil {
+	if err := root.Chmod(name, mode); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "chmod: " + err.Error()})
 		return
 	}

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -2256,19 +2256,31 @@ func handleClearDir(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("clear-dir", "path", cleaned, "uid", req.UID, "gid", req.GID)
 
-	if err := os.RemoveAll(cleaned); err != nil {
+	// Anchored, because this is the one endpoint that deletes recursively as
+	// root, and the tree it deletes in is mounted read-write into several
+	// containers. Through the root every component is resolved against dataRoot
+	// by the kernel, so a symlink planted after the checks above cannot redirect
+	// the RemoveAll — there is no longer an interval to plant it in.
+	root, name, err := anchorUnderRoot(cleaned, dataRoot)
+	if err != nil {
+		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+	defer func() { _ = root.Close() }()
+
+	if err := root.RemoveAll(name); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "remove: " + err.Error()})
 		return
 	}
-	if err := os.MkdirAll(cleaned, mode); err != nil {
+	if err := root.MkdirAll(name, mode); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "mkdir: " + err.Error()})
 		return
 	}
-	if err := os.Chown(cleaned, req.UID, req.GID); err != nil {
+	if err := root.Chown(name, req.UID, req.GID); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "chown: " + err.Error()})
 		return
 	}
-	if err := os.Chmod(cleaned, mode); err != nil {
+	if err := root.Chmod(name, mode); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "chmod: " + err.Error()})
 		return
 	}


### PR DESCRIPTION
`validateUnderRoot` checks a path and hands it back as a string, and a string
carries none of that checking with it. Between the check returning and the
caller's `os.RemoveAll` running, a component can become a symlink pointing
anywhere, and the operation follows it. Its own comment has named that as a known
limit since the release that added it, along with what closing it would take.

This closes it. Every file operation on a caller-supplied path now goes through
an `os.Root` anchored at the root that path was checked against. The kernel
resolves each component against that anchor and refuses one that leaves it, so
check and use are the same act and there is no interval left to plant anything
in.

That became a small change rather than a large one because of the Go 1.26 move in
#32: `os.Root` gained `RemoveAll`, `Chown`, `Chmod` and `MkdirAll` in 1.25, so
none of it had to be hand-written.

## The four sites

| | operations | root |
|---|---|---|
| `handleClearDir` | `RemoveAll`, `MkdirAll`, `Chown`, `Chmod` | dataRoot |
| `handleEnsureDir` | `Stat`, `MkdirAll`, `Chown`, `Chmod` | dataRoot |
| `handleFileReconcile` | `ReadFile`, `MkdirAll`, `WriteFile` | composeRoot or configRoot |
| `removeUntrackedCollisionsForCheckout` | `Remove` | repoDir |

`clear-dir` is why this matters most: it is the one endpoint that deletes
recursively as root, in a tree several containers mount read-write.

`file-reconcile` needed one structural change — it tries composeRoot and falls
back to configRoot, so whichever accepted the path has to be carried out of the
check rather than recomputed after it.

`validateUnderRoot` stays. It answers cheaply and with a message a caller can act
on, which an anchored open cannot, because to the kernel an escape and a missing
file look much alike. Its comment now says which layer promises what instead of
describing a gap that is closed.

## On the tests

They do not race it. A test that plants a symlink in the microseconds between a
check and a use passes on an idle machine and fails on a busy one, which is worse
than no test.

They prove the property that makes the race irrelevant instead: the anchored
operation refuses to leave the root **on its own**, with no help from
`validateUnderRoot`. Each hands the anchor exactly what a winning attacker would
have arranged — a symlink at an intermediate component, which is the shape that
matters, since `os.RemoveAll` on a final-component symlink only unlinks the link.

Each also carries a control performing the same operation unanchored. Those
controls destroy the file outside the root, which is what makes the traps
demonstrably real rather than inert:

```
unanchored  → the file outside the root is gone
anchored    → refused, the file survives
```

## Not included

Two `os.WriteFile(composePath, …)` calls remain unanchored. They are a different
class: `composePath` comes from `composeDir(serviceID)` with the service id
looked up in `allowedServices`, so no part of the path comes from the request and
`validateUnderRoot` is not involved. Checked rather than assumed: of every
running container, only `truffels-api` and `truffels-agent` have
`/srv/truffels/compose` writable — no managed service does. Worth doing for
consistency, but it is a separate argument and a separate change.

Agent suite green, coverage 70.6 %, lint clean.