### PR TITLE
Log requests at the proxy, and skip the healthcheck path

### DIFF
--- a/truffels-api/internal/compose/caddyfile.go
+++ b/truffels-api/internal/compose/caddyfile.go
@@ -14,6 +14,20 @@ const caddyfileTemplate = `{
 }
 
 :80 {
+	# Access log. The proxy is the only component that ever sees a real client
+	# address: everything behind it — the web container's nginx, the API — logs
+	# 172.21.0.x, which is this proxy. Without this block that address exists
+	# nowhere, and "did that device reach us at all" is unanswerable. It was
+	# unanswerable in dev.29, when a phone could not load the UI and the only way
+	# to look was firewall counters and inference.
+	#
+	# stdout so it lands in docker logs alongside every other service; JSON
+	# because that is already the format Caddy's own error lines use.
+	log {
+		output stdout
+		format json
+	}
+
 	# Shared security headers (non-CSP)
 	header {
 		X-Content-Type-Options nosniff
@@ -25,7 +39,11 @@ const caddyfileTemplate = `{
 
 	# Self-contained health endpoint — used by the proxy's container
 	# healthcheck. Returns 200 regardless of upstream state.
+	#
+	# log_skip because the healthcheck runs every 30s: without it this one path
+	# writes ~2900 lines a day and buries the traffic the log exists to show.
 	handle /proxy-health {
+		log_skip
 		respond "OK" 200
 	}
 

--- a/truffels-api/internal/compose/caddyfile_test.go
+++ b/truffels-api/internal/compose/caddyfile_test.go
@@ -24,3 +24,38 @@ func TestRenderCaddyfile_HasStaticHealthRoute(t *testing.T) {
 		t.Error("missing /ckstats* route")
 	}
 }
+
+// The proxy is the only component that ever sees a client's real address —
+// everything behind it logs this proxy's container IP — so without an access
+// log that address exists nowhere and "did that device reach us" cannot be
+// answered. It could not be answered in dev.29, which is why this is pinned.
+func TestRenderCaddyfile_LogsRequests(t *testing.T) {
+	got := RenderCaddyfile()
+
+	for _, want := range []string{"log {", "output stdout", "format json"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Caddyfile is missing %q — requests would go unlogged", want)
+		}
+	}
+}
+
+// The healthcheck runs every 30s. Logging it writes ~2900 lines a day and
+// buries the traffic the log exists to show, so the health route opts out —
+// and it has to be inside that handle block, not merely present in the file.
+func TestRenderCaddyfile_HealthRouteOptsOutOfLogging(t *testing.T) {
+	got := RenderCaddyfile()
+
+	start := strings.Index(got, "handle /proxy-health {")
+	if start < 0 {
+		t.Fatal("no /proxy-health handle block")
+	}
+	end := strings.Index(got[start:], "\n\t}")
+	if end < 0 {
+		t.Fatal("/proxy-health handle block is not closed")
+	}
+	block := got[start : start+end]
+
+	if !strings.Contains(block, "log_skip") {
+		t.Errorf("the health route does not skip logging:\n%s", block)
+	}
+}


### PR DESCRIPTION
The Caddyfile had no `log` directive, so only errors reached the container log.
Every other service in the stack logs its work; this was the one gap — and it sat
in the worst possible place.

The proxy is the only component that ever sees a client's real address.
Everything behind it records `172.21.0.x`, which is the proxy itself: the web
container's nginx logs it, the API logs it. So the question "did that device
reach us at all, and what did we do with the request" had no answer anywhere.

It cost real time in dev.29. A phone could not load the UI, and there was no way
to tell whether it had ever reached the proxy. The answer had to be assembled
from nftables counters and inference, and the first conclusion drawn that way was
wrong.

`/proxy-health` opts out with `log_skip`. The container healthcheck hits it every
30 seconds, so logging it writes roughly 2900 lines a day and buries the traffic
the log exists to show.

The change is in `RenderCaddyfile`, not in the deployed file. The reconciler
writes that file from this template on every API start, so a hand edit would last
until the next restart — the same shape as the ckstats `basePath` that only ever
existed as a local edit.

## Verified rather than assumed

The rendered Caddyfile passes `caddy validate` against `caddy:2.11.4-alpine`, the
image that actually runs:

```
{"level":"info","msg":"adapted config to JSON","adapter":"caddyfile"}
Valid configuration
```

That check is the point. An invalid Caddyfile does not fail in CI — it gets
reconciled onto the running proxy and takes the whole UI down with it, including
the page you would use to fix it.

Both new tests fail against the unchanged template. The health-route test looks
inside that handle block rather than searching the whole file, so `log_skip`
sitting somewhere else would not satisfy it.

Full `truffels-api` suite green, lint clean.