### PR TITLE
Catalog hardening: close the preconditions before catalog services become startable

### DIFF
--- a/truffels-agent/allowlists.go
+++ b/truffels-agent/allowlists.go
@@ -294,6 +294,73 @@ func isValidCommitHash(s string) bool {
 
 // --- Filesystem paths ---
 
+// hasCatalogSegment reports whether any path segment starts with "cat-".
+//
+// Catalog directories (compose/cat-<id>, config/cat-<id>, data/cat-<id>)
+// belong exclusively to the catalog handlers: they are generated from the
+// embedded catalog and re-applied on every apply. The legacy path-based
+// endpoints (file/reconcile, ensure-dir, clear-dir) must never write into or
+// clear them — a write would be undone by the next apply, and a clear would
+// delete catalog service data outside the purge_data contract. This is the
+// mirror image of the cat- prefix firewall: that one keeps catalog code out
+// of legacy directories, this one keeps legacy endpoints out of catalog
+// directories.
+func hasCatalogSegment(path string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if strings.HasPrefix(seg, "cat-") {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveSymlinkPath resolves symlinks in the path and returns the real path
+// on the filesystem. This defends against intermediate symlinks that could
+// redirect operations into catalog directories: a compromised container with
+// r/w mount could create dataRoot/mempool/cache → ../cat-digibyted, and a
+// request to clear "mempool/cache" would pass a literal hasCatalogSegment
+// check but reach the catalog directory via the symlink. os.Root follows such
+// intermediate symlinks (they stay within the root), so the guard must check
+// the symlink-resolved path as well as the literal one.
+//
+// The implementation follows the pattern from validateUnderRoot: walk up to
+// the nearest existing ancestor, EvalSymlinks it, then append the remainder.
+// Returns the resolved path, or the original path if resolution fails or the
+// path does not exist.
+func resolveSymlinkPath(path string) string {
+	probe := path
+	// Walk up to the nearest existing ancestor.
+	for {
+		if _, err := os.Stat(probe); err == nil {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe || parent == "/" {
+			// Could not find an existing ancestor; return original path.
+			return path
+		}
+		probe = parent
+	}
+	// Resolve symlinks in the ancestor.
+	resolved, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		// Resolution failed; return original path.
+		return path
+	}
+	if resolved == probe {
+		// No symlink in the ancestor; return original path.
+		return path
+	}
+	// Symlink was resolved. Reconstruct the full path by appending the
+	// remainder (the part that did not exist) to the resolved ancestor.
+	remainder := strings.TrimPrefix(path, probe)
+	if remainder != "" {
+		remainder = strings.TrimPrefix(remainder, string(filepath.Separator))
+		return filepath.Join(resolved, remainder)
+	}
+	return resolved
+}
+
 // validateUnderRoot returns the cleaned absolute path if it lies under `root`,
 // is not a symlink redirecting outside `root`, and contains no relative-path
 // escapes. Returns ("", error) otherwise. The path's parent must exist for

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -69,4 +69,3 @@ func safeConfigKey(name string) error {
 	}
 	return nil
 }
-

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -49,3 +50,23 @@ func renderDigibyteConf(params map[string]any) (map[string][]byte, error) {
 
 	return map[string][]byte{"digibyte.conf": []byte(b.String())}, nil
 }
+
+// safeConfigKey validates that a config file name is a safe bare filename:
+// not empty, equal to its own filepath.Base (no path separators), not "." or
+// "..", and containing no control characters.
+func safeConfigKey(name string) error {
+	if name == "" {
+		return fmt.Errorf("config key must not be empty")
+	}
+	if name != filepath.Base(name) {
+		return fmt.Errorf("config key %q must be a bare filename", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("config key %q is not allowed", name)
+	}
+	if err := rejectsControlChars(name); err != nil {
+		return fmt.Errorf("config key %q: %w", name, err)
+	}
+	return nil
+}
+

--- a/truffels-agent/catalog_derive.go
+++ b/truffels-agent/catalog_derive.go
@@ -23,3 +23,11 @@ func catDataDir(id string) string {
 func catConfigPath(id, file string) string {
 	return configRoot + "/cat-" + id + "/" + file
 }
+
+// catConfigDir returns the directory containing the rendered config files for
+// a catalog entry. Replaces the filepath.Dir(catConfigPath(id,"x")) idiom —
+// a dummy filename as a path idiom in the trust boundary invites wrong copies.
+func catConfigDir(id string) string {
+	return configRoot + "/cat-" + id
+}
+

--- a/truffels-agent/catalog_derive.go
+++ b/truffels-agent/catalog_derive.go
@@ -30,4 +30,3 @@ func catConfigPath(id, file string) string {
 func catConfigDir(id string) string {
 	return configRoot + "/cat-" + id
 }
-

--- a/truffels-agent/catalog_derive_test.go
+++ b/truffels-agent/catalog_derive_test.go
@@ -26,6 +26,9 @@ func TestDerivedNames(t *testing.T) {
 	if got := catConfigPath("digibyted", "digibyte.conf"); got != "/srv/truffels/config/cat-digibyted/digibyte.conf" {
 		t.Errorf("catConfigPath = %q", got)
 	}
+	if got := catConfigDir("digibyted"); got != "/srv/truffels/config/cat-digibyted" {
+		t.Errorf("catConfigDir = %q", got)
+	}
 }
 
 // The firewall: the catalog path must not be able to address a legacy
@@ -41,3 +44,25 @@ func TestCatalogPathsCannotReachLegacyDirs(t *testing.T) {
 		}
 	}
 }
+
+func TestSafeConfigKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"digibyte.conf", false},
+		{"../x", true},
+		{"a/b", true},
+		{"", true},
+		{".", true},
+		{"..", true},
+		{"bad\x00name", true},
+	}
+	for _, tt := range tests {
+		err := safeConfigKey(tt.name)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("safeConfigKey(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+}
+

--- a/truffels-agent/catalog_derive_test.go
+++ b/truffels-agent/catalog_derive_test.go
@@ -65,4 +65,3 @@ func TestSafeConfigKey(t *testing.T) {
 		}
 	}
 }
-

--- a/truffels-agent/catalog_exclusion_test.go
+++ b/truffels-agent/catalog_exclusion_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestHasCatalogSegment(t *testing.T) {
+	yes := []string{
+		"/srv/truffels/compose/cat-digibyted/docker-compose.yml",
+		"/srv/truffels/config/cat-digibyted/digibyte.conf",
+		"cat-digibyted/docker-compose.yml",
+		"/srv/truffels/data/cat-x",
+	}
+	no := []string{
+		"/srv/truffels/compose/bitcoin/docker-compose.yml",
+		"/srv/truffels/data/duplicate-cat-pictures",   // substring, not a segment prefix
+		"/srv/truffels/data/bitcoin/catalog",           // segment does not start with cat-
+		"proxy/Caddyfile",
+	}
+	for _, p := range yes {
+		if !hasCatalogSegment(p) {
+			t.Errorf("hasCatalogSegment(%q) = false, want true", p)
+		}
+	}
+	for _, p := range no {
+		if hasCatalogSegment(p) {
+			t.Errorf("hasCatalogSegment(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestFileReconcileRejectsCatalogPath(t *testing.T) {
+	tmp := t.TempDir()
+	composeRoot, configRoot = tmp+"/compose", tmp+"/config"
+	defer func() {
+		composeRoot, configRoot = "/srv/truffels/compose", "/srv/truffels/config"
+	}()
+	_ = os.MkdirAll(composeRoot+"/cat-digibyted", 0o755)
+
+	rec := httptest.NewRecorder()
+	body := `{"path":"cat-digibyted/docker-compose.yml","expected_content":"pwned"}`
+	handleFileReconcile(rec, httptest.NewRequest(http.MethodPost, "/v1/file/reconcile", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Code = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(composeRoot + "/cat-digibyted/docker-compose.yml"); !os.IsNotExist(err) {
+		t.Fatal("file/reconcile wrote into a catalog directory")
+	}
+}
+
+func TestClearDirRejectsCatalogPath(t *testing.T) {
+	tmp := t.TempDir()
+	dataRoot = tmp + "/data"
+	defer func() { dataRoot = "/srv/truffels/data" }()
+	_ = os.MkdirAll(dataRoot+"/cat-digibyted", 0o755)
+	marker := dataRoot + "/cat-digibyted/keep.dat"
+	_ = os.WriteFile(marker, []byte("x"), 0o644)
+
+	rec := httptest.NewRecorder()
+	body := `{"path":"` + dataRoot + `/cat-digibyted","uid":1000,"gid":1000,"mode":"0755"}`
+	handleClearDir(rec, httptest.NewRequest(http.MethodPost, "/v1/fs/clear-dir", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Code = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatal("clear-dir touched catalog data")
+	}
+}
+
+func TestEnsureDirRejectsCatalogPath(t *testing.T) {
+	tmp := t.TempDir()
+	dataRoot = tmp + "/data"
+	defer func() { dataRoot = "/srv/truffels/data" }()
+	_ = os.MkdirAll(dataRoot, 0o755)
+
+	rec := httptest.NewRecorder()
+	body := `{"path":"` + dataRoot + `/cat-evil","uid":1000,"gid":1000,"mode":"0755"}`
+	handleEnsureDir(rec, httptest.NewRequest(http.MethodPost, "/v1/fs/ensure-dir", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Code = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(dataRoot + "/cat-evil"); !os.IsNotExist(err) {
+		t.Fatal("ensure-dir created a catalog directory")
+	}
+}
+
+func TestClearDirRejectsSymlinkIntoCatalog(t *testing.T) {
+	tmp := t.TempDir()
+	dataRoot = tmp + "/data"
+	defer func() { dataRoot = "/srv/truffels/data" }()
+	_ = os.MkdirAll(dataRoot+"/mempool", 0o755)
+	_ = os.MkdirAll(dataRoot+"/cat-digibyted", 0o755)
+	marker := dataRoot + "/cat-digibyted/keep.dat"
+	_ = os.WriteFile(marker, []byte("x"), 0o644)
+
+	// Create symlink: dataRoot/mempool/cache → ../cat-digibyted
+	_ = os.Symlink("../cat-digibyted", dataRoot+"/mempool/cache")
+
+	rec := httptest.NewRecorder()
+	body := `{"path":"` + dataRoot + `/mempool/cache","uid":1000,"gid":1000,"mode":"0755"}`
+	handleClearDir(rec, httptest.NewRequest(http.MethodPost, "/v1/fs/clear-dir", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Code = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatal("clear-dir followed symlink into catalog directory")
+	}
+}
+
+func TestFileReconcileRejectsSymlinkIntoCatalog(t *testing.T) {
+	tmp := t.TempDir()
+	composeRoot, configRoot = tmp+"/compose", tmp+"/config"
+	defer func() {
+		composeRoot, configRoot = "/srv/truffels/compose", "/srv/truffels/config"
+	}()
+	_ = os.MkdirAll(composeRoot+"/bitcoin", 0o755)
+	_ = os.MkdirAll(composeRoot+"/cat-digibyted", 0o755)
+	catFile := composeRoot + "/cat-digibyted/docker-compose.yml"
+	_ = os.WriteFile(catFile, []byte("original"), 0o644)
+
+	// Create symlink: composeRoot/bitcoin/docker-compose.yml → ../cat-digibyted/docker-compose.yml
+	_ = os.Symlink("../cat-digibyted/docker-compose.yml", composeRoot+"/bitcoin/docker-compose.yml")
+
+	rec := httptest.NewRecorder()
+	body := `{"path":"bitcoin/docker-compose.yml","expected_content":"pwned"}`
+	handleFileReconcile(rec, httptest.NewRequest(http.MethodPost, "/v1/file/reconcile", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Code = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify file was not modified
+	data, _ := os.ReadFile(catFile)
+	if string(data) != "original" {
+		t.Fatal("file/reconcile followed symlink into catalog directory")
+	}
+}

--- a/truffels-agent/catalog_exclusion_test.go
+++ b/truffels-agent/catalog_exclusion_test.go
@@ -17,8 +17,8 @@ func TestHasCatalogSegment(t *testing.T) {
 	}
 	no := []string{
 		"/srv/truffels/compose/bitcoin/docker-compose.yml",
-		"/srv/truffels/data/duplicate-cat-pictures",   // substring, not a segment prefix
-		"/srv/truffels/data/bitcoin/catalog",           // segment does not start with cat-
+		"/srv/truffels/data/duplicate-cat-pictures", // substring, not a segment prefix
+		"/srv/truffels/data/bitcoin/catalog",        // segment does not start with cat-
 		"proxy/Caddyfile",
 	}
 	for _, p := range yes {

--- a/truffels-agent/catalog_load.go
+++ b/truffels-agent/catalog_load.go
@@ -90,4 +90,3 @@ func LoadCatalog() (Catalog, error) {
 	}
 	return cat, nil
 }
-

--- a/truffels-agent/catalog_load.go
+++ b/truffels-agent/catalog_load.go
@@ -32,6 +32,33 @@ func parseEntry(raw []byte) (CatalogEntry, error) {
 	return e, nil
 }
 
+// validateEntry checks fields that parseEntry cannot verify:
+// container names, empty containers, memory limits, and image references.
+func validateEntry(e CatalogEntry) error {
+	if len(e.Containers) == 0 {
+		return fmt.Errorf("entry %q: containers must not be empty", e.ID)
+	}
+	for _, c := range e.Containers {
+		// Container names use the same rule as catalog IDs — intentional.
+		if !catalogIDRe.MatchString(c.Name) {
+			return fmt.Errorf("entry %q: invalid container name %q", e.ID, c.Name)
+		}
+		if c.MemoryLimitMB <= 0 {
+			return fmt.Errorf("entry %q: container %q: memory_limit_mb must be > 0", e.ID, c.Name)
+		}
+	}
+	if e.Image != "" {
+		// managedImageRefChars is defined in allowlists.go (same package).
+		if !hasOnlyChars(e.Image, managedImageRefChars) {
+			return fmt.Errorf("entry %q: image %q contains invalid characters", e.ID, e.Image)
+		}
+	}
+	if e.Build != nil && e.Build.Version == "" {
+		return fmt.Errorf("entry %q: build is set but version is empty", e.ID)
+	}
+	return nil
+}
+
 func LoadCatalog() (Catalog, error) {
 	entries, err := fs.ReadDir(catalogFS, "catalog")
 	if err != nil {
@@ -56,7 +83,11 @@ func LoadCatalog() (Catalog, error) {
 		if _, dup := cat[e.ID]; dup {
 			return nil, fmt.Errorf("duplicate id %q", e.ID)
 		}
+		if err := validateEntry(e); err != nil {
+			return nil, fmt.Errorf("%s: %w", de.Name(), err)
+		}
 		cat[e.ID] = e
 	}
 	return cat, nil
 }
+

--- a/truffels-agent/catalog_load_test.go
+++ b/truffels-agent/catalog_load_test.go
@@ -134,4 +134,3 @@ func TestValidateEntryAcceptsValidDigibyted(t *testing.T) {
 		t.Fatalf("expected valid entry to pass, got: %v", err)
 	}
 }
-

--- a/truffels-agent/catalog_load_test.go
+++ b/truffels-agent/catalog_load_test.go
@@ -44,3 +44,94 @@ func TestLoadCatalogRejectsTrailingData(t *testing.T) {
 		t.Fatal("expected error on trailing data, got nil")
 	}
 }
+
+func TestValidateEntryRejectsEmptyContainers(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[],"resources":{"memory_floor_mb":1}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err == nil {
+		t.Fatal("expected error for empty containers, got nil")
+	}
+}
+
+func TestValidateEntryRejectsInvalidContainerName(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[{"name":"Node!","memory_limit_mb":100}],
+	  "resources":{"memory_floor_mb":1}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err == nil {
+		t.Fatal("expected error for invalid container name 'Node!', got nil")
+	}
+
+	raw2 := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[{"name":"","memory_limit_mb":100}],
+	  "resources":{"memory_floor_mb":1}}`)
+	e2, err := parseEntry(raw2)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e2); err == nil {
+		t.Fatal("expected error for empty container name, got nil")
+	}
+}
+
+func TestValidateEntryRejectsZeroMemoryLimit(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[{"name":"node","memory_limit_mb":0}],
+	  "resources":{"memory_floor_mb":1}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err == nil {
+		t.Fatal("expected error for memory_limit_mb <= 0, got nil")
+	}
+}
+
+func TestValidateEntryRejectsInvalidImageChars(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[{"name":"node","memory_limit_mb":100}],
+	  "image":"bad/image!name","resources":{"memory_floor_mb":1}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err == nil {
+		t.Fatal("expected error for invalid image characters, got nil")
+	}
+}
+
+func TestValidateEntryRejectsBuildWithoutVersion(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"x","display_name":"X","description":"d",
+	  "role":"chain-node","implementation":"y","containers":[{"name":"node","memory_limit_mb":100}],
+	  "build":{"version":""},"resources":{"memory_floor_mb":1}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err == nil {
+		t.Fatal("expected error for build with empty version, got nil")
+	}
+}
+
+func TestValidateEntryAcceptsValidDigibyted(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"id":"digibyted","display_name":"Digibyte","description":"d",
+	  "role":"chain-node","implementation":"digibyte-core","chain":"dgb",
+	  "containers":[{"name":"node","memory_limit_mb":512}],
+	  "image":"registry.example.com/digibyte:1.0",
+	  "resources":{"memory_floor_mb":256}}`)
+	e, err := parseEntry(raw)
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if err := validateEntry(e); err != nil {
+		t.Fatalf("expected valid entry to pass, got: %v", err)
+	}
+}
+

--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -96,4 +96,3 @@ type ResourceSpec struct {
 	MinDiskGB     int `json:"min_disk_gb,omitempty"`
 	MemoryFloorMB int `json:"memory_floor_mb"`
 }
-

--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -37,6 +37,7 @@ type ParamSpec struct {
 	Min         *int     `json:"min,omitempty"`
 	Max         *int     `json:"max,omitempty"`
 	Enum        []string `json:"enum,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
 }
 
 type ContainerSpec struct {
@@ -95,3 +96,4 @@ type ResourceSpec struct {
 	MinDiskGB     int `json:"min_disk_gb,omitempty"`
 	MemoryFloorMB int `json:"memory_floor_mb"`
 }
+

--- a/truffels-agent/catalog_validate.go
+++ b/truffels-agent/catalog_validate.go
@@ -102,6 +102,18 @@ func coerceParam(spec ParamSpec, raw any) (any, error) {
 		if err := rejectsControlChars(s); err != nil {
 			return nil, err
 		}
+		if spec.Pattern != "" {
+			// Patterns are anchored by the catalog author, not implicitly —
+			// a catalog author writes ^…$ themselves; the code does not enforce it
+			// (documented decision so partial matches remain possible where intended).
+			re, err := regexp.Compile(spec.Pattern)
+			if err != nil {
+				return nil, fmt.Errorf("invalid pattern %q: %w", spec.Pattern, err)
+			}
+			if !re.MatchString(s) {
+				return nil, fmt.Errorf("value %q does not match pattern %q", s, spec.Pattern)
+			}
+		}
 		return s, nil
 	case "enum":
 		s, ok := raw.(string)
@@ -118,3 +130,4 @@ func coerceParam(spec ParamSpec, raw any) (any, error) {
 		return nil, fmt.Errorf("unknown type %q", spec.Type)
 	}
 }
+

--- a/truffels-agent/catalog_validate.go
+++ b/truffels-agent/catalog_validate.go
@@ -130,4 +130,3 @@ func coerceParam(spec ParamSpec, raw any) (any, error) {
 		return nil, fmt.Errorf("unknown type %q", spec.Type)
 	}
 }
-

--- a/truffels-agent/catalog_validate_test.go
+++ b/truffels-agent/catalog_validate_test.go
@@ -107,3 +107,66 @@ func TestValidateParamsAcceptsNormalIntegers(t *testing.T) {
 		t.Errorf("expected no error for normal value 42, got %v", err)
 	}
 }
+
+func TestValidateParamsPatternMatch(t *testing.T) {
+	entry := CatalogEntry{
+		ID: "test-pattern",
+		Params: []ParamSpec{
+			{Name: "sig", Type: "string", Pattern: "^[a-z]{1,8}$"},
+		},
+	}
+	if _, err := ValidateParams(entry, map[string]any{"sig": "abc"}); err != nil {
+		t.Errorf("expected no error for 'abc', got %v", err)
+	}
+}
+
+func TestValidateParamsPatternRejectsUppercase(t *testing.T) {
+	entry := CatalogEntry{
+		ID: "test-pattern",
+		Params: []ParamSpec{
+			{Name: "sig", Type: "string", Pattern: "^[a-z]{1,8}$"},
+		},
+	}
+	if _, err := ValidateParams(entry, map[string]any{"sig": "ABC"}); err == nil {
+		t.Error("expected error for 'ABC'")
+	}
+}
+
+func TestValidateParamsPatternRejectsTooLong(t *testing.T) {
+	entry := CatalogEntry{
+		ID: "test-pattern",
+		Params: []ParamSpec{
+			{Name: "sig", Type: "string", Pattern: "^[a-z]{1,8}$"},
+		},
+	}
+	if _, err := ValidateParams(entry, map[string]any{"sig": "toolonghere"}); err == nil {
+		t.Error("expected error for 'toolonghere'")
+	}
+}
+
+func TestValidateParamsInvalidPattern(t *testing.T) {
+	entry := CatalogEntry{
+		ID: "test-pattern",
+		Params: []ParamSpec{
+			{Name: "sig", Type: "string", Pattern: "(["},
+		},
+	}
+	if _, err := ValidateParams(entry, map[string]any{"sig": "abc"}); err == nil {
+		t.Error("expected error for invalid pattern")
+	}
+}
+
+func TestValidateParamsPatternControlCharsFirst(t *testing.T) {
+	entry := CatalogEntry{
+		ID: "test-pattern",
+		Params: []ParamSpec{
+			{Name: "sig", Type: "string", Pattern: "^[a-z]{1,8}$"},
+		},
+	}
+	// "a\nb" contains a control character, so it must fail even though it
+	// would not match the pattern anyway — control char check runs first.
+	if _, err := ValidateParams(entry, map[string]any{"sig": "a\nb"}); err == nil {
+		t.Error("expected error for control char in pattern string")
+	}
+}
+

--- a/truffels-agent/catalog_validate_test.go
+++ b/truffels-agent/catalog_validate_test.go
@@ -169,4 +169,3 @@ func TestValidateParamsPatternControlCharsFirst(t *testing.T) {
 		t.Error("expected error for control char in pattern string")
 	}
 }
-

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -165,4 +165,3 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 	slog.Info("Catalog service removed", "id", req.ID, "purge_data", req.PurgeData)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "purged": req.PurgeData})
 }
-

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -104,6 +104,19 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Spec section 10: compose down BEFORE files disappear. Otherwise a
+	// running catalog container would be orphaned the moment its compose
+	// file is deleted. Only attempted when a compose file actually exists —
+	// a service that was applied but never started must still remove cleanly
+	// on hosts where docker is unavailable to the test environment.
+	composeFile := catComposeDir(req.ID) + "/docker-compose.yml"
+	if _, err := os.Stat(composeFile); err == nil {
+		if err := runCompose(catComposeDir(req.ID), "down"); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "compose down: " + err.Error()})
+			return
+		}
+	}
+
 	if err := os.RemoveAll(catComposeDir(req.ID)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "compose-dir: " + err.Error()})
 		return

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -12,8 +12,28 @@ import (
 // the two constructively impossible.
 var loadedCatalog Catalog
 
+// catalogEntryResponse wraps CatalogEntry with the derived container names.
+// Container name derivation is the agent's responsibility; the API consumes
+// what /v1/catalog reports. One rule, one place.
+type catalogEntryResponse struct {
+	CatalogEntry
+	ContainerNames []string `json:"container_names"`
+}
+
 func handleCatalogGet(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, loadedCatalog)
+	// Convert each CatalogEntry to catalogEntryResponse, computing container_names.
+	response := make(map[string]catalogEntryResponse)
+	for id, entry := range loadedCatalog {
+		names := make([]string, 0, len(entry.Containers))
+		for _, container := range entry.Containers {
+			names = append(names, catContainerName(id, container.Name))
+		}
+		response[id] = catalogEntryResponse{
+			CatalogEntry:   entry,
+			ContainerNames: names,
+		}
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 func handleServiceApply(w http.ResponseWriter, r *http.Request) {

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 )
 
 // loadedCatalog is filled once at startup. The catalog lives only here in the
@@ -63,7 +62,7 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 	}{
 		{catComposeDir(req.ID), 0o755},
 		{catDataDir(req.ID), 0o755},
-		{filepath.Dir(catConfigPath(req.ID, "x")), 0o755},
+		{catConfigDir(req.ID), 0o755},
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d.path, d.mode); err != nil {
@@ -72,6 +71,10 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	for name, content := range configs {
+		if err := safeConfigKey(name); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "config key: " + err.Error()})
+			return
+		}
 		if err := os.WriteFile(catConfigPath(req.ID, name), content, 0o644); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "config: " + err.Error()})
 			return
@@ -125,7 +128,7 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 	// Rendered config files are artifacts derived from the catalog, not user
 	// data: they are removed together with the compose dir. The data dir is
 	// only ever touched when the caller explicitly asks via purge_data.
-	if err := os.RemoveAll(filepath.Dir(catConfigPath(req.ID, "x"))); err != nil {
+	if err := os.RemoveAll(catConfigDir(req.ID)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "config-dir: " + err.Error()})
 		return
 	}
@@ -142,3 +145,4 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 	slog.Info("Catalog service removed", "id", req.ID, "purge_data", req.PurgeData)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "purged": req.PurgeData})
 }
+

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -86,7 +85,7 @@ func TestServiceRemoveKeepsDataByDefault(t *testing.T) {
 	}
 
 	// Create config file that should be removed (it is a rendered artifact)
-	configDir := filepath.Dir(catConfigPath("digibyted", "x"))
+	configDir := catConfigDir("digibyted")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -203,3 +202,4 @@ func TestServiceApplyWritesFiles(t *testing.T) {
 		t.Error("Data path exists but is not a directory")
 	}
 }
+

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -21,12 +21,28 @@ func TestHandleCatalogGet(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("Code = %d", rec.Code)
 	}
-	var got map[string]CatalogEntry
+	var got map[string]catalogEntryResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("Response not decodable: %v", err)
 	}
 	if _, ok := got["digibyted"]; !ok {
 		t.Error("digibyted missing from response")
+	}
+	// Verify that each entry includes container_names derived from catContainerName
+	entry := got["digibyted"]
+	if len(entry.ContainerNames) == 0 {
+		t.Error("digibyted entry has no container_names")
+	}
+	// Check that at least one container name matches the expected pattern
+	found := false
+	for _, cn := range entry.ContainerNames {
+		if cn == "truffels-digibyted-node" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected container name truffels-digibyted-node not found in %v", entry.ContainerNames)
 	}
 }
 

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -218,4 +218,3 @@ func TestServiceApplyWritesFiles(t *testing.T) {
 		t.Error("Data path exists but is not a directory")
 	}
 }
-

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -133,6 +133,23 @@ func TestServiceRemovePurgesOnlyWhenAsked(t *testing.T) {
 	}
 }
 
+func TestServiceRemoveSkipsDownWithoutComposeFile(t *testing.T) {
+	loadedCatalog, _ = LoadCatalog()
+	tmp := t.TempDir()
+	composeRoot, dataRoot, configRoot = tmp+"/compose", tmp+"/data", tmp+"/config"
+	defer func() {
+		composeRoot, dataRoot, configRoot = "/srv/truffels/compose", "/srv/truffels/data", "/srv/truffels/config"
+	}()
+	// No compose directory created — remove must not attempt to call docker.
+	// Returns 200 and removes config/data as usual.
+	rec := httptest.NewRecorder()
+	handleServiceRemove(rec, httptest.NewRequest(http.MethodPost, "/v1/service/remove",
+		bytes.NewBufferString(`{"id":"digibyted","purge_data":false}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Code = %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestServiceApplyWritesFiles(t *testing.T) {
 	loadedCatalog, _ = LoadCatalog()
 	tmp := t.TempDir()

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -2145,6 +2145,11 @@ func handleFileReconcile(w http.ResponseWriter, r *http.Request) {
 		chosenRoot = configRoot
 	}
 
+	if hasCatalogSegment(fullPath) || hasCatalogSegment(resolveSymlinkPath(fullPath)) {
+		writeJSON(w, 403, map[string]string{"error": "catalog directories are managed exclusively via /v1/service/*"})
+		return
+	}
+
 	slog.Info("file reconcile", "path", fullPath)
 
 	root, name, err := anchorUnderRoot(fullPath, chosenRoot)
@@ -2212,6 +2217,11 @@ func handleEnsureDir(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if hasCatalogSegment(cleaned) || hasCatalogSegment(resolveSymlinkPath(cleaned)) {
+		writeJSON(w, 403, map[string]string{"error": "catalog directories are managed exclusively via /v1/service/*"})
+		return
+	}
+
 	root, name, err := anchorUnderRoot(cleaned, dataRoot)
 	if err != nil {
 		writeJSON(w, 403, map[string]string{"error": err.Error()})
@@ -2276,6 +2286,11 @@ func handleClearDir(w http.ResponseWriter, r *http.Request) {
 	cleaned, err := validateUnderRoot(req.Path, dataRoot)
 	if err != nil {
 		writeJSON(w, 403, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if hasCatalogSegment(cleaned) || hasCatalogSegment(resolveSymlinkPath(cleaned)) {
+		writeJSON(w, 403, map[string]string{"error": "catalog directories are managed exclusively via /v1/service/*"})
 		return
 	}
 

--- a/truffels-api/internal/catalog/client.go
+++ b/truffels-api/internal/catalog/client.go
@@ -66,3 +66,17 @@ func (c *Client) Invalidate() {
 	c.cached = nil
 	c.mu.Unlock()
 }
+
+// IDs returns a map of all catalog service IDs. The map keys are the IDs and
+// values are always true for use as a set.
+func (c *Client) IDs() (map[string]bool, error) {
+	all, err := c.All()
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]bool)
+	for id := range all {
+		ids[id] = true
+	}
+	return ids, nil
+}

--- a/truffels-api/internal/catalog/client_test.go
+++ b/truffels-api/internal/catalog/client_test.go
@@ -81,3 +81,36 @@ func TestEntryContainerNamesWithoutFieldNoDerivation(t *testing.T) {
 		t.Errorf("ContainerNames() = %v, expected empty when field not set (no derivation)", got)
 	}
 }
+
+func TestClientIDs(t *testing.T) {
+	// IDs() should return a map with all catalog entry IDs
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"digibyted":{"schema_version":1,"id":"digibyted",
+		  "display_name":"DigiByte Core","description":"d","role":"chain-node",
+		  "implementation":"digibyte-core","chain":"dgb","containers":[],
+		  "resources":{"memory_floor_mb":1024}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ids, err := c.IDs()
+	if err != nil {
+		t.Fatalf("IDs: %v", err)
+	}
+	if !ids["digibyted"] {
+		t.Errorf("IDs should contain digibyted, got %v", ids)
+	}
+	if len(ids) != 1 {
+		t.Errorf("IDs() = %d entries, expected 1", len(ids))
+	}
+	// Verify it uses the cache
+	if _, err := c.IDs(); err != nil {
+		t.Fatalf("second IDs: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("Agent was called %d times, expected 1 (cache)", calls)
+	}
+}

--- a/truffels-api/internal/catalog/client_test.go
+++ b/truffels-api/internal/catalog/client_test.go
@@ -44,3 +44,40 @@ func TestClientGetUnknown(t *testing.T) {
 		t.Error("Get returned ok=true for unknown id")
 	}
 }
+
+func TestEntryContainerNamesFromField(t *testing.T) {
+	// Entry with container_names field set should return that field, no derivation.
+	entry := Entry{
+		ID: "test-id",
+		Containers: []struct {
+			Name          string `json:"name"`
+			MemoryLimitMB int    `json:"memory_limit_mb"`
+		}{
+			{Name: "node", MemoryLimitMB: 1024},
+		},
+		ContainerNamesField: []string{"truffels-test-id-node"},
+	}
+	got := entry.ContainerNames()
+	if len(got) != 1 || got[0] != "truffels-test-id-node" {
+		t.Errorf("ContainerNames() = %v, expected [truffels-test-id-node]", got)
+	}
+}
+
+func TestEntryContainerNamesWithoutFieldNoDerivation(t *testing.T) {
+	// Entry without container_names field should return empty/nil, not derived names.
+	// This tests the key change: no more self-derivation in the API.
+	entry := Entry{
+		ID: "test-id",
+		Containers: []struct {
+			Name          string `json:"name"`
+			MemoryLimitMB int    `json:"memory_limit_mb"`
+		}{
+			{Name: "node", MemoryLimitMB: 1024},
+		},
+		ContainerNamesField: nil,
+	}
+	got := entry.ContainerNames()
+	if len(got) != 0 {
+		t.Errorf("ContainerNames() = %v, expected empty when field not set (no derivation)", got)
+	}
+}

--- a/truffels-api/internal/catalog/model.go
+++ b/truffels-api/internal/catalog/model.go
@@ -31,14 +31,14 @@ type Entry struct {
 		MinDiskGB     int `json:"min_disk_gb,omitempty"`
 		MemoryFloorMB int `json:"memory_floor_mb"`
 	} `json:"resources"`
+
+	// ContainerNamesField holds the container names as reported by the agent.
+	// Derivation lives in the agent only; the API consumes what /v1/catalog reports.
+	ContainerNamesField []string `json:"container_names"`
 }
 
-// ContainerNames returns the derived container names. Same rule as in the
-// agent (catalog_derive.go): truffels-<id>-<container>.
+// ContainerNames returns the container names reported by the agent.
+// No derivation happens here — the agent is the source of truth.
 func (e Entry) ContainerNames() []string {
-	out := make([]string, 0, len(e.Containers))
-	for _, c := range e.Containers {
-		out = append(out, "truffels-"+e.ID+"-"+c.Name)
-	}
-	return out
+	return e.ContainerNamesField
 }

--- a/truffels-api/internal/updates/engine.go
+++ b/truffels-api/internal/updates/engine.go
@@ -1421,9 +1421,10 @@ var (
 	catalogIDs   map[string]bool
 )
 
-// SetCatalogIDs will be called at startup once the catalog client is wired into
-// the registry projection (follow-up plan). Until then the map stays empty and
-// IsCatalogService reports false for everything.
+// SetCatalogIDs is called at startup from main.go after the update engine starts,
+// supplying the set of catalog service IDs so that IsCatalogService can route
+// catalog updates correctly (through the agent/catalog API rather than through
+// the legacy update path).
 func SetCatalogIDs(ids map[string]bool) { setCatalogIDs(ids) }
 
 func setCatalogIDs(ids map[string]bool) {

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -8,11 +8,13 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"truffels-api/internal/alerts"
 	"truffels-api/internal/api"
 	"truffels-api/internal/auth"
 	"truffels-api/internal/bitcoin"
+	"truffels-api/internal/catalog"
 	composereconcile "truffels-api/internal/compose"
 	"truffels-api/internal/config"
 	"truffels-api/internal/docker"
@@ -65,6 +67,23 @@ func main() {
 	updateEngine := updates.NewEngine(st, registry, compose)
 	updateEngine.Start()
 	defer updateEngine.Stop()
+
+	// Arm the catalog guards. The agent may still be starting when the API
+	// boots (both restart together on self-update), so retry until the
+	// catalog is served rather than crashing or silently staying unarmed.
+	catalogClient := catalog.NewClient(agentURL)
+	go func() {
+		for {
+			ids, err := catalogClient.IDs()
+			if err == nil {
+				updates.SetCatalogIDs(ids)
+				slog.Info("catalog guards armed", "services", len(ids))
+				return
+			}
+			slog.Warn("catalog not yet available, retrying", "err", err)
+			time.Sleep(10 * time.Second)
+		}
+	}()
 
 	// Compose reconciliation — regenerate compose files from templates on startup.
 	// Reconciler emits critical Alerts on compose-up failures so that a typo


### PR DESCRIPTION
Seven hardening tasks on the catalog foundation (#35). Each closes a
precondition the foundation review flagged as required before any catalog
service can be started.

- **Legacy path endpoints refuse catalog directories.** file/reconcile,
  ensure-dir and clear-dir now reject any path whose literal or
  symlink-resolved form contains a cat- segment. Catalog directories are
  managed exclusively through /v1/service/*; the symlink resolution closes
  an intermediate-symlink bypass a sibling link could otherwise use. This
  is the mirror of the cat- prefix firewall.
- **remove stops containers first.** compose down runs before the compose
  directory is deleted, but only when a compose file exists, so a service
  that was applied but never started still removes cleanly.
- **Catalog entries are validated at load time** — empty container list,
  a container name outside the id charset, non-positive memory, an image
  reference with stray characters, or a build block without a version are
  all startup errors rather than first-use surprises.
- **String parameters may declare a pattern**, checked after the
  control-character guard; an invalid pattern is an error, not a panic.
- **catConfigDir** replaces the filepath.Dir(catConfigPath(id,"x")) idiom,
  and rendered config file names are validated as bare filenames, reusing
  the same control-character check as volume sources.
- **Container names are derived in the agent only.** GET /v1/catalog
  reports container_names; the API drops its own derivation, closing the
  two-lists divergence the spec warns about.
- **The update guards are armed at startup.** main wires the catalog client
  to SetCatalogIDs in a retry goroutine, so ApplyUpdate refuses catalog
  services at runtime, not just in tests.

Both modules: go vet, golangci-lint (repo config, v2.12.2) and the full
suites are clean. The legacy path stays untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA