### PR TITLE
Catalog services as first-class citizens: install flow, registry projection, admission, browser UI

### DIFF
--- a/truffels-api/internal/admission/admission.go
+++ b/truffels-api/internal/admission/admission.go
@@ -1,0 +1,59 @@
+package admission
+
+import "fmt"
+
+// Input holds the data needed to evaluate an admission decision.
+type Input struct {
+	RunningP95MB   []int
+	NewFloorMB     int
+	PhysicalRAMMB  int
+	ReserveMB      int
+	NewMinDiskGB   int
+	FreeDiskGB     int
+	GrowthBufferGB int
+}
+
+// Decision is the result of an admission check.
+type Decision struct {
+	Allowed        bool
+	Reason         string
+	RequiredRAMMB  int
+	UsableRAMMB    int
+	RequiredDiskGB int
+	FreeDiskGB     int
+}
+
+// Check evaluates whether a new container can be admitted based on
+// RAM and disk capacity. It is a pure function with no external
+// dependencies.
+func Check(in Input) Decision {
+	usable := in.PhysicalRAMMB - in.ReserveMB
+	required := in.NewFloorMB
+	for _, v := range in.RunningP95MB {
+		required += v
+	}
+	requiredDisk := in.NewMinDiskGB + in.GrowthBufferGB
+
+	d := Decision{
+		RequiredRAMMB:  required,
+		UsableRAMMB:    usable,
+		RequiredDiskGB: requiredDisk,
+		FreeDiskGB:     in.FreeDiskGB,
+	}
+
+	if required > usable {
+		d.Allowed = false
+		d.Reason = fmt.Sprintf("needs ~%d MB RAM, %d MB usable", required, usable)
+		return d
+	}
+
+	if requiredDisk > in.FreeDiskGB {
+		d.Allowed = false
+		d.Reason = fmt.Sprintf("needs ~%d GB disk, %d GB free", requiredDisk, in.FreeDiskGB)
+		return d
+	}
+
+	d.Allowed = true
+	d.Reason = "ok"
+	return d
+}

--- a/truffels-api/internal/admission/admission_test.go
+++ b/truffels-api/internal/admission/admission_test.go
@@ -1,0 +1,81 @@
+package admission
+
+import "testing"
+
+func TestCheck_Allowed(t *testing.T) {
+	in := Input{
+		RunningP95MB:   []int{100, 200},
+		NewFloorMB:     50,
+		PhysicalRAMMB:  1024,
+		ReserveMB:      128,
+		NewMinDiskGB:   10,
+		FreeDiskGB:     50,
+		GrowthBufferGB: 5,
+	}
+	d := Check(in)
+	if !d.Allowed {
+		t.Fatalf("expected Allowed=true, got false (reason: %s)", d.Reason)
+	}
+	if d.RequiredRAMMB != 350 {
+		t.Errorf("expected RequiredRAMMB=350, got %d", d.RequiredRAMMB)
+	}
+	if d.UsableRAMMB != 896 {
+		t.Errorf("expected UsableRAMMB=896, got %d", d.UsableRAMMB)
+	}
+	if d.RequiredDiskGB != 15 {
+		t.Errorf("expected RequiredDiskGB=15, got %d", d.RequiredDiskGB)
+	}
+	if d.FreeDiskGB != 50 {
+		t.Errorf("expected FreeDiskGB=50, got %d", d.FreeDiskGB)
+	}
+}
+
+func TestCheck_RAMTooLow(t *testing.T) {
+	in := Input{
+		RunningP95MB:   []int{500, 600},
+		NewFloorMB:     100,
+		PhysicalRAMMB:  1024,
+		ReserveMB:      128,
+		NewMinDiskGB:   10,
+		FreeDiskGB:     50,
+		GrowthBufferGB: 5,
+	}
+	d := Check(in)
+	if d.Allowed {
+		t.Fatal("expected Allowed=false, got true")
+	}
+	if d.RequiredRAMMB != 1200 {
+		t.Errorf("expected RequiredRAMMB=1200, got %d", d.RequiredRAMMB)
+	}
+	if d.UsableRAMMB != 896 {
+		t.Errorf("expected UsableRAMMB=896, got %d", d.UsableRAMMB)
+	}
+	if d.Reason == "" {
+		t.Error("expected non-empty Reason")
+	}
+}
+
+func TestCheck_DiskTooLow(t *testing.T) {
+	in := Input{
+		RunningP95MB:   []int{100},
+		NewFloorMB:     50,
+		PhysicalRAMMB:  1024,
+		ReserveMB:      128,
+		NewMinDiskGB:   100,
+		FreeDiskGB:     50,
+		GrowthBufferGB: 10,
+	}
+	d := Check(in)
+	if d.Allowed {
+		t.Fatal("expected Allowed=false, got true")
+	}
+	if d.RequiredDiskGB != 110 {
+		t.Errorf("expected RequiredDiskGB=110, got %d", d.RequiredDiskGB)
+	}
+	if d.FreeDiskGB != 50 {
+		t.Errorf("expected FreeDiskGB=50, got %d", d.FreeDiskGB)
+	}
+	if d.Reason == "" {
+		t.Error("expected non-empty Reason")
+	}
+}

--- a/truffels-api/internal/api/catalog_install.go
+++ b/truffels-api/internal/api/catalog_install.go
@@ -176,7 +176,7 @@ func (s *Server) handleCatalogUninstall(w http.ResponseWriter, r *http.Request) 
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body) // ignore error, optional
 
-	_, ok, err := s.store.GetCatalogInstallation(id)
+	inst, ok, err := s.store.GetCatalogInstallation(id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -185,23 +185,25 @@ func (s *Server) handleCatalogUninstall(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not installed")
 		return
 	}
-
-	if err := s.catalogClient.Remove(id, body.PurgeData); err != nil {
-		writeError(w, http.StatusBadGateway, "agent remove failed: "+err.Error())
-		return
-	}
-
+	// Delete the DB row before asking the agent to remove files. This keeps
+	// symmetry with install (which rolls back on DB failure) and, crucially,
+	// prevents a zombie: if the DB delete fails the service stays fully
+	// installed; if the agent remove fails we roll the DB row back, so the
+	// startup reconcile never revives a service whose files are already gone.
 	if err := s.store.RemoveCatalogInstallation(id); err != nil {
 		writeError(w, http.StatusInternalServerError, "db remove failed: "+err.Error())
 		return
 	}
-
-	if body.PurgeData {
-		_ = s.store.SetServiceEnabled(id, false) // clear services row
+	if err := s.catalogClient.Remove(id, body.PurgeData); err != nil {
+		_ = s.store.AddCatalogInstallation(inst.ID, inst.CatalogID, inst.Params) // rollback
+		writeError(w, http.StatusBadGateway, "agent remove failed: "+err.Error())
+		return
 	}
-
+	if body.PurgeData {
+		_ = s.store.SetServiceEnabled(id, false)
+	}
 	if err := s.registry.Refresh(); err != nil {
-		slog.Warn("registry refresh after catalog change failed", "err", err)
+		slog.Warn("registry refresh after uninstall failed", "err", err)
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/truffels-api/internal/api/catalog_install.go
+++ b/truffels-api/internal/api/catalog_install.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"truffels-api/internal/admission"
+)
+
+func (s *Server) handleGetCatalog(w http.ResponseWriter, r *http.Request) {
+	cat, err := s.catalogClient.All()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	var entries []any
+	for _, e := range cat {
+		entries = append(entries, e)
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+func (s *Server) getAdmissionInput(id string, newFloorMB int, newMinDiskGB int) (admission.Input, error) {
+	usableRAM := 8192
+	freeDiskGB := 999
+	if s.collector != nil {
+		metrics := s.collector.Collect()
+		usableRAM = int(metrics.MemTotalMB)
+		freeDiskGB = 0
+		for _, d := range metrics.Disks {
+			if d.Path == "/srv/truffels" || d.Path == "/" {
+				if freeDiskGB == 0 || int(d.AvailGB) < freeDiskGB {
+					freeDiskGB = int(d.AvailGB)
+				}
+			}
+		}
+		if freeDiskGB == 0 && len(metrics.Disks) > 0 {
+			freeDiskGB = int(metrics.Disks[0].AvailGB)
+		}
+	}
+
+	trend, err := s.store.GetContainerSnapshotsForTrend(time.Now().Add(-24 * time.Hour))
+	if err != nil {
+		return admission.Input{}, fmt.Errorf("snapshots: %w", err)
+	}
+
+	usage := make(map[string][]int)
+	for _, snap := range trend {
+		usage[snap.Container] = append(usage[snap.Container], int(snap.MemUsageMB))
+	}
+
+	var p95s []int
+	for _, vals := range usage {
+		if len(vals) == 0 {
+			continue
+		}
+		sort.Ints(vals)
+		idx := int(float64(len(vals)) * 0.95)
+		if idx >= len(vals) {
+			idx = len(vals) - 1
+		}
+		p95s = append(p95s, vals[idx])
+	}
+
+	growthBuffer := 20
+	if s.btcRPC != nil {
+		if info, err := s.btcRPC.GetBlockchainInfo(); err == nil && info.VerificationProgress < 0.9999 {
+			growthBuffer = 300
+		}
+	}
+
+	return admission.Input{
+		RunningP95MB:   p95s,
+		NewFloorMB:     newFloorMB,
+		PhysicalRAMMB:  usableRAM,
+		ReserveMB:      1500,
+		NewMinDiskGB:   newMinDiskGB,
+		FreeDiskGB:     freeDiskGB,
+		GrowthBufferGB: growthBuffer,
+	}, nil
+}
+
+func (s *Server) handleCatalogAdmission(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	cat, err := s.catalogClient.All()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	entry, ok := cat[id]
+	if !ok {
+		writeError(w, http.StatusNotFound, "unknown catalog id")
+		return
+	}
+
+	in, err := s.getAdmissionInput(id, entry.Resources.MemoryFloorMB, entry.Resources.MinDiskGB)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	dec := admission.Check(in)
+	writeJSON(w, http.StatusOK, dec)
+}
+
+func (s *Server) handleCatalogInstall(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Params map[string]any `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+
+	cat, err := s.catalogClient.All()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	entry, ok := cat[id]
+	if !ok {
+		writeError(w, http.StatusNotFound, "unknown catalog id")
+		return
+	}
+
+	_, ok, err = s.store.GetCatalogInstallation(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if ok {
+		writeError(w, http.StatusConflict, "already installed")
+		return
+	}
+
+	in, err := s.getAdmissionInput(id, entry.Resources.MemoryFloorMB, entry.Resources.MinDiskGB)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	dec := admission.Check(in)
+	if !dec.Allowed {
+		writeError(w, http.StatusConflict, dec.Reason)
+		return
+	}
+
+	if err := s.catalogClient.Apply(id, body.Params); err != nil {
+		writeError(w, http.StatusBadGateway, "agent apply failed: "+err.Error())
+		return
+	}
+
+	if err := s.store.AddCatalogInstallation(id, id, body.Params); err != nil {
+		_ = s.catalogClient.Remove(id, false) // rollback
+		writeError(w, http.StatusInternalServerError, "db save failed: "+err.Error())
+		return
+	}
+
+	if err := s.registry.Refresh(); err != nil {
+		slog.Warn("registry refresh after catalog change failed", "err", err)
+	}
+	s.handleGetService(w, r)
+}
+
+func (s *Server) handleCatalogUninstall(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		PurgeData bool `json:"purge_data"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body) // ignore error, optional
+
+	_, ok, err := s.store.GetCatalogInstallation(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, "not installed")
+		return
+	}
+
+	if err := s.catalogClient.Remove(id, body.PurgeData); err != nil {
+		writeError(w, http.StatusBadGateway, "agent remove failed: "+err.Error())
+		return
+	}
+
+	if err := s.store.RemoveCatalogInstallation(id); err != nil {
+		writeError(w, http.StatusInternalServerError, "db remove failed: "+err.Error())
+		return
+	}
+
+	if body.PurgeData {
+		_ = s.store.SetServiceEnabled(id, false) // clear services row
+	}
+
+	if err := s.registry.Refresh(); err != nil {
+		slog.Warn("registry refresh after catalog change failed", "err", err)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/truffels-api/internal/api/catalog_install_test.go
+++ b/truffels-api/internal/api/catalog_install_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"truffels-api/internal/catalog"
+	"truffels-api/internal/model"
+	"truffels-api/internal/service"
+)
+
+func newCatalogTestServerWithAgent(t *testing.T, agentHandler http.HandlerFunc) *Server {
+	srv, st := newTestServer(t)
+
+	// Mock Agent
+	if agentHandler == nil {
+		agentHandler = func(w http.ResponseWriter, r *http.Request) {}
+	}
+	agent := httptest.NewServer(agentHandler)
+	t.Cleanup(func() { agent.Close() })
+	srv.catalogClient = catalog.NewClient(agent.URL)
+	srv.registry = service.NewRegistry("/srv/truffels/compose", "", "", srv.catalogClient, st)
+
+	srv.collector = nil
+
+	// Pre-fill some snapshots for P95 (requires 2000 MB)
+	_ = st.InsertContainerSnapshots([]model.ContainerSnapshot{
+		{Timestamp: time.Now(), Container: "node", MemUsageMB: 2000},
+	})
+
+	return srv
+}
+
+func TestCatalogInstallFailsUnknownID(t *testing.T) {
+	srv := newCatalogTestServerWithAgent(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/catalog" {
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+	req := authenticatedRequest(t, srv, "POST", "/api/truffels/catalog/unknown/install", `{"params":{}}`)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestCatalogInstallAdmissionFail(t *testing.T) {
+	calledApply := false
+	srv := newCatalogTestServerWithAgent(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/catalog" {
+			_, _ = w.Write([]byte(`{"testd":{"id":"testd","resources":{"memory_floor_mb":8000}}}`)) // Needs 8GB, we have 4GB
+		}
+		if r.URL.Path == "/v1/service/apply" {
+			calledApply = true
+		}
+	})
+
+	req := authenticatedRequest(t, srv, "POST", "/api/truffels/catalog/testd/install", `{"params":{}}`)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	if calledApply {
+		t.Errorf("agent apply should not be called on admission fail")
+	}
+	_, ok, _ := srv.store.GetCatalogInstallation("testd")
+	if ok {
+		t.Errorf("expected no DB entry")
+	}
+}
+
+func TestCatalogInstallSuccess(t *testing.T) {
+	applyCalled := false
+	srv := newCatalogTestServerWithAgent(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/catalog" {
+			_, _ = w.Write([]byte(`{"testd":{"id":"testd","resources":{"memory_floor_mb":100}}}`))
+		}
+		if r.URL.Path == "/v1/service/apply" {
+			applyCalled = true
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	req := authenticatedRequest(t, srv, "POST", "/api/truffels/catalog/testd/install", `{"params":{}}`)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !applyCalled {
+		t.Errorf("agent apply not called")
+	}
+	_, ok, _ := srv.store.GetCatalogInstallation("testd")
+	if !ok {
+		t.Errorf("expected DB entry")
+	}
+}
+
+func TestCatalogUninstall(t *testing.T) {
+	srv := newCatalogTestServerWithAgent(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/service/remove" {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	// uninstall not installed
+	req := authenticatedRequest(t, srv, "POST", "/api/truffels/catalog/testd/uninstall", `{"purge_data":true}`)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+
+	// install then uninstall
+	_ = srv.store.AddCatalogInstallation("testd", "testd", map[string]any{})
+	req = authenticatedRequest(t, srv, "POST", "/api/truffels/catalog/testd/uninstall", `{"purge_data":true}`)
+	w = httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	_, ok, _ := srv.store.GetCatalogInstallation("testd")
+	if ok {
+		t.Errorf("still in db")
+	}
+}

--- a/truffels-api/internal/api/handlers_test.go
+++ b/truffels-api/internal/api/handlers_test.go
@@ -25,10 +25,10 @@ func newTestServer(t *testing.T) (*Server, *store.Store) {
 	}
 	t.Cleanup(func() { _ = st.Close() })
 
-	reg := service.NewRegistry("/srv/truffels/compose", "")
+	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 
-	srv := NewServer(reg, st, nil, nil, a, nil, nil, "test")
+	srv := NewServer(reg, st, nil, nil, a, nil, nil, nil, "test")
 	return srv, st
 }
 

--- a/truffels-api/internal/api/router.go
+++ b/truffels-api/internal/api/router.go
@@ -10,6 +10,7 @@ import (
 
 	"truffels-api/internal/auth"
 	"truffels-api/internal/bitcoin"
+	"truffels-api/internal/catalog"
 	"truffels-api/internal/docker"
 	"truffels-api/internal/metrics"
 	"truffels-api/internal/service"
@@ -18,26 +19,28 @@ import (
 )
 
 type Server struct {
-	registry     *service.Registry
-	store        *store.Store
-	compose      *docker.ComposeClient
-	collector    *metrics.Collector
-	auth         *auth.Auth
-	btcRPC       *bitcoin.Client
-	updateEngine *updates.Engine
-	Version      string
+	registry      *service.Registry
+	store         *store.Store
+	compose       *docker.ComposeClient
+	collector     *metrics.Collector
+	auth          *auth.Auth
+	btcRPC        *bitcoin.Client
+	updateEngine  *updates.Engine
+	catalogClient *catalog.Client
+	Version       string
 }
 
-func NewServer(reg *service.Registry, st *store.Store, comp *docker.ComposeClient, coll *metrics.Collector, a *auth.Auth, btc *bitcoin.Client, ue *updates.Engine, version string) *Server {
+func NewServer(reg *service.Registry, st *store.Store, comp *docker.ComposeClient, coll *metrics.Collector, a *auth.Auth, btc *bitcoin.Client, ue *updates.Engine, cat *catalog.Client, version string) *Server {
 	return &Server{
-		registry:     reg,
-		store:        st,
-		compose:      comp,
-		collector:    coll,
-		auth:         a,
-		btcRPC:       btc,
-		updateEngine: ue,
-		Version:      version,
+		registry:      reg,
+		store:         st,
+		compose:       comp,
+		collector:     coll,
+		auth:          a,
+		btcRPC:        btc,
+		updateEngine:  ue,
+		catalogClient: cat,
+		Version:       version,
 	}
 }
 
@@ -105,6 +108,11 @@ func (s *Server) Router() http.Handler {
 			r.Get("/updates/logs", s.handleUpdateLogs)
 			r.Get("/updates/status", s.handleUpdateStatus)
 			r.Post("/updates/rollback/{id}", s.handleRollbackService)
+
+			r.Get("/catalog", s.handleGetCatalog)
+			r.Post("/catalog/{id}/install", s.handleCatalogInstall)
+			r.Post("/catalog/{id}/uninstall", s.handleCatalogUninstall)
+			r.Get("/catalog/{id}/admission", s.handleCatalogAdmission)
 		})
 	})
 

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -145,14 +145,14 @@ func newTestServerWithAgent(t *testing.T, agentState *mockAgentState) (*Server, 
 	mockSrv := newMockAgent(t, agentState)
 	t.Cleanup(mockSrv.Close)
 
-	reg := service.NewRegistry("/srv/truffels/compose", "")
+	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 	compose := docker.NewComposeClient(mockSrv.URL)
 
 	// Set the global agent inspector to use our mock
 	docker.NewAgentInspector(mockSrv.URL)
 
-	srv := NewServer(reg, st, compose, nil, a, nil, nil, "test")
+	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 
@@ -1423,7 +1423,7 @@ func newTestServerWithCollector(t *testing.T, agentState *mockAgentState, tempMi
 	mockSrv := newMockAgent(t, agentState)
 	t.Cleanup(mockSrv.Close)
 
-	reg := service.NewRegistry("/srv/truffels/compose", "")
+	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 	compose := docker.NewComposeClient(mockSrv.URL)
 	docker.NewAgentInspector(mockSrv.URL)
@@ -1454,7 +1454,7 @@ func newTestServerWithCollector(t *testing.T, agentState *mockAgentState, tempMi
 	_ = os.WriteFile(filepath.Join(procDir, "diskstats"), []byte(""), 0644)
 
 	coll := metrics.NewCollector(procDir, sysDir, diskDir)
-	srv := NewServer(reg, st, compose, coll, a, nil, nil, "test")
+	srv := NewServer(reg, st, compose, coll, a, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 
@@ -1615,12 +1615,12 @@ func newTestServerWithPullAgent(t *testing.T, agentState *mockAgentState, pullOu
 	mockSrv := newMockAgentWithPull(t, agentState, pullOutput)
 	t.Cleanup(mockSrv.Close)
 
-	reg := service.NewRegistry("/srv/truffels/compose", "")
+	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 	compose := docker.NewComposeClient(mockSrv.URL)
 	docker.NewAgentInspector(mockSrv.URL)
 
-	srv := NewServer(reg, st, compose, nil, a, nil, nil, "test")
+	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 

--- a/truffels-api/internal/api/updates_test.go
+++ b/truffels-api/internal/api/updates_test.go
@@ -25,11 +25,11 @@ func newTestServerWithEngine(t *testing.T) (*Server, *store.Store, *updates.Engi
 	}
 	t.Cleanup(func() { _ = st.Close() })
 
-	reg := service.NewRegistry("/srv/truffels/compose", "")
+	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 	eng := updates.NewEngine(st, reg, nil)
 
-	srv := NewServer(reg, st, nil, nil, a, nil, eng, "test")
+	srv := NewServer(reg, st, nil, nil, a, nil, eng, nil, "test")
 	return srv, st, eng
 }
 

--- a/truffels-api/internal/catalog/client.go
+++ b/truffels-api/internal/catalog/client.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -79,4 +80,44 @@ func (c *Client) IDs() (map[string]bool, error) {
 		ids[id] = true
 	}
 	return ids, nil
+}
+
+func (c *Client) Apply(id string, params map[string]any) error {
+	type req struct {
+		ID     string         `json:"id"`
+		Params map[string]any `json:"params"`
+	}
+	body, err := json.Marshal(req{ID: id, Params: params})
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Post(c.agentURL+"/v1/service/apply", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("agent apply status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) Remove(id string, purgeData bool) error {
+	type req struct {
+		ID        string `json:"id"`
+		PurgeData bool   `json:"purge_data"`
+	}
+	body, err := json.Marshal(req{ID: id, PurgeData: purgeData})
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Post(c.agentURL+"/v1/service/remove", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("agent remove status %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/truffels-api/internal/service/catalog_adapter.go
+++ b/truffels-api/internal/service/catalog_adapter.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"strconv"
+
+	"truffels-api/internal/catalog"
+	"truffels-api/internal/model"
+)
+
+// CatalogEntryToTemplate projects an installed catalog entry onto the
+// ServiceTemplate the rest of the control plane already understands, so the
+// existing lifecycle handlers work for catalog services unchanged.
+//
+// UpdateSource is deliberately nil: the update path for catalog services is
+// separate (spec 8.1), and the update guards already refuse the legacy path
+// for these ids.
+func CatalogEntryToTemplate(e catalog.Entry, composeRoot, dataRoot string) model.ServiceTemplate {
+	dataDir := dataRoot + "/cat-" + e.ID
+	tmpl := model.ServiceTemplate{
+		ID:             e.ID,
+		DisplayName:    e.DisplayName,
+		Description:    e.Description,
+		ComposeDir:     composeRoot + "/cat-" + e.ID,
+		ContainerNames: e.ContainerNames(),
+		UpdateSource:   nil,
+		DataDirs: []model.DataDir{{
+			Path:      dataDir,
+			Label:     e.DisplayName + " data",
+			Clearable: true,
+		}},
+	}
+	if len(e.Containers) > 0 {
+		// memory limit string form matches the compose templates ("2048M")
+		if mb := e.Containers[0].MemoryLimitMB; mb > 0 {
+			tmpl.MemoryLimit = strconv.Itoa(mb) + "M"
+		}
+	}
+	return tmpl
+}

--- a/truffels-api/internal/service/catalog_adapter_test.go
+++ b/truffels-api/internal/service/catalog_adapter_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"testing"
+	"truffels-api/internal/catalog"
+)
+
+func TestCatalogEntryToTemplate(t *testing.T) {
+	e := catalog.Entry{
+		ID: "digibyted", DisplayName: "DigiByte Core", Description: "d",
+		Role: "chain-node", Implementation: "digibyte-core", Chain: "dgb",
+		ContainerNamesField: []string{"truffels-digibyted-node"},
+	}
+	e.Containers = append(e.Containers, struct {
+		Name          string `json:"name"`
+		MemoryLimitMB int    `json:"memory_limit_mb"`
+	}{Name: "node", MemoryLimitMB: 2048})
+	e.Resources.MemoryFloorMB = 1024
+
+	tmpl := CatalogEntryToTemplate(e, "/srv/truffels/compose", "/srv/truffels/data")
+	if tmpl.ID != "digibyted" {
+		t.Errorf("ID = %q", tmpl.ID)
+	}
+	if len(tmpl.ContainerNames) != 1 || tmpl.ContainerNames[0] != "truffels-digibyted-node" {
+		t.Errorf("ContainerNames = %v", tmpl.ContainerNames)
+	}
+	if tmpl.ComposeDir != "/srv/truffels/compose/cat-digibyted" {
+		t.Errorf("ComposeDir = %q", tmpl.ComposeDir)
+	}
+	if tmpl.UpdateSource != nil {
+		t.Error("UpdateSource must be nil for catalog services")
+	}
+}

--- a/truffels-api/internal/service/registry.go
+++ b/truffels-api/internal/service/registry.go
@@ -98,8 +98,19 @@ func NewRegistry(composeRoot, dataRoot, gitHubRepo string, catalogSource Catalog
 }
 
 func (r *Registry) Refresh() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	var installations []store.CatalogInstallation
+	var entries map[string]catalog.Entry
+	if r.installSource != nil && r.catalogSource != nil {
+		var err error
+		installations, err = r.installSource.ListCatalogInstallations()
+		if err != nil {
+			return fmt.Errorf("failed to list installations: %w", err)
+		}
+		entries, err = r.catalogSource.All()
+		if err != nil {
+			return fmt.Errorf("failed to get catalog entries: %w", err)
+		}
+	}
 
 	newServices := make(map[string]model.ServiceTemplate, len(r.legacyServices))
 	for k, v := range r.legacyServices {
@@ -107,31 +118,21 @@ func (r *Registry) Refresh() error {
 	}
 	newOrder := make([]string, len(r.legacyOrder))
 	copy(newOrder, r.legacyOrder)
-
-	if r.installSource != nil && r.catalogSource != nil {
-		installations, err := r.installSource.ListCatalogInstallations()
-		if err != nil {
-			return fmt.Errorf("failed to list installations: %w", err)
+	for _, inst := range installations {
+		entry, ok := entries[inst.CatalogID]
+		if !ok {
+			slog.Warn("catalog entry not found for installation", "id", inst.CatalogID)
+			continue
 		}
-		entries, err := r.catalogSource.All()
-		if err != nil {
-			return fmt.Errorf("failed to get catalog entries: %w", err)
-		}
-
-		for _, inst := range installations {
-			entry, ok := entries[inst.CatalogID]
-			if !ok {
-				slog.Warn("catalog entry not found for installation", "id", inst.CatalogID)
-				continue
-			}
-			tmpl := CatalogEntryToTemplate(entry, r.composeRoot, r.dataRoot)
-			newServices[tmpl.ID] = tmpl
-			newOrder = append(newOrder, tmpl.ID)
-		}
+		tmpl := CatalogEntryToTemplate(entry, r.composeRoot, r.dataRoot)
+		newServices[tmpl.ID] = tmpl
+		newOrder = append(newOrder, tmpl.ID)
 	}
 
+	r.mu.Lock()
 	r.services = newServices
 	r.order = newOrder
+	r.mu.Unlock()
 	return nil
 }
 

--- a/truffels-api/internal/service/registry.go
+++ b/truffels-api/internal/service/registry.go
@@ -2,16 +2,38 @@ package service
 
 import (
 	"fmt"
+	"log/slog"
+	"sync"
+	"truffels-api/internal/catalog"
 	"truffels-api/internal/model"
 	"truffels-api/internal/service/templates"
+	"truffels-api/internal/store"
 )
 
-type Registry struct {
-	services map[string]model.ServiceTemplate
-	order    []string // topological order
+type CatalogSource interface {
+	All() (map[string]catalog.Entry, error)
 }
 
-func NewRegistry(composeRoot, gitHubRepo string) *Registry {
+type InstallSource interface {
+	ListCatalogInstallations() ([]store.CatalogInstallation, error)
+}
+
+type Registry struct {
+	mu       sync.RWMutex
+	services map[string]model.ServiceTemplate
+	order    []string // topological order
+
+	composeRoot   string
+	dataRoot      string
+	gitHubRepo    string
+	catalogSource CatalogSource
+	installSource InstallSource
+
+	legacyOrder    []string
+	legacyServices map[string]model.ServiceTemplate
+}
+
+func NewRegistry(composeRoot, dataRoot, gitHubRepo string, catalogSource CatalogSource, installSource InstallSource) *Registry {
 	all := []model.ServiceTemplate{
 		templates.Bitcoind,
 		templates.Electrs,
@@ -25,7 +47,12 @@ func NewRegistry(composeRoot, gitHubRepo string) *Registry {
 	}
 
 	r := &Registry{
-		services: make(map[string]model.ServiceTemplate, len(all)),
+		composeRoot:    composeRoot,
+		dataRoot:       dataRoot,
+		gitHubRepo:     gitHubRepo,
+		catalogSource:  catalogSource,
+		installSource:  installSource,
+		legacyServices: make(map[string]model.ServiceTemplate, len(all)),
 	}
 
 	for _, svc := range all {
@@ -40,34 +67,84 @@ func NewRegistry(composeRoot, gitHubRepo string) *Registry {
 			src.Repo = gitHubRepo
 			svc.UpdateSource = &src
 		}
-		r.services[svc.ID] = svc
+		r.legacyServices[svc.ID] = svc
 	}
 
 	// Fixed topological order for the dependency graph
-	r.order = []string{"bitcoind", "electrs", "ckpool", "mempool-db", "ckstats-db", "mempool", "ckstats", "proxy", "truffels"}
+	r.legacyOrder = []string{"bitcoind", "electrs", "ckpool", "mempool-db", "ckstats-db", "mempool", "ckstats", "proxy", "truffels"}
 
 	// Compute stack containers: all containers sharing the same compose dir
 	byDir := map[string][]string{}
-	for _, svc := range r.services {
+	for _, svc := range r.legacyServices {
 		byDir[svc.ComposeDir] = append(byDir[svc.ComposeDir], svc.ContainerNames...)
 	}
-	for id, svc := range r.services {
+	for id, svc := range r.legacyServices {
 		stack := byDir[svc.ComposeDir]
 		if len(stack) > 1 {
 			svc.StackContainers = stack
-			r.services[id] = svc
+			r.legacyServices[id] = svc
 		}
 	}
+
+	// Initialize the current view with legacy services
+	r.services = make(map[string]model.ServiceTemplate, len(r.legacyServices))
+	for k, v := range r.legacyServices {
+		r.services[k] = v
+	}
+	r.order = make([]string, len(r.legacyOrder))
+	copy(r.order, r.legacyOrder)
 
 	return r
 }
 
+func (r *Registry) Refresh() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	newServices := make(map[string]model.ServiceTemplate, len(r.legacyServices))
+	for k, v := range r.legacyServices {
+		newServices[k] = v
+	}
+	newOrder := make([]string, len(r.legacyOrder))
+	copy(newOrder, r.legacyOrder)
+
+	if r.installSource != nil && r.catalogSource != nil {
+		installations, err := r.installSource.ListCatalogInstallations()
+		if err != nil {
+			return fmt.Errorf("failed to list installations: %w", err)
+		}
+		entries, err := r.catalogSource.All()
+		if err != nil {
+			return fmt.Errorf("failed to get catalog entries: %w", err)
+		}
+
+		for _, inst := range installations {
+			entry, ok := entries[inst.CatalogID]
+			if !ok {
+				slog.Warn("catalog entry not found for installation", "id", inst.CatalogID)
+				continue
+			}
+			tmpl := CatalogEntryToTemplate(entry, r.composeRoot, r.dataRoot)
+			newServices[tmpl.ID] = tmpl
+			newOrder = append(newOrder, tmpl.ID)
+		}
+	}
+
+	r.services = newServices
+	r.order = newOrder
+	return nil
+}
+
 func (r *Registry) Get(id string) (model.ServiceTemplate, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	s, ok := r.services[id]
 	return s, ok
 }
 
 func (r *Registry) All() []model.ServiceTemplate {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	result := make([]model.ServiceTemplate, 0, len(r.order))
 	for _, id := range r.order {
 		result = append(result, r.services[id])
@@ -77,7 +154,10 @@ func (r *Registry) All() []model.ServiceTemplate {
 
 // ValidateDependencies checks that all dependencies of a service are running.
 func (r *Registry) ValidateDependencies(id string, isRunning func(string) bool) error {
+	r.mu.RLock()
 	svc, ok := r.services[id]
+	r.mu.RUnlock()
+
 	if !ok {
 		return fmt.Errorf("unknown service: %s", id)
 	}
@@ -103,6 +183,8 @@ func NewTestRegistry(tmpls []model.ServiceTemplate) *Registry {
 
 // Dependents returns services that depend on the given service.
 func (r *Registry) Dependents(id string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	var deps []string
 	for _, svc := range r.services {
 		for _, d := range svc.Dependencies {

--- a/truffels-api/internal/service/registry_catalog_test.go
+++ b/truffels-api/internal/service/registry_catalog_test.go
@@ -1,0 +1,95 @@
+package service_test
+
+import (
+	"testing"
+	"truffels-api/internal/catalog"
+	"truffels-api/internal/service"
+	"truffels-api/internal/store"
+)
+
+type fakeCatalogSource struct {
+	entries map[string]catalog.Entry
+	err     error
+}
+
+func (f *fakeCatalogSource) All() (map[string]catalog.Entry, error) {
+	return f.entries, f.err
+}
+
+type fakeInstallSource struct {
+	installations []store.CatalogInstallation
+	err           error
+}
+
+func (f *fakeInstallSource) ListCatalogInstallations() ([]store.CatalogInstallation, error) {
+	return f.installations, f.err
+}
+
+func TestRegistry_Refresh(t *testing.T) {
+	catSource := &fakeCatalogSource{
+		entries: map[string]catalog.Entry{
+			"digibyted": {
+				ID:                  "digibyted",
+				DisplayName:         "DigiByte Core",
+				ContainerNamesField: []string{"digibyted"},
+			},
+		},
+	}
+	installSource := &fakeInstallSource{
+		installations: []store.CatalogInstallation{
+			{CatalogID: "digibyted"},
+		},
+	}
+
+	r := service.NewRegistry("/compose", "/data", "repo", catSource, installSource)
+	err := r.Refresh()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// 1. Should have legacy service (e.g., bitcoind)
+	_, ok := r.Get("bitcoind")
+	if !ok {
+		t.Errorf("expected legacy service 'bitcoind' to be present")
+	}
+
+	// 2. Should have projected catalog service
+	svc, ok := r.Get("digibyted")
+	if !ok {
+		t.Fatalf("expected catalog service 'digibyted' to be present")
+	}
+
+	if svc.ID != "digibyted" {
+		t.Errorf("expected ID 'digibyted', got %q", svc.ID)
+	}
+	if svc.ComposeDir != "/compose/cat-digibyted" {
+		t.Errorf("expected ComposeDir '/compose/cat-digibyted', got %q", svc.ComposeDir)
+	}
+
+	// 3. Verify order contains legacy then catalog
+	all := r.All()
+	var foundBitcoind, foundDigibyte int
+	for i, s := range all {
+		if s.ID == "bitcoind" {
+			foundBitcoind = i
+		}
+		if s.ID == "digibyted" {
+			foundDigibyte = i
+		}
+	}
+	if foundBitcoind >= foundDigibyte {
+		t.Errorf("expected bitcoind before digibyted in order, bitcoind=%d, digibyted=%d", foundBitcoind, foundDigibyte)
+	}
+
+	// 4. Test empty installation case
+	installSource.installations = nil
+	err = r.Refresh()
+	if err != nil {
+		t.Fatalf("expected no error on empty install, got %v", err)
+	}
+
+	_, ok = r.Get("digibyted")
+	if ok {
+		t.Errorf("expected 'digibyted' to be removed after refresh with empty installations")
+	}
+}

--- a/truffels-api/internal/service/registry_test.go
+++ b/truffels-api/internal/service/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNewRegistry_AllServices(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	all := r.All()
 	if len(all) != 9 {
 		t.Fatalf("expected 9 services, got %d", len(all))
@@ -14,7 +14,7 @@ func TestNewRegistry_AllServices(t *testing.T) {
 }
 
 func TestRegistry_TopologicalOrder(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	all := r.All()
 	expected := []string{
 		"bitcoind", "electrs", "ckpool", "mempool-db", "ckstats-db",
@@ -28,7 +28,7 @@ func TestRegistry_TopologicalOrder(t *testing.T) {
 }
 
 func TestRegistry_Get_Found(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	svc, ok := r.Get("bitcoind")
 	if !ok {
 		t.Fatal("expected to find bitcoind")
@@ -39,7 +39,7 @@ func TestRegistry_Get_Found(t *testing.T) {
 }
 
 func TestRegistry_Get_NotFound(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	_, ok := r.Get("nonexistent")
 	if ok {
 		t.Fatal("expected not found")
@@ -47,7 +47,7 @@ func TestRegistry_Get_NotFound(t *testing.T) {
 }
 
 func TestRegistry_ComposeDir(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 
 	// bitcoind has explicit ComposeDir "bitcoin"
 	btc, _ := r.Get("bitcoind")
@@ -69,7 +69,7 @@ func TestRegistry_ComposeDir(t *testing.T) {
 }
 
 func TestRegistry_ValidateDependencies_NoDeps(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	err := r.ValidateDependencies("bitcoind", func(string) bool { return false })
 	if err != nil {
 		t.Fatalf("bitcoind has no deps, should pass: %v", err)
@@ -77,7 +77,7 @@ func TestRegistry_ValidateDependencies_NoDeps(t *testing.T) {
 }
 
 func TestRegistry_ValidateDependencies_AllRunning(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	err := r.ValidateDependencies("electrs", func(id string) bool {
 		return id == "bitcoind"
 	})
@@ -87,7 +87,7 @@ func TestRegistry_ValidateDependencies_AllRunning(t *testing.T) {
 }
 
 func TestRegistry_ValidateDependencies_DepNotRunning(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	err := r.ValidateDependencies("electrs", func(string) bool { return false })
 	if err == nil {
 		t.Fatal("expected error when dependency not running")
@@ -95,7 +95,7 @@ func TestRegistry_ValidateDependencies_DepNotRunning(t *testing.T) {
 }
 
 func TestRegistry_ValidateDependencies_MultipleDeps(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	// mempool depends on bitcoind and electrs
 	err := r.ValidateDependencies("mempool", func(id string) bool {
 		return id == "bitcoind" // electrs not running
@@ -111,7 +111,7 @@ func TestRegistry_ValidateDependencies_MultipleDeps(t *testing.T) {
 }
 
 func TestRegistry_ValidateDependencies_UnknownService(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	err := r.ValidateDependencies("nonexistent", func(string) bool { return true })
 	if err == nil {
 		t.Fatal("expected error for unknown service")
@@ -119,7 +119,7 @@ func TestRegistry_ValidateDependencies_UnknownService(t *testing.T) {
 }
 
 func TestRegistry_Dependents(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 
 	// bitcoind should have electrs, ckpool, and mempool as dependents
 	deps := r.Dependents("bitcoind")
@@ -136,7 +136,7 @@ func TestRegistry_Dependents(t *testing.T) {
 }
 
 func TestRegistry_Dependents_NoDependents(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	deps := r.Dependents("truffels")
 	if len(deps) != 0 {
 		t.Fatalf("expected 0 dependents, got %d", len(deps))
@@ -144,7 +144,7 @@ func TestRegistry_Dependents_NoDependents(t *testing.T) {
 }
 
 func TestRegistry_ReadOnlyServices(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 	readOnly := []string{"proxy", "mempool-db", "ckstats-db"}
 	for _, id := range readOnly {
 		svc, ok := r.Get(id)
@@ -166,7 +166,7 @@ func TestRegistry_ReadOnlyServices(t *testing.T) {
 }
 
 func TestRegistry_FloatingTagServices(t *testing.T) {
-	r := NewRegistry("/srv/truffels/compose", "")
+	r := NewRegistry("/srv/truffels/compose", "/srv/truffels/data", "", nil, nil)
 
 	// mempool-db uses a floating tag (mariadb:lts)
 	svc, ok := r.Get("mempool-db")

--- a/truffels-api/internal/store/catalog_installations.go
+++ b/truffels-api/internal/store/catalog_installations.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+type CatalogInstallation struct {
+	ID        string         `json:"id"`
+	CatalogID string         `json:"catalog_id"`
+	Params    map[string]any `json:"params"`
+	CreatedAt string         `json:"created_at"`
+}
+
+func (s *Store) AddCatalogInstallation(id, catalogID string, params map[string]any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal params: %w", err)
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO catalog_installations (id, catalog_id, params) VALUES (?, ?, ?)`,
+		id, catalogID, string(raw))
+	return err
+}
+
+func (s *Store) RemoveCatalogInstallation(id string) error {
+	_, err := s.db.Exec(`DELETE FROM catalog_installations WHERE id = ?`, id)
+	return err
+}
+
+func (s *Store) GetCatalogInstallation(id string) (CatalogInstallation, bool, error) {
+	row := s.db.QueryRow(
+		`SELECT id, catalog_id, params, created_at FROM catalog_installations WHERE id = ?`, id)
+	ci, err := scanCatalogInstallation(row)
+	if err == sql.ErrNoRows {
+		return CatalogInstallation{}, false, nil
+	}
+	if err != nil {
+		return CatalogInstallation{}, false, err
+	}
+	return ci, true, nil
+}
+
+func (s *Store) ListCatalogInstallations() ([]CatalogInstallation, error) {
+	rows, err := s.db.Query(
+		`SELECT id, catalog_id, params, created_at FROM catalog_installations ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []CatalogInstallation
+	for rows.Next() {
+		ci, err := scanCatalogInstallation(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ci)
+	}
+	return out, rows.Err()
+}
+
+type rowScanner interface{ Scan(...any) error }
+
+func scanCatalogInstallation(r rowScanner) (CatalogInstallation, error) {
+	var ci CatalogInstallation
+	var raw string
+	if err := r.Scan(&ci.ID, &ci.CatalogID, &raw, &ci.CreatedAt); err != nil {
+		return ci, err
+	}
+	if err := json.Unmarshal([]byte(raw), &ci.Params); err != nil {
+		return ci, fmt.Errorf("unmarshal params: %w", err)
+	}
+	return ci, nil
+}

--- a/truffels-api/internal/store/catalog_installations_test.go
+++ b/truffels-api/internal/store/catalog_installations_test.go
@@ -1,0 +1,27 @@
+package store
+
+import "testing"
+
+func TestCatalogInstallationRoundtrip(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.AddCatalogInstallation("digibyted", "digibyted", map[string]any{"prune_gb": float64(8)}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, ok, err := s.GetCatalogInstallation("digibyted")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.CatalogID != "digibyted" || got.Params["prune_gb"].(float64) != 8 {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	list, _ := s.ListCatalogInstallations()
+	if len(list) != 1 {
+		t.Errorf("list len = %d, want 1", len(list))
+	}
+	if err := s.RemoveCatalogInstallation("digibyted"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, ok, _ := s.GetCatalogInstallation("digibyted"); ok {
+		t.Error("still present after remove")
+	}
+}

--- a/truffels-api/internal/store/migrations/010_catalog_installations.sql
+++ b/truffels-api/internal/store/migrations/010_catalog_installations.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS catalog_installations (
+    id         TEXT PRIMARY KEY,
+    catalog_id TEXT NOT NULL,
+    params     TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/truffels-api/internal/store/sqlite.go
+++ b/truffels-api/internal/store/sqlite.go
@@ -55,6 +55,7 @@ func (s *Store) migrate() error {
 		"migrations/007_host_io_metrics.sql",
 		"migrations/008_trend_alerts.sql",
 		"migrations/009_dir_size_metrics.sql",
+		"migrations/010_catalog_installations.sql",
 	}
 	for _, m := range migrations {
 		data, err := migrationsFS.ReadFile(m)

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -39,19 +39,28 @@ func main() {
 	}
 	defer st.Close()
 
-	// Service registry
-	registry := service.NewRegistry(cfg.ComposeRoot, cfg.GitHubRepo)
-
-	// Ensure all services exist in DB
-	for _, tmpl := range registry.All() {
-		_ = st.EnsureService(tmpl.ID)
-	}
-
 	// Agent client (Docker operations go through truffels-agent)
 	agentURL := envOr("TRUFFELS_AGENT_URL", "http://truffels-agent:9090")
 	compose := docker.NewComposeClient(agentURL)
 	docker.NewAgentInspector(agentURL)
 	slog.Info("agent configured", "url", agentURL)
+
+	// Catalog client is constructed before the registry: the registry projects
+	// installed catalog services, so it needs the catalog and the installation
+	// list as sources.
+	catalogClient := catalog.NewClient(agentURL)
+
+	// Service registry: legacy templates plus a projection of installed
+	// catalog services.
+	registry := service.NewRegistry(cfg.ComposeRoot, cfg.DataRoot, cfg.GitHubRepo, catalogClient, st)
+	if err := registry.Refresh(); err != nil {
+		slog.Warn("initial registry refresh failed", "err", err)
+	}
+
+	// Ensure all services exist in DB
+	for _, tmpl := range registry.All() {
+		_ = st.EnsureService(tmpl.ID)
+	}
 
 	// Host metrics collector
 	collector := metrics.NewCollector(cfg.HostProc, cfg.HostSys, cfg.DataRoot)
@@ -68,20 +77,38 @@ func main() {
 	updateEngine.Start()
 	defer updateEngine.Stop()
 
-	// Arm the catalog guards. The agent may still be starting when the API
-	// boots (both restart together on self-update), so retry until the
-	// catalog is served rather than crashing or silently staying unarmed.
-	catalogClient := catalog.NewClient(agentURL)
+	// Arm the catalog guards and reconcile installed catalog services. The
+	// agent may still be starting when the API boots (both restart together
+	// on self-update), so retry until the catalog is served.
 	go func() {
 		for {
 			ids, err := catalogClient.IDs()
-			if err == nil {
-				updates.SetCatalogIDs(ids)
-				slog.Info("catalog guards armed", "services", len(ids))
+			if err != nil {
+				slog.Warn("catalog not yet available, retrying", "err", err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			updates.SetCatalogIDs(ids)
+			slog.Info("catalog guards armed", "services", len(ids))
+
+			// Reconcile installed catalog services on startup: re-apply each
+			// idempotently so compose+config exist (covers a DB restore whose
+			// files are missing). Running containers survive on their own via
+			// restart:unless-stopped; this does not force anything to start.
+			installs, err := st.ListCatalogInstallations()
+			if err != nil {
+				slog.Warn("list catalog installations failed", "err", err)
 				return
 			}
-			slog.Warn("catalog not yet available, retrying", "err", err)
-			time.Sleep(10 * time.Second)
+			for _, inst := range installs {
+				if err := catalogClient.Apply(inst.CatalogID, inst.Params); err != nil {
+					slog.Warn("catalog reconcile apply failed", "id", inst.CatalogID, "err", err)
+				}
+			}
+			if err := registry.Refresh(); err != nil {
+				slog.Warn("registry refresh after catalog reconcile failed", "err", err)
+			}
+			return
 		}
 	}()
 
@@ -104,7 +131,7 @@ func main() {
 	btcRPC := initBitcoinRPC(cfg.SecretsRoot)
 
 	// HTTP server
-	srv := api.NewServer(registry, st, compose, collector, authenticator, btcRPC, updateEngine, version)
+	srv := api.NewServer(registry, st, compose, collector, authenticator, btcRPC, updateEngine, catalogClient, version)
 	httpServer := &http.Server{
 		Addr:    cfg.Listen,
 		Handler: srv.Router(),

--- a/truffels-web/.gitignore
+++ b/truffels-web/.gitignore
@@ -1,0 +1,1 @@
+*.tsbuildinfo

--- a/truffels-web/src/App.tsx
+++ b/truffels-web/src/App.tsx
@@ -12,6 +12,7 @@ import MonitoringPage from './pages/MonitoringPage'
 import SettingsPage from './pages/SettingsPage'
 import LoginPage from './pages/LoginPage'
 import SetupPage from './pages/SetupPage'
+import AddServicePage from './pages/AddServicePage'
 
 type AuthState = 'loading' | 'setup' | 'login' | 'authenticated'
 
@@ -75,6 +76,7 @@ export default function App() {
         <Route element={<Layout onLogout={() => setAuthState('login')} />}>
           <Route index element={<DashboardPage />} />
           <Route path="services" element={<ServicesPage />} />
+          <Route path="services/add" element={<AddServicePage />} />
           <Route path="services/:id" element={<ServiceDetailPage />} />
           <Route path="alerts" element={<AlertsPage />} />
           <Route path="updates" element={<UpdatesPage />} />

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -111,6 +111,35 @@ export interface ConfigResponse {
   message?: string
 }
 
+export interface CatalogEntry {
+  id: string
+  display_name: string
+  description: string
+  role: string
+  implementation: string
+  chain: string
+  params?: {
+    name: string
+    type: string
+    default: any
+    min?: number
+    max?: number
+    enum?: string[]
+  }[]
+  container_names: string[]
+  resources: any
+}
+
+export interface AdmissionDecision {
+  allowed: boolean
+  reason: string
+  required_ram_mb: number
+  usable_ram_mb: number
+  required_disk_gb: number
+  free_disk_gb: number
+}
+
+
 export interface BitcoindStats {
   blockchain: {
     chain: string
@@ -470,6 +499,10 @@ async function put<T>(path: string, body?: unknown): Promise<T> {
 
 export const api = {
   dashboard: () => get<Dashboard>('/dashboard'),
+  catalog: () => get<CatalogEntry[]>('/catalog'),
+  catalogAdmission: (id: string) => get<AdmissionDecision>('/catalog/' + id + '/admission'),
+  installCatalog: (id: string, params: Record<string, unknown>) => post<ServiceInstance>('/catalog/' + id + '/install', { params }),
+  uninstallCatalog: (id: string, purge_data: boolean) => post<{ status: string }>('/catalog/' + id + '/uninstall', { purge_data }),
   services: () => get<ServiceInstance[]>('/services'),
   service: (id: string) => get<ServiceInstance>(`/services/${id}`),
   serviceAction: (id: string, action: string) => post<{ status: string }>(`/services/${id}/action`, { action }),

--- a/truffels-web/src/pages/AddServicePage.tsx
+++ b/truffels-web/src/pages/AddServicePage.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, CatalogEntry, AdmissionDecision } from '@/lib/api'
+import { useApi } from '@/hooks/useApi'
+import { Card } from '@/components/Card'
+import ConfirmDialog from '@/components/ConfirmDialog'
+
+export default function AddServicePage() {
+  const navigate = useNavigate()
+  const fetcher = useCallback(() => api.catalog(), [])
+  const { data, error, loading } = useApi(fetcher, 0)
+  
+  const [selectedEntry, setSelectedEntry] = useState<CatalogEntry | null>(null)
+  const [installing, setInstalling] = useState(false)
+  const [formData, setFormData] = useState<Record<string, any>>({})
+  
+  const [admission, setAdmission] = useState<AdmissionDecision | null>(null)
+  const [admissionLoading, setAdmissionLoading] = useState(false)
+
+  useEffect(() => {
+    if (selectedEntry) {
+      setAdmissionLoading(true)
+      api.catalogAdmission(selectedEntry.id)
+        .then(res => setAdmission(res))
+        .catch(err => setAdmission({ allowed: false, reason: err.message, required_ram_mb: 0, usable_ram_mb: 0, required_disk_gb: 0, free_disk_gb: 0 }))
+        .finally(() => setAdmissionLoading(false))
+        
+      const defaults: Record<string, any> = {}
+      if (selectedEntry.params) {
+        selectedEntry.params.forEach(p => defaults[p.name] = p.default)
+      }
+      setFormData(defaults)
+    } else {
+      setAdmission(null)
+    }
+  }, [selectedEntry])
+
+  const handleInstall = async () => {
+    if (!selectedEntry) return
+    setInstalling(true)
+    try {
+      await api.installCatalog(selectedEntry.id, formData)
+      navigate('/services')
+    } catch (e: any) {
+      alert(`Install failed: ${e.message}`)
+      setInstalling(false)
+    }
+  }
+
+  if (loading) return <div className="text-gray-400">Loading...</div>
+  if (error) return <div className="text-red-400">Error: {error}</div>
+  if (!data) return null
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <button onClick={() => navigate('/services')} className="text-gray-400 hover:text-gray-200">&larr;</button>
+        <h1 className="text-2xl font-bold">Add Service</h1>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {data.map(entry => (
+          <Card key={entry.id} className="h-full flex flex-col justify-between">
+            <div>
+              <div className="flex items-start justify-between mb-2">
+                <h3 className="font-semibold text-gray-100">{entry.display_name}</h3>
+              </div>
+              <p className="text-sm text-gray-400 mb-3">{entry.description}</p>
+              <div className="flex flex-wrap gap-2 text-xs mb-4">
+                {entry.role && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.role}</span>}
+                {entry.chain && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.chain}</span>}
+              </div>
+            </div>
+            <button 
+              onClick={() => setSelectedEntry(entry)}
+              className="mt-auto px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded text-sm font-medium transition-colors w-max"
+            >
+              Install...
+            </button>
+          </Card>
+        ))}
+      </div>
+
+      {selectedEntry && (
+        <ConfirmDialog
+          open={true}
+          title={`Install ${selectedEntry.display_name}`}
+          onCancel={() => !installing && setSelectedEntry(null)}
+          onConfirm={handleInstall}
+          confirmLabel={installing ? 'Installing...' : 'Install'}
+          confirmDisabled={installing || (admission && !admission.allowed) || admissionLoading}
+        >
+          <div className="space-y-4">
+            {admissionLoading && <div className="text-sm text-gray-400">Checking requirements...</div>}
+            {admission && !admission.allowed && (
+              <div className="p-3 rounded bg-red-500/20 text-red-400 text-sm">
+                Cannot install: {admission.reason}
+              </div>
+            )}
+            {admission && admission.allowed && (
+              <div className="p-3 rounded bg-green-500/20 text-green-400 text-sm">
+                {admission.reason || 'Requirements met.'}
+              </div>
+            )}
+
+            {selectedEntry.params?.map(p => (
+              <div key={p.name} className="flex flex-col gap-1">
+                <label className="text-sm text-gray-300 font-medium">{p.name}</label>
+                {p.type === 'bool' ? (
+                  <input
+                    type="checkbox"
+                    checked={!!formData[p.name]}
+                    onChange={e => setFormData(f => ({ ...f, [p.name]: e.target.checked }))}
+                    className="w-4 h-4 rounded border-gray-600 bg-surface text-accent focus:ring-accent/50"
+                  />
+                ) : p.enum ? (
+                  <select
+                    value={formData[p.name] || ''}
+                    onChange={e => setFormData(f => ({ ...f, [p.name]: e.target.value }))}
+                    className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
+                  >
+                    {p.enum.map(o => <option key={o} value={o}>{o}</option>)}
+                  </select>
+                ) : p.type === 'int' ? (
+                  <input
+                    type="number"
+                    min={p.min}
+                    max={p.max}
+                    value={formData[p.name] ?? ''}
+                    onChange={e => setFormData(f => ({ ...f, [p.name]: parseInt(e.target.value) || 0 }))}
+                    className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
+                  />
+                ) : (
+                  <input
+                    type="text"
+                    value={formData[p.name] || ''}
+                    onChange={e => setFormData(f => ({ ...f, [p.name]: e.target.value }))}
+                    className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </ConfirmDialog>
+      )}
+    </div>
+  )
+}

--- a/truffels-web/src/pages/ServiceDetailPage.tsx
+++ b/truffels-web/src/pages/ServiceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useNavigate } from 'react-router-dom'
 import {
   AreaChart,
   Area,
@@ -15,6 +15,7 @@ import { canRollback } from '@/lib/updates'
 import { useApi } from '@/hooks/useApi'
 import { Card, CardTitle } from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
+import ConfirmDialog from '@/components/ConfirmDialog'
 import {
   type LogSeverity,
   classifyLine,
@@ -58,18 +59,42 @@ function ActionButton({ label, variant, onClick, disabled }: {
 
 export default function ServiceDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [tab, setTab] = useState<'overview' | 'monitor' | 'logs' | 'config'>('overview')
   const [actionLoading, setActionLoading] = useState(false)
   const [actionMsg, setActionMsg] = useState('')
+
+  const [uninstallOpen, setUninstallOpen] = useState(false)
+  const [purgeData, setPurgeData] = useState(false)
+  const [confirmId, setConfirmId] = useState('')
+  const [uninstallLoading, setUninstallLoading] = useState(false)
+  const [uninstallMsg, setUninstallMsg] = useState('')
 
   const fetcher = useCallback(() => api.service(id!), [id])
   const { data: svc, error, loading, refresh } = useApi(fetcher, 5000)
   const updateFetcher = useCallback(() => api.updateStatus(), [])
   const { data: updateStatus } = useApi(updateFetcher, 30000)
 
+  const catalogFetcher = useCallback(() => api.catalog(), [])
+  const { data: catalog } = useApi(catalogFetcher)
+  const isCatalog = catalog?.some(c => c.id === svc?.template.id)
+
   if (loading) return <div className="text-gray-400">Loading...</div>
   if (error) return <div className="text-red-400">Error: {error}</div>
   if (!svc) return null
+
+  const doUninstall = async () => {
+    setUninstallLoading(true)
+    setUninstallMsg('')
+    try {
+      await api.uninstallCatalog(id!, purgeData)
+      navigate('/services')
+    } catch (e: any) {
+      setUninstallMsg(`Error: ${e.message}`)
+    } finally {
+      setUninstallLoading(false)
+    }
+  }
 
   const doAction = async (action: string) => {
     setActionLoading(true)
@@ -131,8 +156,56 @@ export default function ServiceDetailPage() {
             )}
           </>
         )}
+        {isCatalog && (
+          <button
+            onClick={() => { setUninstallOpen(true); setPurgeData(false); setConfirmId(''); setUninstallMsg('') }}
+            disabled={actionLoading}
+            className="px-3 py-1.5 rounded text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+          >
+            Deinstallieren
+          </button>
+        )}
         {actionMsg && <span className="text-sm text-gray-400 ml-2">{actionMsg}</span>}
       </div>
+
+      <ConfirmDialog
+        open={uninstallOpen}
+        title="Dienst deinstallieren"
+        onCancel={() => !uninstallLoading && setUninstallOpen(false)}
+        onConfirm={doUninstall}
+        confirmLabel={uninstallLoading ? 'Deinstalliere...' : 'Deinstallieren'}
+        confirmDisabled={uninstallLoading || (purgeData && confirmId !== id)}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-300">
+            Soll der Dienst <strong>{svc.template.display_name}</strong> wirklich deinstalliert werden?
+          </p>
+          <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-300">
+            <input
+              type="checkbox"
+              checked={purgeData}
+              onChange={(e) => setPurgeData(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-600 bg-surface text-accent focus:ring-accent/50"
+            />
+            Daten löschen (purge_data)
+          </label>
+          
+          {purgeData && (
+            <div className="flex flex-col gap-1 mt-2">
+              <label className="text-xs text-gray-400">
+                Bitte tippen Sie die ID <span className="font-mono text-gray-200">{id}</span> ein, um das Löschen zu bestätigen:
+              </label>
+              <input
+                type="text"
+                value={confirmId}
+                onChange={(e) => setConfirmId(e.target.value)}
+                className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
+              />
+            </div>
+          )}
+          {uninstallMsg && <div className="text-red-400 text-sm mt-2">{uninstallMsg}</div>}
+        </div>
+      </ConfirmDialog>
 
       {/* Tabs */}
       <div className="flex gap-1 border-b border-border">

--- a/truffels-web/src/pages/ServicesPage.tsx
+++ b/truffels-web/src/pages/ServicesPage.tsx
@@ -48,6 +48,8 @@ export default function ServicesPage() {
   const { data, error, loading } = useApi(fetcher, 10000)
   const settingsFetcher = useCallback(() => api.settings(), [])
   const { data: settings } = useApi(settingsFetcher)
+  const catalogFetcher = useCallback(() => api.catalog(), [])
+  const { data: catalog } = useApi(catalogFetcher)
 
   if (loading) return <div className="text-gray-400">Loading...</div>
   if (error) return <div className="text-red-400">Error: {error}</div>
@@ -55,13 +57,25 @@ export default function ServicesPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">Services</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Services</h1>
+        <Link to="/services/add" className="px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded text-sm font-medium transition-colors">
+          Dienst hinzufügen
+        </Link>
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {data.map((svc) => (
           <Link key={svc.template.id} to={`/services/${svc.template.id}`}>
             <Card className="hover:border-accent/30 transition-colors h-full">
               <div className="flex items-start justify-between mb-2">
-                <h3 className="font-semibold text-gray-100">{svc.template.display_name}</h3>
+                <div className="flex items-center gap-2">
+                  <h3 className="font-semibold text-gray-100">{svc.template.display_name}</h3>
+                  {catalog?.some(c => c.id === svc.template.id) && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400">
+                      Katalog
+                    </span>
+                  )}
+                </div>
                 <div className="flex items-center gap-2">
                   {svc.sync_info?.syncing && (
                     <span className="px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-400">


### PR DESCRIPTION
Makes an installed catalog service a full citizen of the control plane:
installable from the UI, listed and managed like a legacy service,
persistent across restarts, guarded by a resource admission check.

## Backend
- **Store** `catalog_installations` records which catalog services are
  installed and with which parameters.
- **Adapter** projects a `catalog.Entry` onto a `ServiceTemplate`, so the
  entire existing lifecycle (list, status, action, logs, config,
  monitoring) works for catalog services unchanged.
- **Registry** builds the service view as the immutable legacy base plus a
  projection of installed catalog services; `Refresh()` fetches outside
  the lock and swaps the built maps atomically under it.
- **Admission** is a pure function: running-container p95 memory plus the
  new service's floor against physical RAM minus reserve, and disk against
  min-disk plus a growth buffer (300 GB while bitcoind resyncs, else 20).
- **Endpoints** `POST /catalog/{id}/install|uninstall`, `GET
  /catalog/{id}/admission`, `GET /catalog`. install validates, refuses a
  double install, runs admission, applies via the agent, records the
  install, refreshes — with a rollback on a DB failure after apply.
  uninstall deletes the DB row before the agent remove and rolls it back
  on failure, so a failed remove never leaves a zombie the startup
  reconcile would revive.
- **Bootstrap** builds the catalog client before the registry and, after
  arming the update guards, re-applies each installed catalog service
  idempotently (covers a DB restore without files).

## Frontend
- New **Add Service** page renders the catalog and installs an entry
  through a dialog built from its parameter schema, with an inline
  admission preview that blocks the button when resources do not fit.
- Installed catalog services show a badge in the service list and gain an
  uninstall action (with a typed data-purge confirmation) on the detail
  page.

Both Go and web modules pass vet, lint (repo config, v2.12.2), tsc, the
full Go suites and vitest. The legacy path is untouched; chain-awareness
(sync/stats) and the remaining chain catalog entries are follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA