### PR TITLE
Fix: admission Decision json tags so the install dialog works

### DIFF
--- a/truffels-api/internal/admission/admission.go
+++ b/truffels-api/internal/admission/admission.go
@@ -15,12 +15,12 @@ type Input struct {
 
 // Decision is the result of an admission check.
 type Decision struct {
-	Allowed        bool
-	Reason         string
-	RequiredRAMMB  int
-	UsableRAMMB    int
-	RequiredDiskGB int
-	FreeDiskGB     int
+	Allowed        bool   `json:"allowed"`
+	Reason         string `json:"reason"`
+	RequiredRAMMB  int    `json:"required_ram_mb"`
+	UsableRAMMB    int    `json:"usable_ram_mb"`
+	RequiredDiskGB int    `json:"required_disk_gb"`
+	FreeDiskGB     int    `json:"free_disk_gb"`
 }
 
 // Check evaluates whether a new container can be admitted based on

--- a/truffels-api/internal/admission/admission_test.go
+++ b/truffels-api/internal/admission/admission_test.go
@@ -1,6 +1,10 @@
 package admission
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestCheck_Allowed(t *testing.T) {
 	in := Input{
@@ -77,5 +81,20 @@ func TestCheck_DiskTooLow(t *testing.T) {
 	}
 	if d.Reason == "" {
 		t.Error("expected non-empty Reason")
+	}
+}
+
+// The web UI reads these exact snake_case keys; a struct without json tags
+// serialized them as PascalCase, which made the install dialog read
+// `allowed` as undefined and always show "Cannot install". Pin the wire shape.
+func TestDecisionJSONKeys(t *testing.T) {
+	raw, err := json.Marshal(Decision{Allowed: true, Reason: "ok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"allowed"`, `"reason"`, `"required_ram_mb"`, `"usable_ram_mb"`, `"required_disk_gb"`, `"free_disk_gb"`} {
+		if !strings.Contains(string(raw), key) {
+			t.Errorf("admission JSON missing %s: %s", key, raw)
+		}
 	}
 }


### PR DESCRIPTION
The resource-admission `Decision` struct had no json tags, so the API
serialized `Allowed`/`Reason`/... in PascalCase while the web install
dialog reads `allowed`/`reason`/`required_ram_mb`/... The dialog read
`allowed` as undefined and showed "Cannot install" for every service
regardless of the real decision (which, verified on the device, was
`allowed: true`).

One-line fix — json tags on Decision — plus a regression test pinning
the wire keys the frontend depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA