### PR TITLE
Fix: install dialog parameters and add-service UX

### DIFF
--- a/truffels-api/internal/catalog/model.go
+++ b/truffels-api/internal/catalog/model.go
@@ -12,6 +12,18 @@ type Entry struct {
 	Implementation string `json:"implementation"`
 	Chain          string `json:"chain,omitempty"`
 
+	// Params is the install-parameter schema the web dialog builds its form
+	// from. Without it the install dialog renders no fields.
+	Params []struct {
+		Name        string   `json:"name"`
+		Description string   `json:"description,omitempty"`
+		Type        string   `json:"type"`
+		Default     any      `json:"default,omitempty"`
+		Min         *int     `json:"min,omitempty"`
+		Max         *int     `json:"max,omitempty"`
+		Enum        []string `json:"enum,omitempty"`
+	} `json:"params,omitempty"`
+
 	Containers []struct {
 		Name          string `json:"name"`
 		MemoryLimitMB int    `json:"memory_limit_mb"`

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -120,6 +120,7 @@ export interface CatalogEntry {
   chain: string
   params?: {
     name: string
+    description?: string
     type: string
     default: any
     min?: number

--- a/truffels-web/src/pages/AddServicePage.tsx
+++ b/truffels-web/src/pages/AddServicePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { api, CatalogEntry, AdmissionDecision } from '@/lib/api'
 import { useApi } from '@/hooks/useApi'
 import { Card } from '@/components/Card'
@@ -7,13 +7,20 @@ import ConfirmDialog from '@/components/ConfirmDialog'
 
 export default function AddServicePage() {
   const navigate = useNavigate()
-  const fetcher = useCallback(() => api.catalog(), [])
-  const { data, error, loading } = useApi(fetcher, 0)
-  
+  const catalogFetcher = useCallback(() => api.catalog(), [])
+  const { data, error, loading } = useApi(catalogFetcher, 0)
+
+  // The installed services tell us which catalog entries are already present,
+  // so their cards can show "Installed" instead of offering another install.
+  const servicesFetcher = useCallback(() => api.services(), [])
+  const { data: services, refresh: refreshServices } = useApi(servicesFetcher, 0)
+  const installedIds = new Set((services ?? []).map(s => s.template.id))
+
   const [selectedEntry, setSelectedEntry] = useState<CatalogEntry | null>(null)
   const [installing, setInstalling] = useState(false)
-  const [formData, setFormData] = useState<Record<string, any>>({})
-  
+  const [formData, setFormData] = useState<Record<string, unknown>>({})
+  const [installed, setInstalled] = useState<string | null>(null)
+
   const [admission, setAdmission] = useState<AdmissionDecision | null>(null)
   const [admissionLoading, setAdmissionLoading] = useState(false)
 
@@ -24,10 +31,10 @@ export default function AddServicePage() {
         .then(res => setAdmission(res))
         .catch(err => setAdmission({ allowed: false, reason: err.message, required_ram_mb: 0, usable_ram_mb: 0, required_disk_gb: 0, free_disk_gb: 0 }))
         .finally(() => setAdmissionLoading(false))
-        
-      const defaults: Record<string, any> = {}
+
+      const defaults: Record<string, unknown> = {}
       if (selectedEntry.params) {
-        selectedEntry.params.forEach(p => defaults[p.name] = p.default)
+        selectedEntry.params.forEach(p => { defaults[p.name] = p.default })
       }
       setFormData(defaults)
     } else {
@@ -40,9 +47,13 @@ export default function AddServicePage() {
     setInstalling(true)
     try {
       await api.installCatalog(selectedEntry.id, formData)
-      navigate('/services')
-    } catch (e: any) {
-      alert(`Install failed: ${e.message}`)
+      const name = selectedEntry.display_name
+      setSelectedEntry(null)
+      setInstalled(name)
+      refreshServices()
+    } catch (e) {
+      alert(`Install failed: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
       setInstalling(false)
     }
   }
@@ -57,27 +68,42 @@ export default function AddServicePage() {
         <button onClick={() => navigate('/services')} className="text-gray-400 hover:text-gray-200">&larr;</button>
         <h1 className="text-2xl font-bold">Add Service</h1>
       </div>
+
+      {installed && (
+        <div className="p-4 rounded bg-green-500/20 text-green-300 text-sm flex items-center justify-between">
+          <span>{installed} was installed. You can start it from <Link to="/services" className="underline font-medium">Services</Link>.</span>
+          <button onClick={() => setInstalled(null)} className="text-green-400 hover:text-green-200 ml-4">&times;</button>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {data.map(entry => (
-          <Card key={entry.id} className="h-full flex flex-col justify-between">
-            <div>
-              <div className="flex items-start justify-between mb-2">
-                <h3 className="font-semibold text-gray-100">{entry.display_name}</h3>
+        {data.map(entry => {
+          const alreadyInstalled = installedIds.has(entry.id)
+          return (
+            <Card key={entry.id} className="h-full flex flex-col justify-between">
+              <div>
+                <div className="flex items-start justify-between mb-2">
+                  <h3 className="font-semibold text-gray-100">{entry.display_name}</h3>
+                </div>
+                <p className="text-sm text-gray-400 mb-3">{entry.description}</p>
+                <div className="flex flex-wrap gap-2 text-xs mb-4">
+                  {entry.role && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.role}</span>}
+                  {entry.chain && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.chain}</span>}
+                </div>
               </div>
-              <p className="text-sm text-gray-400 mb-3">{entry.description}</p>
-              <div className="flex flex-wrap gap-2 text-xs mb-4">
-                {entry.role && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.role}</span>}
-                {entry.chain && <span className="px-2 py-0.5 rounded bg-surface-overlay text-gray-400">{entry.chain}</span>}
-              </div>
-            </div>
-            <button 
-              onClick={() => setSelectedEntry(entry)}
-              className="mt-auto px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded text-sm font-medium transition-colors w-max"
-            >
-              Install...
-            </button>
-          </Card>
-        ))}
+              {alreadyInstalled ? (
+                <span className="mt-auto px-4 py-2 text-green-400 text-sm font-medium w-max">Installed &#10003;</span>
+              ) : (
+                <button
+                  onClick={() => setSelectedEntry(entry)}
+                  className="mt-auto px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded text-sm font-medium transition-colors w-max"
+                >
+                  Install...
+                </button>
+              )}
+            </Card>
+          )
+        })}
       </div>
 
       {selectedEntry && (
@@ -87,7 +113,7 @@ export default function AddServicePage() {
           onCancel={() => !installing && setSelectedEntry(null)}
           onConfirm={handleInstall}
           confirmLabel={installing ? 'Installing...' : 'Install'}
-          confirmDisabled={installing || (admission && !admission.allowed) || admissionLoading}
+          confirmDisabled={installing || (!!admission && !admission.allowed) || admissionLoading}
         >
           <div className="space-y-4">
             {admissionLoading && <div className="text-sm text-gray-400">Checking requirements...</div>}
@@ -98,13 +124,14 @@ export default function AddServicePage() {
             )}
             {admission && admission.allowed && (
               <div className="p-3 rounded bg-green-500/20 text-green-400 text-sm">
-                {admission.reason || 'Requirements met.'}
+                Fits: needs ~{admission.required_ram_mb} MB RAM ({admission.usable_ram_mb} MB available), {admission.required_disk_gb} GB disk ({admission.free_disk_gb} GB free).
               </div>
             )}
 
             {selectedEntry.params?.map(p => (
               <div key={p.name} className="flex flex-col gap-1">
                 <label className="text-sm text-gray-300 font-medium">{p.name}</label>
+                {p.description && <span className="text-xs text-gray-500">{p.description}</span>}
                 {p.type === 'bool' ? (
                   <input
                     type="checkbox"
@@ -114,7 +141,7 @@ export default function AddServicePage() {
                   />
                 ) : p.enum ? (
                   <select
-                    value={formData[p.name] || ''}
+                    value={String(formData[p.name] ?? '')}
                     onChange={e => setFormData(f => ({ ...f, [p.name]: e.target.value }))}
                     className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
                   >
@@ -125,14 +152,14 @@ export default function AddServicePage() {
                     type="number"
                     min={p.min}
                     max={p.max}
-                    value={formData[p.name] ?? ''}
+                    value={String(formData[p.name] ?? '')}
                     onChange={e => setFormData(f => ({ ...f, [p.name]: parseInt(e.target.value) || 0 }))}
                     className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
                   />
                 ) : (
                   <input
                     type="text"
-                    value={formData[p.name] || ''}
+                    value={String(formData[p.name] ?? '')}
                     onChange={e => setFormData(f => ({ ...f, [p.name]: e.target.value }))}
                     className="bg-surface border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-accent text-gray-200"
                   />


### PR DESCRIPTION
Follow-up to the install dialog going live. Four fixes:

- **The API catalog Entry dropped the `params` schema**, so the install
  dialog rendered no fields — you could not set `prune_gb`. Entry now
  carries params and the dialog builds the form from them.
- The admission box showed the raw reason string `"ok"`; it now shows the
  concrete numbers (RAM/disk needed vs available).
- Already-installed entries show **Installed** instead of offering
  another install (which would 409).
- On success the page shows a message that the service is installed and
  can be started from the Services page, and refreshes in place instead
  of navigating away silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA