### PR TITLE
Fix: own catalog data dirs + run DigiByte as full node

### DIFF
--- a/truffels-agent/catalog/digibyted.json
+++ b/truffels-agent/catalog/digibyted.json
@@ -11,16 +11,6 @@
     "version": "9.26.5",
     "sha256": "6baf0c2673bcd635620108116ad57a2a5dc8e9e3d9380a2d708c070a72508587"
   },
-  "params": [
-    {
-      "name": "prune_gb",
-      "description": "Limit block data to this size. 0 = no pruning.",
-      "type": "int",
-      "default": 0,
-      "min": 0,
-      "max": 2000
-    }
-  ],
   "containers": [
     {
       "name": "node",

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -25,27 +24,22 @@ func RenderConfig(id string, params map[string]any) (map[string][]byte, error) {
 	}
 }
 
-func renderDigibyteConf(params map[string]any) (map[string][]byte, error) {
-	pruneGB, ok := params["prune_gb"].(int)
-	if !ok {
-		return nil, fmt.Errorf("prune_gb is missing or has the wrong type: %T", params["prune_gb"])
-	}
-
+func renderDigibyteConf(_ map[string]any) (map[string][]byte, error) {
 	var b strings.Builder
 	b.WriteString("# Project Truffels — DigiByte Core\n")
 	b.WriteString("# Generated from the catalog. Do not edit by hand.\n")
 	b.WriteString("server=1\n")
 	b.WriteString("printtoconsole=1\n")
 	b.WriteString("disablewallet=1\n")
-	b.WriteString("txindex=0\n")
+	// This build ships DigiDollar compiled in, which refuses to start unless
+	// txindex=1. That also rules out pruning (prune and txindex are mutually
+	// exclusive), so this entry runs as a full node with no prune option.
+	b.WriteString("txindex=1\n")
 	// Without this line getblocktemplate returns a Scrypt template:
 	// src/init.cpp:198 sets miningAlgo = ALGO_SCRYPT, and ckpool does not
 	// send an Algo argument. The failure would be silent — the RPC response
 	// is valid, just worthless for a SHA256d pool. See Spec 2.4.
 	b.WriteString("algo=sha256d\n")
-	if pruneGB > 0 {
-		b.WriteString("prune=" + strconv.Itoa(pruneGB*1024) + "\n")
-	}
 	b.WriteString("zmqpubhashblock=tcp://0.0.0.0:28332\n")
 
 	return map[string][]byte{"digibyte.conf": []byte(b.String())}, nil

--- a/truffels-agent/catalog_config_test.go
+++ b/truffels-agent/catalog_config_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRenderConfigDigibyted(t *testing.T) {
-	files, err := RenderConfig("digibyted", map[string]any{"prune_gb": 0})
+	files, err := RenderConfig("digibyted", map[string]any{})
 	if err != nil {
 		t.Fatalf("RenderConfig: %v", err)
 	}
@@ -20,14 +20,12 @@ func TestRenderConfigDigibyted(t *testing.T) {
 	if !strings.Contains(s, "algo=sha256d") {
 		t.Error("algo=sha256d is missing in digibyte.conf")
 	}
-	if strings.Contains(s, "prune=") {
-		t.Error("prune must not be set when prune_gb=0")
+	// This build's DigiDollar refuses to start without txindex=1.
+	if !strings.Contains(s, "txindex=1") {
+		t.Error("txindex=1 is missing in digibyte.conf")
 	}
-}
-
-func TestRenderConfigSetsPrune(t *testing.T) {
-	files, _ := RenderConfig("digibyted", map[string]any{"prune_gb": 12})
-	if !strings.Contains(string(files["digibyte.conf"]), "prune=12288") {
-		t.Errorf("prune=12288 is missing, got:\n%s", files["digibyte.conf"])
+	// txindex=1 rules out pruning: the entry is a full node, never pruned.
+	if strings.Contains(s, "prune=") {
+		t.Error("prune must never be set (incompatible with txindex=1)")
 	}
 }

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 )
 
 // loadedCatalog is filled once at startup. The catalog lives only here in the
@@ -90,6 +92,21 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// The data dir must be writable by the (typically non-root) user the
+	// container runs as. The agent creates it as root, so hand ownership over.
+	// Config dirs stay root-owned on purpose: config files are mounted read-only.
+	if uid, gid, ok := dataDirOwner(entry); ok {
+		if err := os.Chown(catDataDir(req.ID), uid, gid); err != nil {
+			// The agent runs as root in production, where chown always
+			// succeeds. In a non-root test/dev environment chown to a foreign
+			// uid is EPERM and there is nothing to hand over, so continue.
+			if os.Geteuid() == 0 {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "chown data dir: " + err.Error()})
+				return
+			}
+			slog.Warn("data dir chown skipped (agent not running as root)", "id", req.ID, "err", err)
+		}
+	}
 	for name, content := range configs {
 		if err := safeConfigKey(name); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "config key: " + err.Error()})
@@ -164,4 +181,47 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("Catalog service removed", "id", req.ID, "purge_data", req.PurgeData)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "purged": req.PurgeData})
+}
+
+// dataDirOwner returns the uid/gid that should own the catalog data directory:
+// the numeric user of the container that mounts the data volume. Catalog
+// containers drop all capabilities and run unprivileged, so a root-owned data
+// dir would leave them unable to write. Returns ok=false when no container
+// mounts a data volume or its user is not a numeric uid[:gid].
+func dataDirOwner(e CatalogEntry) (uid, gid int, ok bool) {
+	for _, c := range e.Containers {
+		mountsData := false
+		for _, v := range c.Volumes {
+			if v.Kind == "data" {
+				mountsData = true
+				break
+			}
+		}
+		if mountsData {
+			return parseNumericUser(c.User)
+		}
+	}
+	return 0, 0, false
+}
+
+// parseNumericUser parses a Docker "uid[:gid]" string of numeric ids. A bare
+// "uid" uses that id for the group too, matching how the container resolves it.
+// Empty or non-numeric users yield ok=false rather than an arbitrary owner.
+func parseNumericUser(s string) (uid, gid int, ok bool) {
+	if s == "" {
+		return 0, 0, false
+	}
+	u, g, found := strings.Cut(s, ":")
+	uid, err := strconv.Atoi(u)
+	if err != nil {
+		return 0, 0, false
+	}
+	gid = uid
+	if found {
+		gid, err = strconv.Atoi(g)
+		if err != nil {
+			return 0, 0, false
+		}
+	}
+	return uid, gid, true
 }

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -175,7 +175,7 @@ func TestServiceApplyWritesFiles(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	handleServiceApply(rec, httptest.NewRequest(http.MethodPost, "/v1/service/apply",
-		bytes.NewBufferString(`{"id":"digibyted","params":{"prune_gb":12}}`)))
+		bytes.NewBufferString(`{"id":"digibyted","params":{}}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("Code = %d: %s", rec.Code, rec.Body.String())
 	}
@@ -206,8 +206,8 @@ func TestServiceApplyWritesFiles(t *testing.T) {
 	if !strings.Contains(configContent, "algo=sha256d") {
 		t.Error("Config file does not contain algo=sha256d")
 	}
-	if !strings.Contains(configContent, "prune=12288") {
-		t.Error("Config file does not contain prune=12288 (prune_gb=12 should become 12*1024)")
+	if !strings.Contains(configContent, "txindex=1") {
+		t.Error("Config file does not contain txindex=1 (required by this build's DigiDollar)")
 	}
 
 	// Check (c): data directory exists
@@ -216,5 +216,43 @@ func TestServiceApplyWritesFiles(t *testing.T) {
 		t.Fatalf("Data directory does not exist: %v", err)
 	} else if !stat.IsDir() {
 		t.Error("Data path exists but is not a directory")
+	}
+}
+
+func TestParseNumericUser(t *testing.T) {
+	cases := []struct {
+		in       string
+		uid, gid int
+		ok       bool
+	}{
+		{"1000:1000", 1000, 1000, true},
+		{"1000", 1000, 1000, true}, // bare uid → gid defaults to uid
+		{"0:0", 0, 0, true},
+		{"", 0, 0, false},       // no user set
+		{"nobody", 0, 0, false}, // non-numeric
+		{"1000:grp", 0, 0, false},
+	}
+	for _, c := range cases {
+		uid, gid, ok := parseNumericUser(c.in)
+		if ok != c.ok || (ok && (uid != c.uid || gid != c.gid)) {
+			t.Errorf("parseNumericUser(%q) = (%d,%d,%v), want (%d,%d,%v)", c.in, uid, gid, ok, c.uid, c.gid, c.ok)
+		}
+	}
+}
+
+// The data dir owner is the user of the container that mounts the data volume.
+func TestDataDirOwner(t *testing.T) {
+	e := CatalogEntry{Containers: []ContainerSpec{
+		{Name: "aux", User: "0:0", Volumes: []VolumeSpec{{Kind: "config", File: "x.conf", Mount: "/x"}}},
+		{Name: "node", User: "1000:1000", Volumes: []VolumeSpec{{Kind: "data", Mount: "/data"}}},
+	}}
+	uid, gid, ok := dataDirOwner(e)
+	if !ok || uid != 1000 || gid != 1000 {
+		t.Errorf("dataDirOwner = (%d,%d,%v), want (1000,1000,true)", uid, gid, ok)
+	}
+	// No data volume anywhere → no owner to assign.
+	none := CatalogEntry{Containers: []ContainerSpec{{Name: "x", User: "1000:1000"}}}
+	if _, _, ok := dataDirOwner(none); ok {
+		t.Error("dataDirOwner should be false when no container mounts a data volume")
 	}
 }


### PR DESCRIPTION
Two bugs that surfaced the first time a catalog service actually started (the dev.37 lifecycle fix made that possible, verified on-device with DigiByte Core).

## 1. Catalog data dir ownership
The agent created `catDataDir` as root but never chowned it to the container's user. Catalog containers run unprivileged (digibyted: `1000:1000`) and crash-looped with `Unable to open settings file … for writing`. Now the agent chowns the data dir to the numeric user of the container that mounts it. Fatal only when the agent is root (production); a non-root test/dev agent skips with a warning. Affects **every** catalog service with a non-root user, not just DGB.

## 2. DigiByte full node (txindex=1, no prune)
This DGB build ships DigiDollar, which refuses to start without `txindex=1` — and `txindex` is incompatible with pruning. Config now sets `txindex=1`, drops the prune logic, and the `prune_gb` param is removed (it could only ever produce a node that won't start). Runs as a full node; the DGB chain is small.

## Verification
- Agent `go test ./...` green, `golangci-lint` 0 issues
- On-device end-to-end (dev.37 + these fixes hotfixed): fresh install → `up` builds the image → container healthy → DGB node syncing mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)