### PR TITLE
Catalog stack network (foundation F1)

### DIFF
--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -6,21 +6,25 @@ package main
 // what blockchain it serves. See Spec 4.3 — BCH uses asicseer-pool instead of
 // ckpool; a schema with only `role` would create an entry that doesn't work.
 type CatalogEntry struct {
-	SchemaVersion  int             `json:"schema_version"`
-	ID             string          `json:"id"`
-	DisplayName    string          `json:"display_name"`
-	Description    string          `json:"description"`
-	Role           string          `json:"role"`
-	Implementation string          `json:"implementation"`
-	Chain          string          `json:"chain,omitempty"`
-	Image          string          `json:"image,omitempty"`
-	Build          *BuildSpec      `json:"build,omitempty"`
-	Params         []ParamSpec     `json:"params,omitempty"`
-	Containers     []ContainerSpec `json:"containers"`
-	Requires       []RequireSpec   `json:"requires,omitempty"`
-	Source         *SourceSpec     `json:"source,omitempty"`
-	ChainInfo      *ChainSpec      `json:"chain_info,omitempty"`
-	Resources      ResourceSpec    `json:"resources"`
+	SchemaVersion  int    `json:"schema_version"`
+	ID             string `json:"id"`
+	DisplayName    string `json:"display_name"`
+	Description    string `json:"description"`
+	Role           string `json:"role"`
+	Implementation string `json:"implementation"`
+	Chain          string `json:"chain,omitempty"`
+	// Stack groups entries that must reach each other (node + pool + stats).
+	// All members of a stack join a shared external network in addition to
+	// their own isolated one, so they resolve each other by container name.
+	Stack      string          `json:"stack,omitempty"`
+	Image      string          `json:"image,omitempty"`
+	Build      *BuildSpec      `json:"build,omitempty"`
+	Params     []ParamSpec     `json:"params,omitempty"`
+	Containers []ContainerSpec `json:"containers"`
+	Requires   []RequireSpec   `json:"requires,omitempty"`
+	Source     *SourceSpec     `json:"source,omitempty"`
+	ChainInfo  *ChainSpec      `json:"chain_info,omitempty"`
+	Resources  ResourceSpec    `json:"resources"`
 }
 
 type BuildSpec struct {

--- a/truffels-agent/compose_render.go
+++ b/truffels-agent/compose_render.go
@@ -10,6 +10,9 @@ import (
 
 func catNetworkName(id string) string { return "cat-" + id + "-net" }
 
+// stackNetworkName is the shared external network every member of a stack joins.
+func stackNetworkName(stack string) string { return "cat-stack-" + stack + "-net" }
+
 func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 	if !isValidCatalogID(e.ID) {
 		return nil, fmt.Errorf("invalid id %q", e.ID)
@@ -38,6 +41,18 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 		},
 	}
 
+	// A stacked entry additionally joins the shared external stack network, so
+	// its containers can reach the other stack members by name. The network is
+	// created and torn down by the agent, not compose (External: true).
+	svcNetworks := []string{"chain"}
+	if e.Stack != "" {
+		if !isValidCatalogID(e.Stack) {
+			return nil, fmt.Errorf("invalid stack %q", e.Stack)
+		}
+		cf.Networks["stack"] = composeNetwork{Name: stackNetworkName(e.Stack), External: true}
+		svcNetworks = []string{"chain", "stack"}
+	}
+
 	for _, c := range e.Containers {
 		svc := composeService{
 			Image:         image,
@@ -46,7 +61,7 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 			User:          c.User,
 			SecurityOpt:   []string{"no-new-privileges:true"},
 			CapDrop:       []string{"ALL"},
-			Networks:      []string{"chain"},
+			Networks:      svcNetworks,
 			Entrypoint:    c.Entrypoint,
 			Deploy: composeDeploy{Resources: composeResources{
 				Limits: composeLimits{Memory: strconv.Itoa(c.MemoryLimitMB) + "M"},

--- a/truffels-agent/compose_render_test.go
+++ b/truffels-agent/compose_render_test.go
@@ -200,3 +200,66 @@ func TestRenderComposeImageEntryHasNoBuild(t *testing.T) {
 		t.Errorf("image-only entry emitted a build block: %s", out)
 	}
 }
+
+// A stacked entry joins the shared external stack network in addition to its
+// own, so its containers can reach the other members by name.
+func TestRenderComposeStacked(t *testing.T) {
+	e := CatalogEntry{
+		ID:    "ckpool-dgb",
+		Stack: "dgb",
+		Image: "truffels/ckpool:v1.0.0",
+		Containers: []ContainerSpec{{
+			Name: "pool", User: "1000:1000", MemoryLimitMB: 256,
+		}},
+	}
+	out, err := RenderCompose(e, map[string]any{})
+	if err != nil {
+		t.Fatalf("RenderCompose: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	// service is on both its own network and the stack network
+	nets := doc["services"].(map[string]any)["pool"].(map[string]any)["networks"].([]any)
+	if len(nets) != 2 || nets[0] != "chain" || nets[1] != "stack" {
+		t.Errorf("service networks = %v, want [chain stack]", nets)
+	}
+	// the stack network is declared external with the shared name
+	stackNet := doc["networks"].(map[string]any)["stack"].(map[string]any)
+	if stackNet["name"] != "cat-stack-dgb-net" {
+		t.Errorf("stack network name = %v, want cat-stack-dgb-net", stackNet["name"])
+	}
+	if stackNet["external"] != true {
+		t.Errorf("stack network must be external, got %v", stackNet["external"])
+	}
+}
+
+// An entry with no stack must be unchanged: one network, no external net.
+func TestRenderComposeUnstacked(t *testing.T) {
+	e := CatalogEntry{
+		ID:    "solo",
+		Image: "example/img:1.0",
+		Containers: []ContainerSpec{{
+			Name: "svc", User: "1000:1000", MemoryLimitMB: 128,
+		}},
+	}
+	out, err := RenderCompose(e, map[string]any{})
+	if err != nil {
+		t.Fatalf("RenderCompose: %v", err)
+	}
+	if strings.Contains(string(out), "cat-stack-") || strings.Contains(string(out), `"external"`) {
+		t.Errorf("unstacked entry must not reference a stack network: %s", out)
+	}
+}
+
+// A bad stack name must be rejected before it can reach a docker network name.
+func TestRenderComposeRejectsBadStack(t *testing.T) {
+	for _, bad := range []string{"../x", "DGB", "a b", "cat/../x"} {
+		e := CatalogEntry{ID: "x", Stack: bad, Image: "i:1",
+			Containers: []ContainerSpec{{Name: "c", User: "1000:1000", MemoryLimitMB: 64}}}
+		if _, err := RenderCompose(e, map[string]any{}); err == nil {
+			t.Errorf("stack %q was accepted", bad)
+		}
+	}
+}

--- a/truffels-agent/compose_types.go
+++ b/truffels-agent/compose_types.go
@@ -70,4 +70,8 @@ type composeLimits struct {
 
 type composeNetwork struct {
 	Name string `json:"name"`
+	// External marks a network compose must NOT create or destroy: it is the
+	// shared stack network, whose lifecycle the agent manages (ref-counted
+	// across stack members). Only ever set for the stack network.
+	External bool `json:"external,omitempty"`
 }

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -10,6 +11,34 @@ import (
 	"strings"
 	"time"
 )
+
+// ensureStackNetwork creates the shared external network for a stack if it does
+// not already exist. Idempotent: members install sequentially, and a lost
+// create race is reconciled by re-inspecting.
+func ensureStackNetwork(ctx context.Context, stack string) error {
+	name := stackNetworkName(stack)
+	if _, err := runStdout(ctx, "docker", "network", "inspect", name); err == nil {
+		return nil
+	}
+	if out, err := runCapture(ctx, "docker", "network", "create", name); err != nil {
+		if _, e2 := runStdout(ctx, "docker", "network", "inspect", name); e2 == nil {
+			return nil // someone else created it in the meantime
+		}
+		return fmt.Errorf("create stack network %s: %s: %w", name, strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
+// removeStackNetwork tears the shared network down — best effort. docker refuses
+// to remove a network that still has attached containers, which is exactly the
+// ref-count we want: only the last stack member to leave actually removes it.
+func removeStackNetwork(ctx context.Context, stack string) {
+	name := stackNetworkName(stack)
+	if out, err := runCapture(ctx, "docker", "network", "rm", name); err != nil {
+		slog.Info("stack network kept (still in use or absent)",
+			"stack", stack, "detail", strings.TrimSpace(out))
+	}
+}
 
 // loadedCatalog is filled once at startup. The catalog lives only here in the
 // agent; the API fetches it via this endpoint. This makes a version skew between
@@ -124,6 +153,17 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A stacked entry's compose references the shared external network, so it
+	// must exist before the service is brought up.
+	if entry.Stack != "" {
+		nctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := ensureStackNetwork(nctx, entry.Stack); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "stack network: " + err.Error()})
+			return
+		}
+	}
+
 	slog.Info("Catalog service applied", "id", req.ID)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "id": req.ID})
 }
@@ -141,7 +181,8 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "invalid id"})
 		return
 	}
-	if _, ok := loadedCatalog[req.ID]; !ok {
+	entry, ok := loadedCatalog[req.ID]
+	if !ok {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "unknown catalog entry"})
 		return
 	}
@@ -179,6 +220,14 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		slog.Warn("Catalog data deleted", "id", req.ID, "path", catDataDir(req.ID))
+	}
+
+	// After the container is down and gone, try to drop the shared stack
+	// network. It only actually goes away once the last member has left.
+	if entry.Stack != "" {
+		nctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		removeStackNetwork(nctx, entry.Stack)
 	}
 
 	slog.Info("Catalog service removed", "id", req.ID, "purge_data", req.PurgeData)


### PR DESCRIPTION
First of the catalog-chain-stack foundation PRs. Adds the shared-network capability so a future pool/stats entry can reach a node entry — **no entry uses it yet**, and the running DigiByte node is untouched.

- `CatalogEntry.Stack`: an entry declaring `stack: "<name>"` joins a shared external network `cat-stack-<name>-net` in addition to its own `cat-<id>-net`, resolving other members by container name (same model as legacy `bitcoin-backend`).
- `composeNetwork.External`: typed, bounded allowlist widening — only "join a named bridge network", never `network_mode`/`host`/`privileged`. Struct-as-allowlist preserved.
- Agent creates the shared network on apply (idempotent) and best-effort removes it on remove; docker won't drop a network with attached endpoints, so it ref-counts to the last member.
- Stack name validated with the catalog-id charset before reaching a docker network name.

Part of the DGB mining stack effort (spec local). Next: F2 RPC exposure + shared secret, F3 shared log-volume + deps, then the DGB pool/stats entries.

## Verification
Agent `go test` green, `golangci-lint` 0 issues, gofmt clean. Network create/remove is exercised end-to-end once a stacked entry ships (S1); F1 is unit-tested at the render layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)