### PR TITLE
Catalog stack RPC secret + node RPC exposure (foundation F2)

### DIFF
--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -15,16 +15,16 @@ import (
 // formats of the services are too different for a common abstraction, and a
 // generic renderer would be exactly the place where an escaping problem
 // re-emerges.
-func RenderConfig(id string, params map[string]any) (map[string][]byte, error) {
+func RenderConfig(id string, params map[string]any, creds *stackCreds) (map[string][]byte, error) {
 	switch id {
 	case "digibyted":
-		return renderDigibyteConf(params)
+		return renderDigibyteConf(creds)
 	default:
 		return map[string][]byte{}, nil
 	}
 }
 
-func renderDigibyteConf(_ map[string]any) (map[string][]byte, error) {
+func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	var b strings.Builder
 	b.WriteString("# Project Truffels — DigiByte Core\n")
 	b.WriteString("# Generated from the catalog. Do not edit by hand.\n")
@@ -41,6 +41,19 @@ func renderDigibyteConf(_ map[string]any) (map[string][]byte, error) {
 	// is valid, just worthless for a SHA256d pool. See Spec 2.4.
 	b.WriteString("algo=sha256d\n")
 	b.WriteString("zmqpubhashblock=tcp://0.0.0.0:28332\n")
+
+	// When part of a stack, expose RPC so the pool can reach the node with the
+	// shared credential. rpcallowip uses the broad private ranges the legacy
+	// node uses; actual reachability stays scoped to the shared stack network.
+	// The password is hex from crypto/rand — no config-escaping concern.
+	if creds != nil {
+		b.WriteString("rpcuser=" + creds.User + "\n")
+		b.WriteString("rpcpassword=" + creds.Pass + "\n")
+		b.WriteString("rpcbind=0.0.0.0\n")
+		b.WriteString("rpcallowip=172.16.0.0/12\n")
+		b.WriteString("rpcallowip=10.0.0.0/8\n")
+		b.WriteString("rpcport=14022\n")
+	}
 
 	return map[string][]byte{"digibyte.conf": []byte(b.String())}, nil
 }

--- a/truffels-agent/catalog_config_test.go
+++ b/truffels-agent/catalog_config_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRenderConfigDigibyted(t *testing.T) {
-	files, err := RenderConfig("digibyted", map[string]any{})
+	files, err := RenderConfig("digibyted", map[string]any{}, nil)
 	if err != nil {
 		t.Fatalf("RenderConfig: %v", err)
 	}
@@ -27,5 +27,28 @@ func TestRenderConfigDigibyted(t *testing.T) {
 	// txindex=1 rules out pruning: the entry is a full node, never pruned.
 	if strings.Contains(s, "prune=") {
 		t.Error("prune must never be set (incompatible with txindex=1)")
+	}
+	// Unstacked: no RPC exposure.
+	if strings.Contains(s, "rpcbind") || strings.Contains(s, "rpcuser") {
+		t.Errorf("unstacked node must not expose RPC:\n%s", s)
+	}
+}
+
+// When stacked, the node exposes RPC with the shared credential so the pool
+// can reach it.
+func TestRenderConfigDigibytedStacked(t *testing.T) {
+	creds := &stackCreds{User: "truffels", Pass: "deadbeefcafe"}
+	files, err := RenderConfig("digibyted", map[string]any{}, creds)
+	if err != nil {
+		t.Fatalf("RenderConfig: %v", err)
+	}
+	s := string(files["digibyte.conf"])
+	for _, want := range []string{
+		"rpcuser=truffels", "rpcpassword=deadbeefcafe",
+		"rpcbind=0.0.0.0", "rpcallowip=172.16.0.0/12", "rpcport=14022",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("stacked digibyte.conf missing %q:\n%s", want, s)
+		}
 	}
 }

--- a/truffels-agent/catalog_derive.go
+++ b/truffels-agent/catalog_derive.go
@@ -30,3 +30,16 @@ func catConfigPath(id, file string) string {
 func catConfigDir(id string) string {
 	return configRoot + "/cat-" + id
 }
+
+// catStackSecretDir/Path hold the canonical shared RPC credential for a stack.
+// It lives under the config root (agent-writable; the real secrets mount is
+// read-only) but in a cat-stack-<name> dir that is never mounted into any
+// container — only the specific rendered config files are. The same password
+// is written into the node's and the pool's config, so both authenticate.
+func catStackSecretDir(stack string) string {
+	return configRoot + "/cat-stack-" + stack
+}
+
+func catStackSecretPath(stack string) string {
+	return catStackSecretDir(stack) + "/rpc.env"
+}

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -11,6 +13,60 @@ import (
 	"strings"
 	"time"
 )
+
+// stackCreds is the shared RPC credential every member of a stack uses to reach
+// the node: the node binds its RPC to it, the pool authenticates with it.
+type stackCreds struct {
+	User string
+	Pass string
+}
+
+// ensureStackSecret returns the stack's shared RPC credential, generating and
+// persisting it on first use. Idempotent: a second member of the same stack
+// reads the credential the first one wrote, so node and pool always match.
+func ensureStackSecret(stack string) (*stackCreds, error) {
+	if !isValidCatalogID(stack) {
+		return nil, fmt.Errorf("invalid stack %q", stack)
+	}
+	path := catStackSecretPath(stack)
+	if b, err := os.ReadFile(path); err == nil {
+		return parseStackCreds(b)
+	}
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("generate stack secret: %w", err)
+	}
+	creds := &stackCreds{User: "truffels", Pass: hex.EncodeToString(buf)}
+	if err := os.MkdirAll(catStackSecretDir(stack), 0o750); err != nil {
+		return nil, err
+	}
+	content := "RPC_USER=" + creds.User + "\nRPC_PASS=" + creds.Pass + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o640); err != nil {
+		return nil, err
+	}
+	return creds, nil
+}
+
+// parseStackCreds reads back the RPC_USER / RPC_PASS lines ensureStackSecret wrote.
+func parseStackCreds(b []byte) (*stackCreds, error) {
+	c := &stackCreds{}
+	for _, line := range strings.Split(string(b), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "RPC_USER":
+			c.User = v
+		case "RPC_PASS":
+			c.Pass = v
+		}
+	}
+	if c.User == "" || c.Pass == "" {
+		return nil, fmt.Errorf("stack secret is incomplete")
+	}
+	return c, nil
+}
 
 // ensureStackNetwork creates the shared external network for a stack if it does
 // not already exist. Idempotent: members install sequentially, and a lost
@@ -102,11 +158,6 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	configs, err := RenderConfig(req.ID, params)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
 
 	// From here on we write. Everything before could only reject.
 	dirs := []struct {
@@ -137,6 +188,22 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 			}
 			slog.Warn("data dir chown skipped (agent not running as root)", "id", req.ID, "err", err)
 		}
+	}
+	// A stacked entry shares an RPC credential across its members; the node's
+	// config binds RPC to it. Acquiring it may generate and persist the secret,
+	// so it belongs here in the write section rather than in the reject-only part.
+	var creds *stackCreds
+	if entry.Stack != "" {
+		creds, err = ensureStackSecret(entry.Stack)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "stack secret: " + err.Error()})
+			return
+		}
+	}
+	configs, err := RenderConfig(req.ID, params, creds)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
 	}
 	for name, content := range configs {
 		if err := safeConfigKey(name); err != nil {

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -300,3 +300,29 @@ func TestDigibytedHasSyncProbe(t *testing.T) {
 		t.Errorf("sync probe should end in getblockchaininfo, got %v", e.ChainInfo.SyncProbe)
 	}
 }
+
+// The stack secret must be stable: the second member of a stack reads exactly
+// what the first wrote, so node and pool authenticate with the same credential.
+func TestEnsureStackSecretIsStable(t *testing.T) {
+	tmp := t.TempDir()
+	configRoot = tmp + "/config"
+	defer func() { configRoot = "/srv/truffels/config" }()
+
+	c1, err := ensureStackSecret("dgb")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	c2, err := ensureStackSecret("dgb")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if c1.User != c2.User || c1.Pass != c2.Pass {
+		t.Errorf("secret changed between calls: %+v vs %+v", c1, c2)
+	}
+	if len(c1.Pass) < 32 {
+		t.Errorf("generated pass too short: %q", c1.Pass)
+	}
+	if _, err := ensureStackSecret("../x"); err == nil {
+		t.Error("invalid stack name was accepted")
+	}
+}


### PR DESCRIPTION
Second foundation PR. Adds the shared RPC credential and conditional node RPC exposure. **digibyted is not stacked yet, so its config is unchanged — capability only, node untouched.**

- `ensureStackSecret` generates a per-stack RPC user+password once and persists it at `config/cat-stack-<name>/rpc.env` (agent-writable; the real `secrets/` mount is read-only, and this dir is never mounted into a container). A second stack member reads what the first wrote — node and pool always match.
- `renderDigibyteConf` emits `rpcuser`/`rpcpassword`/`rpcbind`/`rpcallowip`/`rpcport` **only when stacked** (creds passed). `rpcallowip` uses the legacy broad private ranges; the shared stack network scopes actual reachability. Password is hex from crypto/rand.
- `RenderConfig` now takes the stack creds; apply acquires them in the write section (secret generation is a write) before rendering.

Part of the DGB mining stack. Next: F3 shared log-volume + cross-entry deps, then the DGB pool/stats entries (S1) with the single node restart.

## Verification
Agent `go test` green (incl. secret-stability + stacked/unstacked config tests), `golangci-lint` 0 issues, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)