### PR TITLE
Catalog pool-logs volumes + cross-entry deps (foundation F3)

### DIFF
--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -63,10 +63,14 @@ type PortSpec struct {
 // VolumeSpec never names a host path. Kind plus derived root determine it;
 // an entry thus cannot mount `/`.
 type VolumeSpec struct {
-	Kind  string `json:"kind"` // "data" | "config"
+	Kind  string `json:"kind"` // "data" | "config" | "pool-logs"
 	File  string `json:"file,omitempty"`
 	Mount string `json:"mount"`
 	RO    bool   `json:"ro,omitempty"`
+	// From names another catalog entry whose data this volume borrows, used by
+	// kind "pool-logs" so a stats service can read a pool's logs. It is a
+	// catalog id (validated), never a host path.
+	From string `json:"from,omitempty"`
 }
 
 type HealthcheckSpec struct {

--- a/truffels-agent/compose_render.go
+++ b/truffels-agent/compose_render.go
@@ -78,7 +78,9 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 				return nil, err
 			}
 			line := src + ":" + v.Mount
-			if v.RO {
+			// Borrowed pool logs are always read-only: a stats service must
+			// never write into the pool's data.
+			if v.RO || v.Kind == "pool-logs" {
 				line += ":ro"
 			}
 			svc.Volumes = append(svc.Volumes, line)
@@ -110,6 +112,13 @@ func volumeSource(id string, v VolumeSpec) (string, error) {
 	switch v.Kind {
 	case "data":
 		return catDataDir(id), nil
+	case "pool-logs":
+		// A stats service borrows the pool's log directory. From is another
+		// catalog entry's id (validated), so the path is derived, never passed.
+		if !isValidCatalogID(v.From) {
+			return "", fmt.Errorf("pool-logs volume needs a valid from, got %q", v.From)
+		}
+		return catDataDir(v.From) + "/logs", nil
 	case "config":
 		if v.File == "" {
 			return "", fmt.Errorf("volume kind=config without file")

--- a/truffels-agent/compose_render_test.go
+++ b/truffels-agent/compose_render_test.go
@@ -263,3 +263,45 @@ func TestRenderComposeRejectsBadStack(t *testing.T) {
 		}
 	}
 }
+
+// A stats service borrows the pool's logs: the pool's log dir is mounted
+// read-only at the declared target.
+func TestRenderComposePoolLogs(t *testing.T) {
+	e := CatalogEntry{
+		ID:    "ckstats-dgb",
+		Image: "truffels/ckstats:v1.0.0",
+		Containers: []ContainerSpec{{
+			Name: "stats", User: "1000:1000", MemoryLimitMB: 256,
+			Volumes: []VolumeSpec{{Kind: "pool-logs", From: "ckpool-dgb", Mount: "/pool-logs"}},
+		}},
+	}
+	out, err := RenderCompose(e, map[string]any{})
+	if err != nil {
+		t.Fatalf("RenderCompose: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	vols := doc["services"].(map[string]any)["stats"].(map[string]any)["volumes"].([]any)
+	found := false
+	for _, v := range vols {
+		s := v.(string)
+		if strings.Contains(s, "cat-ckpool-dgb/logs") && strings.HasSuffix(s, ":ro") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pool-logs volume missing or not read-only: %v", vols)
+	}
+}
+
+// pool-logs must reject a From that is not a valid catalog id, so it can never
+// point the mount at an arbitrary path.
+func TestVolumeSourcePoolLogsRejectsBadFrom(t *testing.T) {
+	for _, bad := range []string{"", "../x", "Bad"} {
+		if _, err := volumeSource("stats", VolumeSpec{Kind: "pool-logs", From: bad, Mount: "/x"}); err == nil {
+			t.Errorf("bad from %q was accepted", bad)
+		}
+	}
+}

--- a/truffels-api/internal/api/catalog_install.go
+++ b/truffels-api/internal/api/catalog_install.go
@@ -156,6 +156,19 @@ func (s *Server) handleCatalogInstall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Required services must already be installed. registry.Get returns a
+	// catalog service only once it is installed (and legacy services always),
+	// so this refuses e.g. installing ckpool-dgb before digibyted.
+	for _, req := range entry.Requires {
+		if req.ID == "" {
+			continue
+		}
+		if _, present := s.registry.Get(req.ID); !present {
+			writeError(w, http.StatusConflict, "requires "+req.ID+" to be installed first")
+			return
+		}
+	}
+
 	in, err := s.getAdmissionInput(id, entry.Resources.MemoryFloorMB, entry.Resources.MinDiskGB)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/truffels-api/internal/service/catalog_adapter.go
+++ b/truffels-api/internal/service/catalog_adapter.go
@@ -35,5 +35,13 @@ func CatalogEntryToTemplate(e catalog.Entry, composeRoot, dataRoot string) model
 			tmpl.MemoryLimit = strconv.Itoa(mb) + "M"
 		}
 	}
+	// A catalog entry's Requires become ordinary template dependencies, so the
+	// existing "dependency must be running" check in the start handler covers
+	// catalog stacks unchanged (e.g. ckpool-dgb requires digibyted).
+	for _, req := range e.Requires {
+		if req.ID != "" {
+			tmpl.Dependencies = append(tmpl.Dependencies, req.ID)
+		}
+	}
 	return tmpl
 }

--- a/truffels-api/internal/service/catalog_adapter_test.go
+++ b/truffels-api/internal/service/catalog_adapter_test.go
@@ -31,3 +31,18 @@ func TestCatalogEntryToTemplate(t *testing.T) {
 		t.Error("UpdateSource must be nil for catalog services")
 	}
 }
+
+// A catalog entry's Requires must project onto template Dependencies so the
+// existing start-time dependency check enforces stack ordering.
+func TestCatalogEntryToTemplateRequires(t *testing.T) {
+	e := catalog.Entry{ID: "ckpool-dgb", DisplayName: "DGB Pool"}
+	e.Requires = append(e.Requires, struct {
+		Role string `json:"role"`
+		ID   string `json:"id,omitempty"`
+	}{Role: "chain-node", ID: "digibyted"})
+
+	tmpl := CatalogEntryToTemplate(e, "/srv/truffels/compose", "/srv/truffels/data")
+	if len(tmpl.Dependencies) != 1 || tmpl.Dependencies[0] != "digibyted" {
+		t.Errorf("Dependencies = %v, want [digibyted]", tmpl.Dependencies)
+	}
+}


### PR DESCRIPTION
Third and last foundation PR. **No entry uses these yet — capability only, the running DigiByte node is untouched.**

- **Shared log volume:** a container may declare `{kind: pool-logs, from: <entry-id>, mount: ...}`; the generator mounts that entry's log dir (`catDataDir(from)/logs`) **read-only** (always, so stats can never write the pool's data). `from` is a validated catalog id, never a host path. This is how ckstats-dgb will read ckpool-dgb's logs.
- **Cross-entry deps:** a catalog entry's `Requires` now project onto template `Dependencies`, so the existing start-time "dependency must be running" check covers catalog stacks unchanged. Install additionally refuses when a required service is not installed (`registry.Get`), so ckpool-dgb can't be installed before digibyted.

After this: the DGB pool/stats entries (S1) + the one node restart to switch on RPC exposure.

## Verification
Agent + API `go test` green (pool-logs render/reject, Requires→Dependencies), `golangci-lint` 0 issues both modules, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)