### PR TITLE
DigiByte pool (ckpool-dgb) — S1a

### DIFF
--- a/truffels-agent/catalog/ckpool-dgb.json
+++ b/truffels-agent/catalog/ckpool-dgb.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "id": "ckpool-dgb",
+  "display_name": "DigiByte Pool (ckpool)",
+  "description": "ckpool mining pool for DigiByte, connected to the DigiByte Core node over the shared stack network.",
+  "role": "pool",
+  "implementation": "ckpool",
+  "chain": "dgb",
+  "stack": "dgb",
+  "build": {
+    "dockerfile": "dockerfiles/ckpool/Dockerfile",
+    "version": "v1.0.0"
+  },
+  "requires": [{"role": "chain-node", "id": "digibyted"}],
+  "params": [
+    {
+      "name": "dgb_address",
+      "description": "DigiByte payout address (block rewards are paid here).",
+      "type": "string",
+      "pattern": "^(dgb1[a-z0-9]{20,90}|[DS][1-9A-HJ-NP-Za-km-z]{25,40})$"
+    },
+    {
+      "name": "dgb_sig",
+      "description": "Coinbase signature tag included in mined blocks.",
+      "type": "string",
+      "default": "/Truffels/"
+    }
+  ],
+  "containers": [
+    {
+      "name": "pool",
+      "memory_limit_mb": 256,
+      "user": "1000:1000",
+      "entrypoint": ["sh", "-c", "rm -f /tmp/ckpool/main.pid; exec ckpool -B -l 4 -c /etc/ckpool/ckpool.conf"],
+      "ports": [{"container": 3334, "host": 3334, "role": "stratum"}],
+      "volumes": [
+        {"kind": "data", "mount": "/data"},
+        {"kind": "config", "file": "ckpool.conf", "mount": "/etc/ckpool/ckpool.conf", "ro": true}
+      ],
+      "healthcheck": {
+        "test": ["CMD-SHELL", "pidof ckpool || exit 1"],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "20s"
+      }
+    }
+  ],
+  "resources": {"min_disk_gb": 2, "memory_floor_mb": 128}
+}

--- a/truffels-agent/catalog/digibyted.json
+++ b/truffels-agent/catalog/digibyted.json
@@ -6,6 +6,7 @@
   "role": "chain-node",
   "implementation": "digibyte-core",
   "chain": "dgb",
+  "stack": "dgb",
   "build": {
     "dockerfile": "dockerfiles/digibyted/Dockerfile",
     "version": "9.26.5",

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -19,9 +20,61 @@ func RenderConfig(id string, params map[string]any, creds *stackCreds) (map[stri
 	switch id {
 	case "digibyted":
 		return renderDigibyteConf(creds)
+	case "ckpool-dgb":
+		return renderCkpoolDGBConf(params, creds)
 	default:
 		return map[string][]byte{}, nil
 	}
+}
+
+// ckpool.conf is JSON, and two of its values (address, signature) are user
+// params. Building it with encoding/json means a param can never break out of
+// its string — the same structural-safety argument the compose generator makes.
+type ckpoolBtcd struct {
+	URL    string `json:"url"`
+	Auth   string `json:"auth"`
+	Pass   string `json:"pass"`
+	Notify bool   `json:"notify"`
+}
+
+type ckpoolConf struct {
+	Btcd      []ckpoolBtcd `json:"btcd"`
+	ZmqBlock  string       `json:"zmqblock"`
+	BlockPoll int          `json:"blockpoll"`
+	LogDir    string       `json:"logdir"`
+	BtcAddr   string       `json:"btcaddress"`
+	BtcSig    string       `json:"btcsig"`
+	ServerURL []string     `json:"serverurl"`
+	StartDiff int          `json:"startdiff"`
+	MinDiff   int          `json:"mindiff"`
+	MaxDiff   int          `json:"maxdiff"`
+}
+
+func renderCkpoolDGBConf(params map[string]any, creds *stackCreds) (map[string][]byte, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("ckpool-dgb requires stack credentials")
+	}
+	addr, _ := params["dgb_address"].(string)
+	sig, _ := params["dgb_sig"].(string)
+	// The node's container name resolves on the shared stack network.
+	node := catContainerName("digibyted", "node")
+	conf := ckpoolConf{
+		Btcd:      []ckpoolBtcd{{URL: node + ":14022", Auth: creds.User, Pass: creds.Pass, Notify: true}},
+		ZmqBlock:  "tcp://" + node + ":28332",
+		BlockPoll: 100,
+		LogDir:    "/data/logs",
+		BtcAddr:   addr,
+		BtcSig:    sig,
+		ServerURL: []string{"0.0.0.0:3334"},
+		StartDiff: 1,
+		MinDiff:   1,
+		MaxDiff:   0,
+	}
+	b, err := json.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]byte{"ckpool.conf": b}, nil
 }
 
 func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {

--- a/truffels-agent/catalog_config_test.go
+++ b/truffels-agent/catalog_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -50,5 +51,59 @@ func TestRenderConfigDigibytedStacked(t *testing.T) {
 		if !strings.Contains(s, want) {
 			t.Errorf("stacked digibyte.conf missing %q:\n%s", want, s)
 		}
+	}
+}
+
+// The pool config is valid JSON, points at the node by its stack DNS name,
+// carries the shared credential, and includes the payout address/signature.
+func TestRenderCkpoolDGBConf(t *testing.T) {
+	creds := &stackCreds{User: "truffels", Pass: "secretpass"}
+	files, err := RenderConfig("ckpool-dgb", map[string]any{
+		"dgb_address": "dgb1qc4txtrd36vw0hrjz93gvfhd28dvv0uu37rphy6",
+		"dgb_sig":     "/Truffels/",
+	}, creds)
+	if err != nil {
+		t.Fatalf("RenderConfig: %v", err)
+	}
+	raw := files["ckpool.conf"]
+	if raw == nil {
+		t.Fatal("ckpool.conf missing")
+	}
+	var conf map[string]any
+	if err := json.Unmarshal(raw, &conf); err != nil {
+		t.Fatalf("ckpool.conf is not valid JSON: %v", err)
+	}
+	s := string(raw)
+	for _, want := range []string{
+		"truffels-digibyted-node:14022", "secretpass",
+		"dgb1qc4txtrd36vw0hrjz93gvfhd28dvv0uu37rphy6", "0.0.0.0:3334", "/data/logs",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("ckpool.conf missing %q:\n%s", want, s)
+		}
+	}
+	if _, err := RenderConfig("ckpool-dgb", map[string]any{}, nil); err == nil {
+		t.Error("ckpool-dgb without stack creds should error")
+	}
+}
+
+// The payout address is required and pattern-checked.
+func TestCkpoolDGBAddressValidation(t *testing.T) {
+	cat, err := LoadCatalog()
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	e, ok := cat["ckpool-dgb"]
+	if !ok {
+		t.Fatal("ckpool-dgb not in catalog")
+	}
+	if _, err := ValidateParams(e, map[string]any{"dgb_address": "dgb1qc4txtrd36vw0hrjz93gvfhd28dvv0uu37rphy6"}); err != nil {
+		t.Errorf("valid address rejected: %v", err)
+	}
+	if _, err := ValidateParams(e, map[string]any{}); err == nil {
+		t.Error("missing dgb_address should be rejected (required)")
+	}
+	if _, err := ValidateParams(e, map[string]any{"dgb_address": "not an address!!"}); err == nil {
+		t.Error("malformed dgb_address should be rejected")
 	}
 }

--- a/truffels-agent/compose_render_test.go
+++ b/truffels-agent/compose_render_test.go
@@ -36,6 +36,17 @@ func TestRenderComposeShape(t *testing.T) {
 	}
 }
 
+// testEntryParams supplies valid params for entries that have required ones,
+// so whole-catalog tests can render every entry.
+func testEntryParams(id string) map[string]any {
+	switch id {
+	case "ckpool-dgb":
+		return map[string]any{"dgb_address": "dgb1qc4txtrd36vw0hrjz93gvfhd28dvv0uu37rphy6"}
+	default:
+		return map[string]any{}
+	}
+}
+
 // The forbidden keys must not appear in ANY output, for no catalog entry.
 // See Spec 4.1.
 func TestRenderComposeNeverEmitsForbiddenKeys(t *testing.T) {
@@ -45,7 +56,7 @@ func TestRenderComposeNeverEmitsForbiddenKeys(t *testing.T) {
 	}
 	cat, _ := LoadCatalog()
 	for id, e := range cat {
-		params, err := ValidateParams(e, map[string]any{})
+		params, err := ValidateParams(e, testEntryParams(id))
 		if err != nil {
 			t.Fatalf("%s: ValidateParams: %v", id, err)
 		}
@@ -65,7 +76,7 @@ func TestRenderComposeNeverEmitsForbiddenKeys(t *testing.T) {
 func TestRenderComposeVolumesStayUnderDerivedRoots(t *testing.T) {
 	cat, _ := LoadCatalog()
 	for id, e := range cat {
-		params, _ := ValidateParams(e, map[string]any{})
+		params, _ := ValidateParams(e, testEntryParams(id))
 		out, _ := RenderCompose(e, params)
 		var doc map[string]any
 		_ = json.Unmarshal(out, &doc)

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -73,6 +74,12 @@ func parseStackCreds(b []byte) (*stackCreds, error) {
 // create race is reconciled by re-inspecting.
 func ensureStackNetwork(ctx context.Context, stack string) error {
 	name := stackNetworkName(stack)
+	// No docker in this environment (unit tests / dev): the network is created
+	// for real in production, where the agent always has the docker CLI.
+	if _, err := exec.LookPath("docker"); err != nil {
+		slog.Warn("stack network skipped (docker unavailable)", "stack", stack)
+		return nil
+	}
 	if _, err := runStdout(ctx, "docker", "network", "inspect", name); err == nil {
 		return nil
 	}


### PR DESCRIPTION
The pool half of the DGB mining stack, on top of the F1–F3 foundation. Agent-only (the foundation + existing API carry it). **The running node stays on its current config until it is deliberately reinstalled at deploy time — this PR does not restart it.**

- **ckpool-dgb** catalog entry: build-type reusing `dockerfiles/ckpool` (no official ckpool image exists — built from the ckolivas source, pinned). `stack: "dgb"`, `requires: digibyted`. Params: `dgb_address` (required, pattern-checked) + `dgb_sig`.
- **renderCkpoolDGBConf** builds `ckpool.conf` with `encoding/json` (address & signature are user params → structural JSON encoding keeps them in-string): `btcd` → `truffels-digibyted-node:14022` with the shared stack credential, `zmqblock` at the node, stratum on `0.0.0.0:3334`.
- **digibyted** gains `stack: "dgb"` → its RPC exposes once reinstalled (the single planned node restart, done at deploy).
- `ensureStackNetwork` no-ops when the docker CLI is absent (unit tests), matching the chown guard.

Next: S1b (ckstats-db-dgb + ckstats-dgb). Deploy of S1a includes the one node restart + first pool install.

## Verification
Agent `go test` green (ckpool.conf render + address validation + whole-catalog forbidden-keys with the new entry), `golangci-lint` 0 issues, gofmt clean. Pool↔node end-to-end verified on-device after dev.40 self-update + the node restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)