### PR TITLE
DigiByte pool stats (ckstats-db-dgb + ckstats-dgb) — S1b

### DIFF
--- a/truffels-agent/catalog/ckstats-db-dgb.json
+++ b/truffels-agent/catalog/ckstats-db-dgb.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "id": "ckstats-db-dgb",
+  "display_name": "DigiByte Pool Stats DB",
+  "description": "PostgreSQL database backing the DigiByte pool statistics.",
+  "role": "database",
+  "implementation": "postgres",
+  "chain": "dgb",
+  "stack": "dgb",
+  "image": "postgres:16-alpine",
+  "containers": [
+    {
+      "name": "db",
+      "memory_limit_mb": 512,
+      "user": "70:70",
+      "env_file": "postgres.env",
+      "volumes": [
+        {"kind": "data", "mount": "/var/lib/postgresql/data"}
+      ],
+      "healthcheck": {
+        "test": ["CMD-SHELL", "pg_isready -U ckpool -d ckstats"],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 5,
+        "start_period": "30s"
+      }
+    }
+  ],
+  "resources": {"min_disk_gb": 2, "memory_floor_mb": 256}
+}

--- a/truffels-agent/catalog/ckstats-dgb.json
+++ b/truffels-agent/catalog/ckstats-dgb.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "ckstats-dgb",
+  "display_name": "DigiByte Pool Stats",
+  "description": "ckstats dashboard for DigiByte pool statistics. Reads the pool's logs and stores stats in its database.",
+  "role": "stats",
+  "implementation": "ckstats",
+  "chain": "dgb",
+  "stack": "dgb",
+  "build": {
+    "dockerfile": "dockerfiles/ckstats/Dockerfile",
+    "version": "v1.0.0"
+  },
+  "requires": [
+    {"role": "pool", "id": "ckpool-dgb"},
+    {"role": "database", "id": "ckstats-db-dgb"}
+  ],
+  "containers": [
+    {
+      "name": "app",
+      "memory_limit_mb": 512,
+      "env_file": "ckstats.env",
+      "ports": [{"container": 3000, "host": 3335, "role": "http"}],
+      "volumes": [
+        {"kind": "pool-logs", "from": "ckpool-dgb", "mount": "/ckpool-logs", "ro": true}
+      ],
+      "healthcheck": {
+        "test": ["CMD-SHELL", "node -e 'fetch(\"http://127.0.0.1:3000/ckstats\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 5,
+        "start_period": "60s"
+      }
+    },
+    {
+      "name": "cron",
+      "memory_limit_mb": 256,
+      "env_file": "ckstats.env",
+      "entrypoint": ["/bin/sh", "-c", "CLEANUP_COUNTER=0; while true; do date +%s > /tmp/cron-last-run; echo seed; pnpm seed 2>&1; echo update-users; pnpm update-users 2>&1; CLEANUP_COUNTER=$$((CLEANUP_COUNTER + 1)); if [ \"$$CLEANUP_COUNTER\" -ge 120 ]; then echo cleanup; pnpm cleanup 2>&1; CLEANUP_COUNTER=0; fi; sleep 60; done"],
+      "volumes": [
+        {"kind": "pool-logs", "from": "ckpool-dgb", "mount": "/ckpool-logs", "ro": true}
+      ],
+      "healthcheck": {
+        "test": ["CMD-SHELL", "test $$(( $$(date +%s) - $$(cat /tmp/cron-last-run 2>/dev/null || echo 0) )) -lt 180"],
+        "interval": "30s",
+        "timeout": "5s",
+        "retries": 3,
+        "start_period": "120s"
+      }
+    }
+  ],
+  "resources": {"min_disk_gb": 2, "memory_floor_mb": 512}
+}

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -22,9 +22,42 @@ func RenderConfig(id string, params map[string]any, creds *stackCreds) (map[stri
 		return renderDigibyteConf(creds)
 	case "ckpool-dgb":
 		return renderCkpoolDGBConf(params, creds)
+	case "ckstats-db-dgb":
+		return renderCkstatsDBEnv(creds)
+	case "ckstats-dgb":
+		return renderCkstatsEnv(creds)
 	default:
 		return map[string][]byte{}, nil
 	}
+}
+
+// renderCkstatsDBEnv writes the postgres env for the stats database. The
+// password is the shared per-stack secret, so the stats app authenticates with
+// the same value.
+func renderCkstatsDBEnv(creds *stackCreds) (map[string][]byte, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("ckstats-db-dgb requires stack credentials")
+	}
+	env := "POSTGRES_USER=ckpool\nPOSTGRES_DB=ckstats\nPOSTGRES_PASSWORD=" + creds.Pass + "\n"
+	return map[string][]byte{"postgres.env": []byte(env)}, nil
+}
+
+// renderCkstatsEnv writes the ckstats app env: where to read the pool logs, and
+// how to reach its database (by the db's stack DNS name, with the shared secret).
+func renderCkstatsEnv(creds *stackCreds) (map[string][]byte, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("ckstats-dgb requires stack credentials")
+	}
+	var b strings.Builder
+	b.WriteString("API_URL=/ckpool-logs\n")
+	b.WriteString("DB_HOST=" + catContainerName("ckstats-db-dgb", "db") + "\n")
+	b.WriteString("DB_PORT=5432\n")
+	b.WriteString("DB_USER=ckpool\n")
+	b.WriteString("DB_PASSWORD=" + creds.Pass + "\n")
+	b.WriteString("DB_NAME=ckstats\n")
+	b.WriteString("DB_SSL=false\n")
+	b.WriteString("DB_SSL_REJECT_UNAUTHORIZED=false\n")
+	return map[string][]byte{"ckstats.env": []byte(b.String())}, nil
 }
 
 // ckpool.conf is JSON, and two of its values (address, signature) are user

--- a/truffels-agent/catalog_config_test.go
+++ b/truffels-agent/catalog_config_test.go
@@ -107,3 +107,29 @@ func TestCkpoolDGBAddressValidation(t *testing.T) {
 		t.Error("malformed dgb_address should be rejected")
 	}
 }
+
+// The stats DB and app share the per-stack secret as their DB password, and the
+// app points at the DB by its stack DNS name.
+func TestRenderCkstatsEnvs(t *testing.T) {
+	creds := &stackCreds{User: "truffels", Pass: "poolpass99"}
+	db, err := RenderConfig("ckstats-db-dgb", map[string]any{}, creds)
+	if err != nil {
+		t.Fatalf("db env: %v", err)
+	}
+	if !strings.Contains(string(db["postgres.env"]), "POSTGRES_PASSWORD=poolpass99") {
+		t.Errorf("postgres.env missing password: %s", db["postgres.env"])
+	}
+	app, err := RenderConfig("ckstats-dgb", map[string]any{}, creds)
+	if err != nil {
+		t.Fatalf("app env: %v", err)
+	}
+	s := string(app["ckstats.env"])
+	for _, want := range []string{"DB_HOST=truffels-ckstats-db-dgb-db", "DB_PASSWORD=poolpass99", "API_URL=/ckpool-logs"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("ckstats.env missing %q:\n%s", want, s)
+		}
+	}
+	if _, err := RenderConfig("ckstats-db-dgb", map[string]any{}, nil); err == nil {
+		t.Error("ckstats-db-dgb without creds should error")
+	}
+}

--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -52,6 +52,9 @@ type ContainerSpec struct {
 	Ports         []PortSpec       `json:"ports,omitempty"`
 	Volumes       []VolumeSpec     `json:"volumes,omitempty"`
 	Healthcheck   *HealthcheckSpec `json:"healthcheck,omitempty"`
+	// EnvFile names a rendered config file (bare filename) whose KEY=VALUE lines
+	// become this container's environment — e.g. postgres credentials.
+	EnvFile string `json:"env_file,omitempty"`
 }
 
 type PortSpec struct {

--- a/truffels-agent/compose_render.go
+++ b/truffels-agent/compose_render.go
@@ -94,6 +94,14 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 				StartPeriod: c.Healthcheck.StartPeriod,
 			}
 		}
+		if c.EnvFile != "" {
+			// The env file is a rendered config artifact; it must be a bare
+			// filename so it can only resolve inside the entry's config dir.
+			if err := safeConfigKey(c.EnvFile); err != nil {
+				return nil, fmt.Errorf("env_file: %w", err)
+			}
+			svc.EnvFile = []string{catConfigPath(e.ID, c.EnvFile)}
+		}
 		cf.Services[c.Name] = svc
 	}
 

--- a/truffels-agent/compose_render_test.go
+++ b/truffels-agent/compose_render_test.go
@@ -88,7 +88,11 @@ func TestRenderComposeVolumesStayUnderDerivedRoots(t *testing.T) {
 			for _, v := range vols {
 				src := strings.SplitN(v.(string), ":", 2)[0]
 				src = filepath.Clean(src)
-				okPrefix := strings.HasPrefix(src, catDataDir(id)) ||
+				// Sources live under a catalog entry's data dir (its own, or —
+				// for a pool-logs volume — another entry's, always a validated
+				// cat-<id> path) or the entry's own config dir. Never "/" or a
+				// host path.
+				okPrefix := strings.HasPrefix(src, dataRoot+"/cat-") ||
 					strings.HasPrefix(src, configRoot+"/cat-"+id+"/")
 				if !okPrefix {
 					t.Errorf("%s: bind source %q lies outside the derived roots", id, src)
@@ -314,5 +318,23 @@ func TestVolumeSourcePoolLogsRejectsBadFrom(t *testing.T) {
 		if _, err := volumeSource("stats", VolumeSpec{Kind: "pool-logs", From: bad, Mount: "/x"}); err == nil {
 			t.Errorf("bad from %q was accepted", bad)
 		}
+	}
+}
+
+// A container declaring an env_file has it rendered as a path under the entry's
+// config dir.
+func TestRenderComposeEnvFile(t *testing.T) {
+	cat, _ := LoadCatalog()
+	e, ok := cat["ckstats-db-dgb"]
+	if !ok {
+		t.Fatal("ckstats-db-dgb not in catalog")
+	}
+	out, err := RenderCompose(e, map[string]any{})
+	if err != nil {
+		t.Fatalf("RenderCompose: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "env_file") || !strings.Contains(s, "cat-ckstats-db-dgb/postgres.env") {
+		t.Errorf("ckstats-db-dgb should reference env_file postgres.env:\n%s", s)
 	}
 }

--- a/truffels-agent/compose_types.go
+++ b/truffels-agent/compose_types.go
@@ -33,6 +33,11 @@ type composeService struct {
 	Healthcheck   *composeHealth `json:"healthcheck,omitempty"`
 	Deploy        composeDeploy  `json:"deploy"`
 	Build         *composeBuild  `json:"build,omitempty"`
+	// EnvFile loads KEY=VALUE environment from a rendered config file. It is a
+	// bounded widening of the allowlist: env_file only sets environment
+	// variables (no privilege escalation, no host access), and the file is
+	// catalog-rendered content under the config root, never a caller path.
+	EnvFile []string `json:"env_file,omitempty"`
 }
 
 // composeBuild is emitted only for catalog entries that ship a Dockerfile


### PR DESCRIPTION
The stats half of the DGB mining stack, completing the DGB catalog stack (node + pool + stats).

- **env_file support (foundation):** `composeService`/`ContainerSpec` gain `env_file`, loading KEY=VALUE from a rendered config file. Bounded allowlist widening — env_file only sets environment (no privilege escalation), and the file is a catalog-rendered artifact under the config root (validated bare name).
- **ckstats-db-dgb:** `postgres:16-alpine` run as **user 70 with cap_drop ALL** — verified via a throwaway spike that initdb succeeds capless with a chowned data dir, so no `cap_add` is needed (the catalog forbids it). Password = shared per-stack secret.
- **ckstats-dgb:** the ckstats dashboard (app + cron), built from `dockerfiles/ckstats`. Reads the pool's logs via a `pool-logs` volume, reaches its DB by the db's stack DNS name with the shared secret, `requires` ckpool-dgb + ckstats-db-dgb. Env mirrors legacy ckstats.

Agent-only (foundation + existing API carry it). Deploy = dev.41 self-update, then install ckstats-db-dgb + ckstats-dgb; the complex ckstats app (Prisma migrations, seed) may need on-device iteration like digibyted did.

Note: `TestPrepareBuildSource` is a pre-existing flaky (git exec-bit), unrelated.

## Verification
Agent `go test` green (env renders, env_file emission, pool-logs), `golangci-lint` 0 issues, gofmt clean. Postgres-capless-as-user-70 verified by spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)