### PR TITLE
DGB stack polish: ckstats Dockerfile (A), list perf (C), reconcile fix (D)

### DIFF
--- a/dockerfiles/ckstats-dgb/Dockerfile
+++ b/dockerfiles/ckstats-dgb/Dockerfile
@@ -1,0 +1,77 @@
+# ckstats-dgb — Next.js mining stats dashboard for the DigiByte pool.
+#
+# Self-contained variant of dockerfiles/ckstats/Dockerfile: it clones the
+# upstream source itself instead of COPYing it from a bind-mounted working copy,
+# so it builds under the catalog build flow (context = this dir, no source tree
+# supplied). Served under /ckstats-dgb so it never collides with the legacy
+# ckstats at /ckstats.
+FROM node:22-slim AS builder
+
+ENV CI=true
+# git to fetch the source; pnpm 10 (see dockerfiles/ckstats for the pin rationale).
+RUN set -e; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+WORKDIR /app
+# Full clone (blobs on demand), pinned to a known-good commit. Not shallow: a
+# pinned checkout needs the history to reach the commit.
+ARG SOURCE_REF=8f2e7c2f8403
+RUN git clone --filter=blob:none https://github.com/mrv777/ckstats.git . && \
+    git checkout "$SOURCE_REF"
+
+RUN pnpm install --no-frozen-lockfile || (sleep 10 && pnpm install --no-frozen-lockfile) || (sleep 30 && pnpm install --no-frozen-lockfile) || (sleep 60 && pnpm install --no-frozen-lockfile)
+RUN pnpm add dotenv || (sleep 10 && pnpm add dotenv) || (sleep 30 && pnpm add dotenv) || (sleep 60 && pnpm add dotenv)
+
+# Prefix client-side fetch() calls with the basePath (Next.js basePath does not
+# rewrite raw fetch()). Same reasoning as the legacy image, /ckstats-dgb here.
+RUN sed -i "s|fetch('/api/|fetch('/ckstats-dgb/api/|g" components/Header.tsx && \
+    sed -i "s|fetch(\`/api/|fetch(\`/ckstats-dgb/api/|g" components/UserResetButton.tsx components/PrivacyToggle.tsx && \
+    npx prettier --write components/Header.tsx components/UserResetButton.tsx components/PrivacyToggle.tsx
+
+# Serve the whole app under /ckstats-dgb. Idempotent, fails loudly if the
+# upstream config layout changed (see the legacy image for the full rationale).
+RUN if ! grep -q "basePath:" next.config.js; then \
+      sed -i "s|const nextConfig = {|const nextConfig = {\n  basePath: '/ckstats-dgb',|" next.config.js; \
+    fi; \
+    grep -q "basePath: '/ckstats-dgb'" next.config.js || { \
+      echo "FATAL: could not inject basePath into next.config.js (upstream layout changed)" >&2; \
+      cat next.config.js >&2; \
+      exit 1; \
+    }
+
+RUN pnpm build
+
+FROM node:22-slim
+
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@10 --activate
+RUN set -e; \
+    retry() { "$@" && return 0; for s in 10 30 60; do sleep $s; "$@" && return 0; done; return 1; }; \
+    retry apt-get update && \
+    retry apt-get install -y --no-install-recommends cron postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG SOURCE_REF=8f2e7c2f8403
+LABEL org.truffels.source-ref=$SOURCE_REF
+
+WORKDIR /app
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/pnpm-workspace.yaml* ./
+COPY --from=builder /app/scripts ./scripts
+COPY --from=builder /app/lib ./lib
+COPY --from=builder /app/utils ./utils
+COPY --from=builder /app/tsconfig.json ./
+COPY --from=builder /app/tsconfig.scripts.json ./
+COPY --from=builder /app/ormconfig.ts ./
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/migrations ./migrations
+
+EXPOSE 3000
+
+CMD ["pnpm", "start"]

--- a/truffels-agent/catalog/ckstats-dgb.json
+++ b/truffels-agent/catalog/ckstats-dgb.json
@@ -8,24 +8,44 @@
   "chain": "dgb",
   "stack": "dgb",
   "build": {
-    "dockerfile": "dockerfiles/ckstats/Dockerfile",
+    "dockerfile": "dockerfiles/ckstats-dgb/Dockerfile",
     "version": "v1.0.0"
   },
   "requires": [
-    {"role": "pool", "id": "ckpool-dgb"},
-    {"role": "database", "id": "ckstats-db-dgb"}
+    {
+      "role": "pool",
+      "id": "ckpool-dgb"
+    },
+    {
+      "role": "database",
+      "id": "ckstats-db-dgb"
+    }
   ],
   "containers": [
     {
       "name": "app",
       "memory_limit_mb": 512,
       "env_file": "ckstats.env",
-      "ports": [{"container": 3000, "host": 3335, "role": "http"}],
+      "ports": [
+        {
+          "container": 3000,
+          "host": 3335,
+          "role": "http"
+        }
+      ],
       "volumes": [
-        {"kind": "pool-logs", "from": "ckpool-dgb", "mount": "/ckpool-logs", "ro": true}
+        {
+          "kind": "pool-logs",
+          "from": "ckpool-dgb",
+          "mount": "/ckpool-logs",
+          "ro": true
+        }
       ],
       "healthcheck": {
-        "test": ["CMD-SHELL", "node -e 'fetch(\"http://127.0.0.1:3000/ckstats\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"],
+        "test": [
+          "CMD-SHELL",
+          "node -e 'fetch(\"http://127.0.0.1:3000/ckstats-dgb\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"
+        ],
         "interval": "30s",
         "timeout": "10s",
         "retries": 5,
@@ -36,12 +56,24 @@
       "name": "cron",
       "memory_limit_mb": 256,
       "env_file": "ckstats.env",
-      "entrypoint": ["/bin/sh", "-c", "CLEANUP_COUNTER=0; while true; do date +%s > /tmp/cron-last-run; echo seed; pnpm seed 2>&1; echo update-users; pnpm update-users 2>&1; CLEANUP_COUNTER=$$((CLEANUP_COUNTER + 1)); if [ \"$$CLEANUP_COUNTER\" -ge 120 ]; then echo cleanup; pnpm cleanup 2>&1; CLEANUP_COUNTER=0; fi; sleep 60; done"],
+      "entrypoint": [
+        "/bin/sh",
+        "-c",
+        "CLEANUP_COUNTER=0; while true; do date +%s > /tmp/cron-last-run; echo seed; pnpm seed 2>&1; echo update-users; pnpm update-users 2>&1; CLEANUP_COUNTER=$$((CLEANUP_COUNTER + 1)); if [ \"$$CLEANUP_COUNTER\" -ge 120 ]; then echo cleanup; pnpm cleanup 2>&1; CLEANUP_COUNTER=0; fi; sleep 60; done"
+      ],
       "volumes": [
-        {"kind": "pool-logs", "from": "ckpool-dgb", "mount": "/ckpool-logs", "ro": true}
+        {
+          "kind": "pool-logs",
+          "from": "ckpool-dgb",
+          "mount": "/ckpool-logs",
+          "ro": true
+        }
       ],
       "healthcheck": {
-        "test": ["CMD-SHELL", "test $$(( $$(date +%s) - $$(cat /tmp/cron-last-run 2>/dev/null || echo 0) )) -lt 180"],
+        "test": [
+          "CMD-SHELL",
+          "test $$(( $$(date +%s) - $$(cat /tmp/cron-last-run 2>/dev/null || echo 0) )) -lt 180"
+        ],
         "interval": "30s",
         "timeout": "5s",
         "retries": 3,
@@ -49,5 +81,8 @@
       }
     }
   ],
-  "resources": {"min_disk_gb": 2, "memory_floor_mb": 512}
+  "resources": {
+    "min_disk_gb": 2,
+    "memory_floor_mb": 512
+  }
 }

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -136,6 +136,13 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ID     string         `json:"id"`
 		Params map[string]any `json:"params"`
+		// OnlyIfMissing makes apply a no-op when the compose file already
+		// exists. The startup reconcile sets it: its job is to heal files that a
+		// DB restore left missing, not to re-render a service whose catalog
+		// template changed — rewriting config under a running container that was
+		// created from the old render desyncs the two (e.g. new RPC creds the
+		// running node never loaded). A real install leaves it false.
+		OnlyIfMissing bool `json:"only_if_missing,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
@@ -152,6 +159,13 @@ func handleServiceApply(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "unknown catalog entry"})
 		return
+	}
+	// A reconcile only writes what is missing; leave an existing install alone.
+	if req.OnlyIfMissing {
+		if _, err := os.Stat(catComposeDir(req.ID) + "/docker-compose.yml"); err == nil {
+			writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "id": req.ID, "skipped": true})
+			return
+		}
 	}
 	// 3. Parameters against the declared schema.
 	params, err := ValidateParams(entry, req.Params)

--- a/truffels-api/internal/api/catalog_install.go
+++ b/truffels-api/internal/api/catalog_install.go
@@ -181,7 +181,7 @@ func (s *Server) handleCatalogInstall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.catalogClient.Apply(id, body.Params); err != nil {
+	if err := s.catalogClient.Apply(id, body.Params, false); err != nil {
 		writeError(w, http.StatusBadGateway, "agent apply failed: "+err.Error())
 		return
 	}

--- a/truffels-api/internal/api/services.go
+++ b/truffels-api/internal/api/services.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -17,23 +18,39 @@ import (
 )
 
 func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
-	var services []model.ServiceInstance
-	for _, tmpl := range s.registry.All() {
-		containers := docker.InspectContainers(tmpl.ContainerNames)
-		enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
-		svc := model.ServiceInstance{
-			Template:   tmpl,
-			State:      deriveState(containers),
-			Enabled:    enabled,
-			Containers: containers,
-		}
-		if !enabled && (svc.State == model.StateStopped || svc.State == model.StateUnknown) {
-			svc.State = model.StateDisabled
-		}
-		svc.DependencyIssues = s.checkDependencyIssues(tmpl)
-		s.enrichSyncInfo(&svc)
-		services = append(services, svc)
+	// Each service's status is an independent set of docker inspects plus RPC/
+	// probe calls. Done sequentially the page grew to ~2s as the catalog stack
+	// added services; fan the per-service work out (bounded) so the wall-clock
+	// is the slowest single service, not their sum. Each goroutine writes its
+	// own slice index, so no shared state is mutated concurrently.
+	tmpls := s.registry.All()
+	services := make([]model.ServiceInstance, len(tmpls))
+	sem := make(chan struct{}, 8)
+	var wg sync.WaitGroup
+	for i, tmpl := range tmpls {
+		wg.Add(1)
+		go func(i int, tmpl model.ServiceTemplate) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			containers := docker.InspectContainers(tmpl.ContainerNames)
+			enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
+			svc := model.ServiceInstance{
+				Template:   tmpl,
+				State:      deriveState(containers),
+				Enabled:    enabled,
+				Containers: containers,
+			}
+			if !enabled && (svc.State == model.StateStopped || svc.State == model.StateUnknown) {
+				svc.State = model.StateDisabled
+			}
+			svc.DependencyIssues = s.checkDependencyIssues(tmpl)
+			s.enrichSyncInfo(&svc)
+			services[i] = svc
+		}(i, tmpl)
 	}
+	wg.Wait()
 	writeJSON(w, http.StatusOK, services)
 }
 

--- a/truffels-api/internal/catalog/client.go
+++ b/truffels-api/internal/catalog/client.go
@@ -145,12 +145,17 @@ func (c *Client) IDs() (map[string]bool, error) {
 	return ids, nil
 }
 
-func (c *Client) Apply(id string, params map[string]any) error {
+// Apply renders and writes a catalog service's compose/config on the agent.
+// onlyIfMissing makes it a no-op when the service is already provisioned — used
+// by the startup reconcile so it heals missing files without rewriting (and
+// desyncing) a service whose template changed under a running container.
+func (c *Client) Apply(id string, params map[string]any, onlyIfMissing bool) error {
 	type req struct {
-		ID     string         `json:"id"`
-		Params map[string]any `json:"params"`
+		ID            string         `json:"id"`
+		Params        map[string]any `json:"params"`
+		OnlyIfMissing bool           `json:"only_if_missing,omitempty"`
 	}
-	body, err := json.Marshal(req{ID: id, Params: params})
+	body, err := json.Marshal(req{ID: id, Params: params, OnlyIfMissing: onlyIfMissing})
 	if err != nil {
 		return err
 	}

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -101,7 +101,7 @@ func main() {
 				return
 			}
 			for _, inst := range installs {
-				if err := catalogClient.Apply(inst.CatalogID, inst.Params); err != nil {
+				if err := catalogClient.Apply(inst.CatalogID, inst.Params, true); err != nil {
 					slog.Warn("catalog reconcile apply failed", "id", inst.CatalogID, "err", err)
 				}
 			}


### PR DESCRIPTION
Three fixes from deploying the DGB stack.

**A — self-contained ckstats-dgb Dockerfile.** The ckstats app couldn't build under the catalog build flow (its Dockerfile COPYs source from a bind-mounted working copy that the catalog context doesn't supply). New `dockerfiles/ckstats-dgb/Dockerfile` clones the upstream source itself (like ckpool), pinned, and serves under `/ckstats-dgb`. **Verified: builds end to end** (throwaway build, exit 0).

**C — parallelize the services list.** `/services` fetched every service's status sequentially and grew to ~2s as the stack added services. Fan the per-service work out with a bounded pool (each goroutine writes its own slot; shared reads are concurrency-safe). Wall-clock is now the slowest single service, not the sum.

**D — reconcile only heals missing files.** The startup catalog reconcile re-applied every installed service unconditionally; when a template changed (digibyted gaining `stack:"dgb"`), it rewrote the config under the running container → healthcheck "incorrect password" until a manual recreate. `Apply` gains `only_if_missing` (set by the reconcile): a no-op when the compose already exists, so it heals missing files but never desyncs a running service.

Next: deploy + verify the ckstats dashboard builds AND runs (migrations), then B (Caddy proxy route + UI "Open" link).

## Verification
Agent + API `go test` green, `golangci-lint` 0 issues both modules, gofmt clean. ckstats-dgb image build verified on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)