### PR TITLE
DGB stack completion: up-build timeout + migrations (E), proxy route + UI link (B)

### DIFF
--- a/truffels-agent/catalog/ckstats-dgb.json
+++ b/truffels-agent/catalog/ckstats-dgb.json
@@ -59,7 +59,7 @@
       "entrypoint": [
         "/bin/sh",
         "-c",
-        "CLEANUP_COUNTER=0; while true; do date +%s > /tmp/cron-last-run; echo seed; pnpm seed 2>&1; echo update-users; pnpm update-users 2>&1; CLEANUP_COUNTER=$$((CLEANUP_COUNTER + 1)); if [ \"$$CLEANUP_COUNTER\" -ge 120 ]; then echo cleanup; pnpm cleanup 2>&1; CLEANUP_COUNTER=0; fi; sleep 60; done"
+        "until pnpm migration:run; do echo waiting for db; sleep 5; done; CLEANUP_COUNTER=0; while true; do date +%s > /tmp/cron-last-run; echo seed; pnpm seed 2>&1; echo update-users; pnpm update-users 2>&1; CLEANUP_COUNTER=$$((CLEANUP_COUNTER + 1)); if [ \"$$CLEANUP_COUNTER\" -ge 120 ]; then echo cleanup; pnpm cleanup 2>&1; CLEANUP_COUNTER=0; fi; sleep 60; done"
       ],
       "volumes": [
         {

--- a/truffels-agent/catalog/ckstats-dgb.json
+++ b/truffels-agent/catalog/ckstats-dgb.json
@@ -84,5 +84,10 @@
   "resources": {
     "min_disk_gb": 2,
     "memory_floor_mb": 512
+  },
+  "web": {
+    "route": "/ckstats-dgb",
+    "container": "app",
+    "port": 3000
   }
 }

--- a/truffels-agent/catalog_types.go
+++ b/truffels-agent/catalog_types.go
@@ -24,7 +24,18 @@ type CatalogEntry struct {
 	Requires   []RequireSpec   `json:"requires,omitempty"`
 	Source     *SourceSpec     `json:"source,omitempty"`
 	ChainInfo  *ChainSpec      `json:"chain_info,omitempty"`
+	Web        *WebSpec        `json:"web,omitempty"`
 	Resources  ResourceSpec    `json:"resources"`
+}
+
+// WebSpec declares that an entry serves a web UI the proxy should expose. Route
+// is a fixed path prefix (the app is built with it as its basePath, so it is
+// not a runtime parameter), Container is which of the entry's containers serves
+// it, Port is the container port.
+type WebSpec struct {
+	Route     string `json:"route"`
+	Container string `json:"container"`
+	Port      int    `json:"port"`
 }
 
 type BuildSpec struct {

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -214,7 +214,8 @@ func handleComposeUp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	dir := composeDir(req.ServiceID)
-	if err := runCompose(dir, "up", "-d", "--remove-orphans"); err != nil {
+	// up -d builds a missing catalog image; give it a build-sized budget.
+	if err := runComposeTimeout(dir, 20*time.Minute, "up", "-d", "--remove-orphans"); err != nil {
 		writeJSON(w, 500, map[string]string{"error": err.Error()})
 		return
 	}
@@ -903,10 +904,18 @@ func runStdout(ctx context.Context, name string, args ...string) (string, error)
 }
 
 func runCompose(composeDir string, args ...string) error {
+	return runComposeTimeout(composeDir, 5*time.Minute, args...)
+}
+
+// runComposeTimeout is runCompose with an explicit deadline. `up` may build a
+// catalog image (a slow Next.js build outruns five minutes), so its caller
+// passes a build-sized budget; down/stop keep the short default so the API's
+// uninstall timeout still outlasts the agent's teardown.
+func runComposeTimeout(composeDir string, timeout time.Duration, args ...string) error {
 	fullArgs := append([]string{"compose", "-f", composeDir + "/docker-compose.yml"}, args...)
 	slog.Info("docker compose", "dir", composeDir, "args", strings.Join(args, " "))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "docker", fullArgs...)

--- a/truffels-api/internal/api/catalog_install.go
+++ b/truffels-api/internal/api/catalog_install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"truffels-api/internal/admission"
+	"truffels-api/internal/compose"
 )
 
 func (s *Server) handleGetCatalog(w http.ResponseWriter, r *http.Request) {
@@ -195,7 +196,30 @@ func (s *Server) handleCatalogInstall(w http.ResponseWriter, r *http.Request) {
 	if err := s.registry.Refresh(); err != nil {
 		slog.Warn("registry refresh after catalog change failed", "err", err)
 	}
+	s.syncCaddyRoutes()
 	s.handleGetService(w, r)
+}
+
+// syncCaddyRoutes regenerates the proxy Caddyfile from the currently installed
+// web services and reloads the proxy if it changed, so a web service's route
+// appears (install) or disappears (uninstall) without waiting for a restart.
+// A no-op when nothing web-facing changed: an unchanged Caddyfile skips the
+// proxy reload.
+func (s *Server) syncCaddyRoutes() {
+	if s.compose == nil {
+		return
+	}
+	caddyfile := compose.RenderCaddyfile(compose.WebRoutesFrom(s.registry))
+	changed, err := s.compose.FileReconcile("/srv/truffels/config/proxy/Caddyfile", caddyfile)
+	if err != nil {
+		slog.Warn("caddy route sync: write failed", "err", err)
+		return
+	}
+	if changed {
+		if err := s.compose.Restart("proxy"); err != nil {
+			slog.Warn("caddy route sync: proxy reload failed", "err", err)
+		}
+	}
 }
 
 func (s *Server) handleCatalogUninstall(w http.ResponseWriter, r *http.Request) {
@@ -234,5 +258,6 @@ func (s *Server) handleCatalogUninstall(w http.ResponseWriter, r *http.Request) 
 	if err := s.registry.Refresh(); err != nil {
 		slog.Warn("registry refresh after uninstall failed", "err", err)
 	}
+	s.syncCaddyRoutes()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/truffels-api/internal/catalog/model.go
+++ b/truffels-api/internal/catalog/model.go
@@ -47,6 +47,13 @@ type Entry struct {
 		SyncProbe []string `json:"sync_probe,omitempty"`
 	} `json:"chain_info,omitempty"`
 
+	// Web declares a proxied web UI (route + which container/port serves it).
+	Web *struct {
+		Route     string `json:"route"`
+		Container string `json:"container"`
+		Port      int    `json:"port"`
+	} `json:"web,omitempty"`
+
 	Resources struct {
 		MinDiskGB     int `json:"min_disk_gb,omitempty"`
 		MemoryFloorMB int `json:"memory_floor_mb"`

--- a/truffels-api/internal/compose/caddyfile.go
+++ b/truffels-api/internal/compose/caddyfile.go
@@ -1,11 +1,50 @@
 package compose
 
-// RenderCaddyfile returns the canonical Caddyfile content for the proxy
-// service. The first handle block (/proxy-health) is a static OK response
-// so the proxy healthcheck doesn't depend on any upstream — fixes the
-// dev.14 false-positive where stopping mempool marked Caddy unhealthy.
-func RenderCaddyfile() string {
-	return caddyfileTemplate
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"truffels-api/internal/model"
+	"truffels-api/internal/service"
+)
+
+// WebRoutesFrom collects the web routes of every registered service that
+// declares one — the set the proxy exposes and the UI links to.
+func WebRoutesFrom(reg *service.Registry) []model.WebRoute {
+	var routes []model.WebRoute
+	for _, tmpl := range reg.All() {
+		if tmpl.Web != nil {
+			routes = append(routes, *tmpl.Web)
+		}
+	}
+	return routes
+}
+
+// caddyRouteRe/caddyHostRe bound what a catalog web route can inject into the
+// Caddyfile: a rooted path and a hostname. Anything else is skipped rather than
+// written, so a bad entry can never produce a Caddyfile that fails to parse.
+var (
+	caddyRouteRe = regexp.MustCompile(`^/[A-Za-z0-9/_-]+$`)
+	caddyHostRe  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+// RenderCaddyfile returns the Caddyfile for the proxy, with a handle block for
+// each installed catalog web service spliced in before the mempool catch-all.
+// The first handle block (/proxy-health) is a static OK response so the proxy
+// healthcheck doesn't depend on any upstream.
+func RenderCaddyfile(webRoutes []model.WebRoute) string {
+	var b strings.Builder
+	for _, wr := range webRoutes {
+		if !caddyRouteRe.MatchString(wr.Route) || !caddyHostRe.MatchString(wr.Container) || wr.Port <= 0 || wr.Port > 65535 {
+			continue
+		}
+		b.WriteString("\thandle " + wr.Route + "* {\n")
+		b.WriteString("\t\theader Content-Security-Policy \"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'\"\n")
+		b.WriteString("\t\treverse_proxy " + wr.Container + ":" + strconv.Itoa(wr.Port) + "\n")
+		b.WriteString("\t}\n")
+	}
+	return strings.Replace(caddyfileTemplate, "%CATALOG_WEB_ROUTES%\n", b.String(), 1)
 }
 
 const caddyfileTemplate = `{
@@ -70,7 +109,7 @@ const caddyfileTemplate = `{
 		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
 		reverse_proxy truffels-mempool-frontend:8080
 	}
-
+%CATALOG_WEB_ROUTES%
 	handle {
 		header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws:; img-src 'self' data:; font-src 'self'"
 		reverse_proxy truffels-mempool-frontend:8080

--- a/truffels-api/internal/compose/caddyfile_test.go
+++ b/truffels-api/internal/compose/caddyfile_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRenderCaddyfile_HasStaticHealthRoute(t *testing.T) {
-	got := RenderCaddyfile()
+	got := RenderCaddyfile(nil)
 	if !strings.Contains(got, "handle /proxy-health") {
 		t.Error("missing /proxy-health route")
 	}
@@ -30,7 +30,7 @@ func TestRenderCaddyfile_HasStaticHealthRoute(t *testing.T) {
 // log that address exists nowhere and "did that device reach us" cannot be
 // answered. It could not be answered in dev.29, which is why this is pinned.
 func TestRenderCaddyfile_LogsRequests(t *testing.T) {
-	got := RenderCaddyfile()
+	got := RenderCaddyfile(nil)
 
 	for _, want := range []string{"log {", "output stdout", "format json"} {
 		if !strings.Contains(got, want) {
@@ -43,7 +43,7 @@ func TestRenderCaddyfile_LogsRequests(t *testing.T) {
 // buries the traffic the log exists to show, so the health route opts out —
 // and it has to be inside that handle block, not merely present in the file.
 func TestRenderCaddyfile_HealthRouteOptsOutOfLogging(t *testing.T) {
-	got := RenderCaddyfile()
+	got := RenderCaddyfile(nil)
 
 	start := strings.Index(got, "handle /proxy-health {")
 	if start < 0 {

--- a/truffels-api/internal/compose/reconciler.go
+++ b/truffels-api/internal/compose/reconciler.go
@@ -134,7 +134,7 @@ func (r *Reconciler) reconcileService(serviceID string) error {
 	// the same agent file/reconcile path so structural Caddy config changes
 	// flow through the update channel.
 	if serviceID == "proxy" {
-		caddyfile := RenderCaddyfile()
+		caddyfile := RenderCaddyfile(WebRoutesFrom(r.registry))
 		caddyfilePath := "/srv/truffels/config/proxy/Caddyfile"
 		if err := r.reconcileFileWithRetry(caddyfilePath, caddyfile); err != nil {
 			slog.Warn("Caddyfile reconcile failed; proceeding with compose",

--- a/truffels-api/internal/model/service.go
+++ b/truffels-api/internal/model/service.go
@@ -38,6 +38,18 @@ type ServiceTemplate struct {
 	// Surfaced in the Service Data Storage panel. Clearable entries get a Clear
 	// button in the UI; non-clearable ones are view-only.
 	DataDirs []DataDir `json:"data_dirs,omitempty"`
+
+	// Web, when set, means the proxy exposes this service's UI at Route and the
+	// admin UI shows an "Open" link there.
+	Web *WebRoute `json:"web,omitempty"`
+}
+
+// WebRoute is a proxied web UI: Route is the path prefix, Container is the full
+// container name to reverse_proxy to, Port is its port.
+type WebRoute struct {
+	Route     string `json:"route"`
+	Container string `json:"container"`
+	Port      int    `json:"port"`
 }
 
 // EnsureDir describes a directory the reconciler must create before bringing

--- a/truffels-api/internal/service/catalog_adapter.go
+++ b/truffels-api/internal/service/catalog_adapter.go
@@ -43,5 +43,15 @@ func CatalogEntryToTemplate(e catalog.Entry, composeRoot, dataRoot string) model
 			tmpl.Dependencies = append(tmpl.Dependencies, req.ID)
 		}
 	}
+	// A web entry gets its route projected with the full container name (the
+	// same "truffels-<id>-<container>" derivation the agent uses) so the proxy
+	// can reverse_proxy to it and the UI can link to it.
+	if e.Web != nil {
+		tmpl.Web = &model.WebRoute{
+			Route:     e.Web.Route,
+			Container: "truffels-" + e.ID + "-" + e.Web.Container,
+			Port:      e.Web.Port,
+		}
+	}
 	return tmpl
 }

--- a/truffels-web/src/lib/api.ts
+++ b/truffels-web/src/lib/api.ts
@@ -61,6 +61,7 @@ export interface ServiceTemplate {
   update_source?: UpdateSource
   stack_containers?: string[]
   data_dirs?: DataDir[]
+  web?: { route: string; container: string; port: number }
 }
 
 export interface DataDir {

--- a/truffels-web/src/pages/ServicesPage.tsx
+++ b/truffels-web/src/pages/ServicesPage.tsx
@@ -77,6 +77,17 @@ export default function ServicesPage() {
                   )}
                 </div>
                 <div className="flex items-center gap-2">
+                  {svc.template.web && svc.state === 'running' && (
+                    <a
+                      href={svc.template.web.route}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="px-1.5 py-0.5 rounded text-xs font-medium bg-accent/20 text-accent hover:bg-accent/30"
+                    >
+                      Öffnen ↗
+                    </a>
+                  )}
                   {svc.sync_info?.syncing && (
                     <span className="px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-400">
                       Syncing {(svc.sync_info.progress * 100).toFixed(1)}%


### PR DESCRIPTION
Completes the DGB stats stack so a fresh install builds, migrates, and is reachable via a clean URL with a UI link.

**E — build-sized up timeout + self-migrating ckstats.** `up -d` builds a missing catalog image, but runCompose capped every op at 5 min — a Next.js build outran that and was killed. The up path now gets 20 min (down/stop stay short so the uninstall timeout still outlasts teardown). And the ckstats cron runs `pnpm migration:run` (retrying until the DB is ready) before its seed loop, so the schema exists on first start — `pnpm start` alone never created it.

**B — proxy route + "Open" link.** A catalog entry can declare a `web` UI (route + container + port). The Caddyfile is generated with a validated `handle` block per installed web service; install/uninstall rewrite it and reload the proxy live. The services list shows an "Öffnen ↗" link. ckstats-dgb declares `/ckstats-dgb`. (Install-time-configurable routes aren't feasible for Next.js — basePath is build-time.)

Deploy note: after self-update, ckstats-dgb must be reinstalled (D: reconcile won't rewrite existing) so its compose picks up the new Dockerfile/web declaration.

## Verification
Agent + API `go test` green, `golangci-lint` 0 issues both modules, `tsc --noEmit` clean. On-device: ckstats dashboard builds, migrates, serves /ckstats-dgb (HTTP 200), and is healthy (verified with the manual-build workaround; E makes it build under the catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)