### PR TITLE
Raise DigiByte memory limit to 4 GB (OOM restart loop)

### DIFF
--- a/truffels-agent/catalog/digibyted.json
+++ b/truffels-agent/catalog/digibyted.json
@@ -15,16 +15,41 @@
   "containers": [
     {
       "name": "node",
-      "memory_limit_mb": 2048,
+      "memory_limit_mb": 4096,
       "user": "1000:1000",
-      "entrypoint": ["digibyted", "-conf=/dgb.conf", "-datadir=/data", "-printtoconsole"],
-      "ports": [{"container": 12024, "host": 12024, "role": "p2p"}],
+      "entrypoint": [
+        "digibyted",
+        "-conf=/dgb.conf",
+        "-datadir=/data",
+        "-printtoconsole"
+      ],
+      "ports": [
+        {
+          "container": 12024,
+          "host": 12024,
+          "role": "p2p"
+        }
+      ],
       "volumes": [
-        {"kind": "data", "mount": "/data"},
-        {"kind": "config", "file": "digibyte.conf", "mount": "/dgb.conf", "ro": true}
+        {
+          "kind": "data",
+          "mount": "/data"
+        },
+        {
+          "kind": "config",
+          "file": "digibyte.conf",
+          "mount": "/dgb.conf",
+          "ro": true
+        }
       ],
       "healthcheck": {
-        "test": ["CMD", "digibyte-cli", "-conf=/dgb.conf", "-datadir=/data", "-getinfo"],
+        "test": [
+          "CMD",
+          "digibyte-cli",
+          "-conf=/dgb.conf",
+          "-datadir=/data",
+          "-getinfo"
+        ],
         "interval": "30s",
         "timeout": "10s",
         "retries": 3,
@@ -32,6 +57,19 @@
       }
     }
   ],
-  "chain_info": {"p2p_port": 12024, "rpc_port": 14022, "rpc_style": "bitcoin-core", "sync_probe": ["digibyte-cli", "-conf=/dgb.conf", "-datadir=/data", "getblockchaininfo"]},
-  "resources": {"min_disk_gb": 12, "memory_floor_mb": 1024}
+  "chain_info": {
+    "p2p_port": 12024,
+    "rpc_port": 14022,
+    "rpc_style": "bitcoin-core",
+    "sync_probe": [
+      "digibyte-cli",
+      "-conf=/dgb.conf",
+      "-datadir=/data",
+      "getblockchaininfo"
+    ]
+  },
+  "resources": {
+    "min_disk_gb": 12,
+    "memory_floor_mb": 2048
+  }
 }


### PR DESCRIPTION
DigiByte Core was OOM-killed by its 2 GB cgroup limit during IBD (confirmed in the kernel log: `Memory cgroup out of memory: Killed process ... digibyted`, RSS ~1.9 GB / 2 GB). It restarted on a loop — 7 restarts with no user action — re-doing header sync each time, which crawled the sync progress. A ~24M-block chain with a growing UTXO set needs more than 2 GB.

Raise `memory_limit_mb` to 4096 and `memory_floor_mb` (admission) to 2048. The running node already got the new limit live via `docker update --memory 4g` (no restart, dropped from 98% → 54%); this makes it permanent on reinstall.

## Verification
Agent `go test` green; JSON valid. Live fix confirmed on-device: restart count held steady after raising the limit, memory at ~54% of 4 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)