### PR TITLE
DGB dbcache + small catalog hardenings

### DIFF
--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -126,6 +126,10 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	// send an Algo argument. The failure would be silent — the RPC response
 	// is valid, just worthless for a SHA256d pool. See Spec 2.4.
 	b.WriteString("algo=sha256d\n")
+	// A larger UTXO cache keeps initial block download from thrashing the disk;
+	// the entry runs with a 4 GB memory limit, which leaves room for a 1 GB
+	// cache on top of the node's baseline.
+	b.WriteString("dbcache=1024\n")
 	b.WriteString("zmqpubhashblock=tcp://0.0.0.0:28332\n")
 
 	// When part of a stack, expose RPC so the pool can reach the node with the

--- a/truffels-agent/catalog_validate.go
+++ b/truffels-agent/catalog_validate.go
@@ -4,11 +4,29 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // catalogIDRe matches valid catalog entry IDs: lowercase letters, digits, hyphens,
 // 1-32 characters long, must start with letter or digit.
 var catalogIDRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
+
+// patternCache compiles each ParamSpec pattern once and reuses it. ValidateParams
+// runs on every install and admission check; recompiling the same fixed pattern
+// each time was pure waste.
+var patternCache sync.Map // string -> *regexp.Regexp
+
+func compilePattern(pattern string) (*regexp.Regexp, error) {
+	if v, ok := patternCache.Load(pattern); ok {
+		return v.(*regexp.Regexp), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	patternCache.Store(pattern, re)
+	return re, nil
+}
 
 // isValidCatalogID checks if the ID is a valid catalog entry identifier.
 func isValidCatalogID(s string) bool { return catalogIDRe.MatchString(s) }
@@ -106,7 +124,7 @@ func coerceParam(spec ParamSpec, raw any) (any, error) {
 			// Patterns are anchored by the catalog author, not implicitly —
 			// a catalog author writes ^…$ themselves; the code does not enforce it
 			// (documented decision so partial matches remain possible where intended).
-			re, err := regexp.Compile(spec.Pattern)
+			re, err := compilePattern(spec.Pattern)
 			if err != nil {
 				return nil, fmt.Errorf("invalid pattern %q: %w", spec.Pattern, err)
 			}

--- a/truffels-api/internal/catalog/client.go
+++ b/truffels-api/internal/catalog/client.go
@@ -84,8 +84,9 @@ func (c *cancelOnClose) Close() error {
 func (c *Client) All() (map[string]Entry, error) {
 	c.mu.RLock()
 	if c.cached != nil {
-		defer c.mu.RUnlock()
-		return c.cached, nil
+		out := copyEntries(c.cached)
+		c.mu.RUnlock()
+		return out, nil
 	}
 	c.mu.RUnlock()
 
@@ -111,7 +112,17 @@ func (c *Client) All() (map[string]Entry, error) {
 	c.mu.Lock()
 	c.cached = out
 	c.mu.Unlock()
-	return out, nil
+	return copyEntries(out), nil
+}
+
+// copyEntries returns a shallow copy of the entry map so callers can iterate or
+// build sets without mutating the client's cache.
+func copyEntries(m map[string]Entry) map[string]Entry {
+	out := make(map[string]Entry, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 func (c *Client) Get(id string) (Entry, bool) {


### PR DESCRIPTION
Low-risk polish done while the DGB node syncs (no deploy).

- **dbcache=1024** in the DigiByte config — with the 4 GB memory limit there's room for a larger UTXO cache, so IBD thrashes the disk less. Applies on the next (re)install.
- **Compiled-pattern cache** — `ValidateParams` recompiled each `ParamSpec` regex on every call; compile once and reuse.
- **Catalog client cache copy** — `All()` handed back its internal map; return a shallow copy so callers can't mutate the cache.

## Verification
Agent + API `go test` green, `golangci-lint` 0 issues both modules, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)