### PR TITLE
DGB stack follow-ups: proxy net, log perms, stack net, editable config

### DIFF
--- a/dockerfiles/ckstats-dgb/Dockerfile
+++ b/dockerfiles/ckstats-dgb/Dockerfile
@@ -72,6 +72,13 @@ COPY --from=builder /app/ormconfig.ts ./
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/migrations ./migrations
 
+# Run as the node user (uid 1000). The catalog runs this with cap_drop=ALL, so
+# a root process would lose CAP_DAC_OVERRIDE and could not read the pool's
+# logs (owned by uid 1000). Running as 1000 matches the pool and reads them
+# natively; chown /app so the app can still write its runtime cache.
+RUN chown -R node:node /app
+USER node
+
 EXPOSE 3000
 
 CMD ["pnpm", "start"]

--- a/truffels-agent/catalog/ckstats-dgb.json
+++ b/truffels-agent/catalog/ckstats-dgb.json
@@ -50,7 +50,8 @@
         "timeout": "10s",
         "retries": 5,
         "start_period": "60s"
-      }
+      },
+      "user": "1000:1000"
     },
     {
       "name": "cron",
@@ -78,7 +79,8 @@
         "timeout": "5s",
         "retries": 3,
         "start_period": "120s"
-      }
+      },
+      "user": "1000:1000"
     }
   ],
   "resources": {

--- a/truffels-agent/compose_render.go
+++ b/truffels-agent/compose_render.go
@@ -53,7 +53,17 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 		svcNetworks = []string{"chain", "stack"}
 	}
 
+	// A web entry's serving container must sit on a network the reverse proxy
+	// can reach it on; truffels-edge is where the proxy lives.
+	if e.Web != nil {
+		cf.Networks["edge"] = composeNetwork{Name: "truffels-edge", External: true}
+	}
+
 	for _, c := range e.Containers {
+		nets := svcNetworks
+		if e.Web != nil && c.Name == e.Web.Container {
+			nets = append(append([]string{}, svcNetworks...), "edge")
+		}
 		svc := composeService{
 			Image:         image,
 			ContainerName: catContainerName(e.ID, c.Name),
@@ -61,7 +71,7 @@ func RenderCompose(e CatalogEntry, params map[string]any) ([]byte, error) {
 			User:          c.User,
 			SecurityOpt:   []string{"no-new-privileges:true"},
 			CapDrop:       []string{"ALL"},
-			Networks:      svcNetworks,
+			Networks:      nets,
 			Entrypoint:    c.Entrypoint,
 			Deploy: composeDeploy{Resources: composeResources{
 				Limits: composeLimits{Memory: strconv.Itoa(c.MemoryLimitMB) + "M"},

--- a/truffels-agent/handlers_catalog.go
+++ b/truffels-agent/handlers_catalog.go
@@ -92,17 +92,6 @@ func ensureStackNetwork(ctx context.Context, stack string) error {
 	return nil
 }
 
-// removeStackNetwork tears the shared network down — best effort. docker refuses
-// to remove a network that still has attached containers, which is exactly the
-// ref-count we want: only the last stack member to leave actually removes it.
-func removeStackNetwork(ctx context.Context, stack string) {
-	name := stackNetworkName(stack)
-	if out, err := runCapture(ctx, "docker", "network", "rm", name); err != nil {
-		slog.Info("stack network kept (still in use or absent)",
-			"stack", stack, "detail", strings.TrimSpace(out))
-	}
-}
-
 // loadedCatalog is filled once at startup. The catalog lives only here in the
 // agent; the API fetches it via this endpoint. This makes a version skew between
 // the two constructively impossible.
@@ -269,8 +258,7 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "invalid id"})
 		return
 	}
-	entry, ok := loadedCatalog[req.ID]
-	if !ok {
+	if _, ok := loadedCatalog[req.ID]; !ok {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "unknown catalog entry"})
 		return
 	}
@@ -310,14 +298,10 @@ func handleServiceRemove(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("Catalog data deleted", "id", req.ID, "path", catDataDir(req.ID))
 	}
 
-	// After the container is down and gone, try to drop the shared stack
-	// network. It only actually goes away once the last member has left.
-	if entry.Stack != "" {
-		nctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		removeStackNetwork(nctx, entry.Stack)
-	}
-
+	// The shared stack network is deliberately left in place: other stack
+	// members (even stopped ones) hold compose references to it by name, and
+	// removing+recreating it on a single member's uninstall would orphan them
+	// against a stale network id. An unused bridge network is a negligible leak.
 	slog.Info("Catalog service removed", "id", req.ID, "purge_data", req.PurgeData)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "purged": req.PurgeData})
 }

--- a/truffels-api/internal/catalog/model.go
+++ b/truffels-api/internal/catalog/model.go
@@ -27,6 +27,10 @@ type Entry struct {
 	Containers []struct {
 		Name          string `json:"name"`
 		MemoryLimitMB int    `json:"memory_limit_mb"`
+		Volumes       []struct {
+			Kind string `json:"kind"`
+			File string `json:"file,omitempty"`
+		} `json:"volumes,omitempty"`
 	} `json:"containers"`
 
 	Requires []struct {

--- a/truffels-api/internal/service/catalog_adapter.go
+++ b/truffels-api/internal/service/catalog_adapter.go
@@ -43,6 +43,21 @@ func CatalogEntryToTemplate(e catalog.Entry, composeRoot, dataRoot string) model
 			tmpl.Dependencies = append(tmpl.Dependencies, req.ID)
 		}
 	}
+	// An entry with a rendered config file (not purely env-based) exposes it
+	// for viewing and editing at cat-<id>/<file>. Edits survive self-updates
+	// (the reconcile only writes missing files); a reinstall re-renders it,
+	// the same as reinstalling a legacy service.
+	for _, c := range e.Containers {
+		for _, v := range c.Volumes {
+			if v.Kind == "config" && v.File != "" {
+				tmpl.ConfigPath = "cat-" + e.ID + "/" + v.File
+				break
+			}
+		}
+		if tmpl.ConfigPath != "" {
+			break
+		}
+	}
 	// A web entry gets its route projected with the full container name (the
 	// same "truffels-<id>-<container>" derivation the agent uses) so the proxy
 	// can reverse_proxy to it and the UI can link to it.

--- a/truffels-api/internal/service/catalog_adapter_test.go
+++ b/truffels-api/internal/service/catalog_adapter_test.go
@@ -14,6 +14,10 @@ func TestCatalogEntryToTemplate(t *testing.T) {
 	e.Containers = append(e.Containers, struct {
 		Name          string `json:"name"`
 		MemoryLimitMB int    `json:"memory_limit_mb"`
+		Volumes       []struct {
+			Kind string `json:"kind"`
+			File string `json:"file,omitempty"`
+		} `json:"volumes,omitempty"`
 	}{Name: "node", MemoryLimitMB: 2048})
 	e.Resources.MemoryFloorMB = 1024
 


### PR DESCRIPTION
The four follow-ups found bringing the DGB stack up (code only; they take effect on the next reinstall, so the running node keeps syncing).

1. **Proxy 502** — the reverse proxy (on `truffels-edge`) couldn't reach a catalog web container on its own cat nets. A web entry's serving container now also joins `truffels-edge`.
2. **ckstats EACCES on pool logs** — it ran as root but with `cap_drop=ALL`, losing `CAP_DAC_OVERRIDE`, so it couldn't read the 1000-owned `0750` log dir. Run ckstats as uid 1000 (matching the pool) + chown `/app` in its Dockerfile.
3. **Stack network orphaning** — uninstalling one member removed the shared network; its new id then orphaned the other stopped members. Leave the network in place (unused bridge = negligible leak).
4. **Editable config** — catalog services with a rendered config file (digibyte.conf, ckpool.conf) now expose it in the config tab for viewing/editing, like legacy. Edits survive self-updates (reconcile only writes missing files), re-rendered on explicit reinstall. Env-based entries (ckstats) keep the environment-based message.

## Verification
Agent + API `go test` green, `golangci-lint` 0 issues both modules, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)