### PR TITLE
monitoring visibility: OOM detection, restart-count coloring, DGB config headers

### DIFF
--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -114,8 +114,9 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	var b strings.Builder
 	b.WriteString("# Project Truffels — DigiByte Core\n")
 	b.WriteString("# Generated from the catalog. Do not edit by hand.\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Chain ---\n")
 	b.WriteString("server=1\n")
-	b.WriteString("printtoconsole=1\n")
 	b.WriteString("disablewallet=1\n")
 	// This build ships DigiDollar compiled in, which refuses to start unless
 	// txindex=1. That also rules out pruning (prune and txindex are mutually
@@ -126,6 +127,8 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	// send an Algo argument. The failure would be silent — the RPC response
 	// is valid, just worthless for a SHA256d pool. See Spec 2.4.
 	b.WriteString("algo=sha256d\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Performance ---\n")
 	// A larger UTXO cache speeds initial block download, but on this 8 GB box
 	// digibyted shares RAM with bitcoind's own node. At dbcache=1024 the peak
 	// RSS during IBD crossed the 4 GB memory limit and the kernel OOM-killed
@@ -133,6 +136,11 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	// the in-memory UTXO set near ~440 MiB, holding the peak safely under the
 	// limit at a modest cost in flush frequency.
 	b.WriteString("dbcache=512\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Logging ---\n")
+	b.WriteString("printtoconsole=1\n")
+	b.WriteString("\n")
+	b.WriteString("# --- ZMQ ---\n")
 	b.WriteString("zmqpubhashblock=tcp://0.0.0.0:28332\n")
 
 	// When part of a stack, expose RPC so the pool can reach the node with the
@@ -140,6 +148,8 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	// node uses; actual reachability stays scoped to the shared stack network.
 	// The password is hex from crypto/rand — no config-escaping concern.
 	if creds != nil {
+		b.WriteString("\n")
+		b.WriteString("# --- RPC ---\n")
 		b.WriteString("rpcuser=" + creds.User + "\n")
 		b.WriteString("rpcpassword=" + creds.Pass + "\n")
 		b.WriteString("rpcbind=0.0.0.0\n")

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -77,6 +77,7 @@ func main() {
 	mux.HandleFunc("POST /v1/compose/build", handleComposeBuild)
 	mux.HandleFunc("GET /v1/stats", handleStats)
 	mux.HandleFunc("GET /v1/health", handleHealth)
+	mux.HandleFunc("GET /v1/oom-events", handleOOMEvents)
 	mux.HandleFunc("GET /v1/host/dir-size", handleHostDirSize)
 	mux.HandleFunc("POST /v1/system/shutdown", handleSystemShutdown)
 	mux.HandleFunc("POST /v1/system/restart", handleSystemRestart)
@@ -97,6 +98,10 @@ func main() {
 	mux.HandleFunc("POST /v1/docker/prune-buildcache", handleDockerPruneBuildCache)
 
 	srv := &http.Server{Addr: listen, Handler: mux}
+
+	// Continuously record container OOM-kill events so the control plane can
+	// surface them (docker's OOMKilled flag is unreliable under auto-restart).
+	go watchOOMEvents(context.Background())
 
 	go func() {
 		sigCh := make(chan os.Signal, 1)

--- a/truffels-agent/oom.go
+++ b/truffels-agent/oom.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// oomEvent records one container OOM-kill observed on the Docker event stream.
+type oomEvent struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	Time int64  `json:"time"` // unix seconds
+}
+
+// oomTracker keeps a bounded, time-limited history of recent OOM-kill events.
+//
+// The Docker daemon emits an `oom` event the moment the cgroup OOM-killer kills
+// a container's process — reliably, and independent of the restart policy. It
+// does NOT, however, retain past events long enough for periodic polling to
+// catch them (a container that OOMs and is auto-restarted shows OOMKilled=false
+// on the next inspect). So the agent streams `docker events` continuously and
+// records the OOM actions here for the control plane to poll.
+type oomTracker struct {
+	mu     sync.Mutex
+	events []oomEvent
+}
+
+const (
+	oomRetention = 60 * time.Minute
+	oomMaxEvents = 100
+)
+
+func (t *oomTracker) add(e oomEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, e)
+	if len(t.events) > oomMaxEvents {
+		t.events = t.events[len(t.events)-oomMaxEvents:]
+	}
+}
+
+// recent returns a copy of the events newer than oomRetention, pruning older
+// ones from the store as a side effect.
+func (t *oomTracker) recent(now int64) []oomEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	cutoff := now - int64(oomRetention/time.Second)
+	kept := make([]oomEvent, 0, len(t.events))
+	for _, e := range t.events {
+		if e.Time >= cutoff {
+			kept = append(kept, e)
+		}
+	}
+	t.events = kept
+	out := make([]oomEvent, len(kept))
+	copy(out, kept)
+	return out
+}
+
+var oomState = &oomTracker{}
+
+// dockerEvent is the subset of `docker events --format {{json .}}` we read.
+type dockerEvent struct {
+	Time  int64 `json:"time"`
+	Actor struct {
+		ID         string            `json:"ID"`
+		Attributes map[string]string `json:"Attributes"`
+	} `json:"Actor"`
+}
+
+// watchOOMEvents streams container OOM events from the Docker daemon and records
+// them in oomState, reconnecting if the stream drops (e.g. daemon restart). It
+// is read-only: it only consumes the event stream over the Docker socket the
+// agent already holds — no host access, no mutation.
+func watchOOMEvents(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		streamOOMOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+func streamOOMOnce(ctx context.Context) {
+	cmd := exec.CommandContext(ctx, "docker", "events",
+		"--filter", "type=container", "--filter", "event=oom",
+		"--format", "{{json .}}")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		slog.Error("oom watch: stdout pipe", "err", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		slog.Error("oom watch: start", "err", err)
+		return
+	}
+	scanner := bufio.NewScanner(stdout)
+	// A container with a very large label/attribute set could emit an event
+	// line past bufio's default 64 KiB token cap; without a larger buffer that
+	// would end the scan and trigger a reconnect loop. 1 MiB is far beyond any
+	// realistic event line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var ev dockerEvent
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			continue
+		}
+		e := oomEvent{
+			Name: ev.Actor.Attributes["name"],
+			ID:   ev.Actor.ID,
+			Time: ev.Time,
+		}
+		if e.Time == 0 {
+			e.Time = time.Now().Unix()
+		}
+		oomState.add(e)
+		slog.Warn("container OOM-killed", "container", e.Name, "id", e.ID)
+	}
+	// Wait reaps the process; its error is expected on ctx cancel / stream end.
+	_ = cmd.Wait()
+}
+
+// handleOOMEvents returns the OOM-kill events seen in the last hour.
+func handleOOMEvents(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"events": oomState.recent(time.Now().Unix())})
+}

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -213,6 +213,9 @@ func (e *Engine) evaluate() {
 	// Dependency health checks
 	e.checkDependencyHealth()
 
+	// Out-of-memory kills (from the agent's Docker event stream)
+	e.checkOOM()
+
 	// ---- Trend alerts: every 10th tick (~5 minutes) ----
 	if e.snapshotTick%10 == 0 {
 		e.checkTrends()
@@ -694,6 +697,43 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 			}
 		}
 		e.prevStates[name] = cs
+	}
+}
+
+// checkOOM raises a critical alert for any managed container the agent reports
+// as OOM-killed within the last hour, and resolves it for services with no
+// recent OOM. Docker's per-container OOMKilled flag reads false again as soon
+// as the restart policy brings the container back, so the agent instead streams
+// the daemon's `oom` events; this consumes that recent-events list. The alert
+// therefore lingers ~1 h after the last kill, then self-clears.
+func (e *Engine) checkOOM() {
+	events, err := docker.OOMEvents()
+	if err != nil {
+		return // agent unreachable this tick — leave existing alerts untouched
+	}
+
+	// container name -> service ID
+	nameToService := map[string]string{}
+	for _, tmpl := range e.registry.All() {
+		for _, name := range tmpl.ContainerNames {
+			nameToService[name] = tmpl.ID
+		}
+	}
+
+	oomedService := map[string]string{} // serviceID -> a container name that OOM'd
+	for _, ev := range events {
+		if svc, ok := nameToService[ev.Name]; ok {
+			oomedService[svc] = ev.Name
+		}
+	}
+
+	for _, tmpl := range e.registry.All() {
+		if name, ok := oomedService[tmpl.ID]; ok {
+			e.upsert("oom_killed", tmpl.ID, model.SeverityCritical,
+				"Container %s ran out of memory and was killed", name)
+		} else {
+			e.resolve("oom_killed", tmpl.ID)
+		}
 	}
 }
 

--- a/truffels-api/internal/docker/status.go
+++ b/truffels-api/internal/docker/status.go
@@ -85,6 +85,43 @@ func Stats() ([]ContainerResourceStats, error) {
 	return agentClient.stats()
 }
 
+// OOMEvent is one container OOM-kill the agent observed on the Docker event
+// stream. Time is unix seconds.
+type OOMEvent struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	Time int64  `json:"time"`
+}
+
+// OOMEvents returns the container OOM-kill events the agent has seen in the last
+// hour. Returns nil, nil when no agent is configured.
+func OOMEvents() ([]OOMEvent, error) {
+	if agentClient == nil {
+		return nil, nil
+	}
+	return agentClient.oomEvents()
+}
+
+func (ai *AgentInspector) oomEvents() ([]OOMEvent, error) {
+	resp, err := ai.httpClient.Get(ai.agentURL + "/v1/oom-events")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("agent oom-events: HTTP %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Events []OOMEvent `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("agent oom-events decode: %w", err)
+	}
+	return body.Events, nil
+}
+
 func (ai *AgentInspector) stats() ([]ContainerResourceStats, error) {
 	resp, err := ai.httpClient.Get(ai.agentURL + "/v1/stats")
 	if err != nil {

--- a/truffels-web/src/pages/AlertsPage.tsx
+++ b/truffels-web/src/pages/AlertsPage.tsx
@@ -9,6 +9,7 @@ const ALERT_TYPE_LABELS: Record<string, string> = {
   high_temp: 'High Temperature',
   service_unhealthy: 'Service Unhealthy',
   restart_loop: 'Restart Loop',
+  oom_killed: 'Out of Memory',
   upstream_unhealthy: 'Upstream Unhealthy',
   memory_trend: 'Memory Trend',
   disk_trend: 'Disk Trend',

--- a/truffels-web/src/pages/ServiceDetailPage.tsx
+++ b/truffels-web/src/pages/ServiceDetailPage.tsx
@@ -550,7 +550,7 @@ function OverviewTab({ svc, updateCheck, serviceId }: { svc: ServiceInstance; up
                   <td className="py-2 pr-4"><StatusBadge status={c.status} /></td>
                   <td className="py-2 pr-4">{c.health ? <StatusBadge status={c.health} /> : <span className="text-gray-500">-</span>}</td>
                   <td className="py-2 pr-4 text-gray-400">{c.status === 'running' ? formatUptime(c.started_at) : '-'}</td>
-                  <td className="py-2 pr-4 text-gray-400">{c.restart_count}</td>
+                  <td className={`py-2 pr-4 ${c.restart_count > 3 ? 'text-red-400' : c.restart_count > 0 ? 'text-yellow-400' : 'text-gray-400'}`}>{c.restart_count}</td>
                   <td className="py-2 text-gray-500 text-xs font-mono truncate max-w-xs">{c.image.split('@')[0]}</td>
                 </tr>
               ))}


### PR DESCRIPTION
Three monitoring/UX improvements, reviewed locally by agy + qwen before push.

## 1. Container OOM detection (the main one)
Docker's per-container `OOMKilled` flag reads false again the instant the restart policy brings a container back — so a node that OOM-loops (as digibyted did during its IBD) shows no OOM evidence on inspect; the kill was only visible in the kernel log. Now:
- **agent** streams the daemon's `oom` events (read-only, over the Docker socket it already holds), keeps the last hour, exposes `GET /v1/oom-events`.
- **api** alerts engine polls it each tick, maps the container to its service, raises a critical `oom_killed` alert (self-clears ~1h after the last kill).
- **web** AlertsPage labels it "Out of Memory".

## 2. Restart-count coloring on the service detail page
The container table there showed `restart_count` in flat gray; it now uses the same red-above-3 / yellow-above-0 thresholds the monitoring table already applies.

## 3. DGB config section headers
`renderDigibyteConf` now groups its lines under the same `# --- Section ---` headers Bitcoin Core's rendered config uses, so the (now editable) DigiByte config reads like bitcoind's. Cosmetic — same keys/values.

## Verification
- Gates green: agent + api build/gofmt/vet/tests, web tsc.
- Local review (agy + qwen): qwen flagged 3 items — a scanner 64KiB-limit hardening (applied); event-replay-on-reconnect and alert-loss-on-agent-down (both rejected: `docker events` without `--since` doesn't replay, and the agent's 1h retention covers transient unreachability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA