### PR TITLE
catalog: Bitcoin Cash Node (BCHN) entry — BCH stack phase 1

### DIFF
--- a/dockerfiles/bchn/Dockerfile
+++ b/dockerfiles/bchn/Dockerfile
@@ -1,0 +1,47 @@
+# Bitcoin Cash Node (BCHN) — built from official release binaries.
+#
+# There is no official BCHN Docker image. BCHN publishes signed release
+# tarballs at download.bitcoincashnode.org; we pin the exact aarch64 tarball
+# by SHA256.
+#
+# BCHN only serves the current release under /releases/latest/ (no versioned
+# directory — verified 2026-08-22, the versioned path 404s). The SHA256 pin
+# below therefore doubles as the version guard: if "latest" ever moves past
+# 29.1.0, this build fails loudly at the checksum check instead of silently
+# shipping a different node.
+#
+# The checksum is from the maintainer-signed SHA256SUMS.29.1.0.asc.Calin_Culianu.
+# Cross-checked: the x86_64 line in that same signed file matches the value the
+# BCH reference build verified via GPG against Calin Culianu's key
+# (D465135F97D0047E18E99DC321810A542031C02C).
+FROM debian:bookworm-slim AS fetch
+
+ARG BCHN_VERSION=29.1.0
+ARG BCHN_SHA256=15c5c0400c828d6690970200ad59c18207313c7047b29d571f7e9870d06300ea
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN set -eu; \
+    url="https://download.bitcoincashnode.org/releases/latest/linux/bitcoin-cash-node-${BCHN_VERSION}-aarch64-linux-gnu.tar.gz"; \
+    curl -fsSL -o bchn.tar.gz "$url"; \
+    echo "${BCHN_SHA256}  bchn.tar.gz" | sha256sum -c -; \
+    tar -xzf bchn.tar.gz; \
+    mkdir -p /out; \
+    cp "bitcoin-cash-node-${BCHN_VERSION}/bin/bitcoind" "bitcoin-cash-node-${BCHN_VERSION}/bin/bitcoin-cli" /out/
+
+FROM debian:bookworm-slim
+
+# BCHN release binaries link against the usual C/C++ runtime; the slim base
+# provides libstdc++6 and friends. No boost/libevent packages needed.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libstdc++6 && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 1000 -m -s /bin/bash bch
+
+COPY --from=fetch /out/bitcoind /out/bitcoin-cli /usr/local/bin/
+
+USER 1000:1000
+WORKDIR /data
+ENTRYPOINT ["bitcoind"]

--- a/truffels-agent/catalog/bchn.json
+++ b/truffels-agent/catalog/bchn.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "id": "bchn",
+  "display_name": "Bitcoin Cash Node",
+  "description": "Bitcoin Cash Node (BCHN), pruned. Runs with listen=0 and no wallet; feeds a solo Stratum pool over the stack network.",
+  "role": "chain-node",
+  "implementation": "bitcoin-cash-node",
+  "chain": "bch",
+  "stack": "bch",
+  "build": {
+    "dockerfile": "dockerfiles/bchn/Dockerfile",
+    "version": "29.1.0",
+    "sha256": "15c5c0400c828d6690970200ad59c18207313c7047b29d571f7e9870d06300ea"
+  },
+  "containers": [
+    {
+      "name": "node",
+      "memory_limit_mb": 4096,
+      "user": "1000:1000",
+      "entrypoint": [
+        "bitcoind",
+        "-conf=/bch.conf",
+        "-datadir=/data",
+        "-printtoconsole"
+      ],
+      "ports": [],
+      "volumes": [
+        {
+          "kind": "data",
+          "mount": "/data"
+        },
+        {
+          "kind": "config",
+          "file": "bch.conf",
+          "mount": "/bch.conf",
+          "ro": true
+        }
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "bitcoin-cli",
+          "-conf=/bch.conf",
+          "-datadir=/data",
+          "-getinfo"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "60s"
+      }
+    }
+  ],
+  "chain_info": {
+    "p2p_port": 8333,
+    "rpc_port": 8332,
+    "rpc_style": "bitcoin-core",
+    "sync_probe": [
+      "bitcoin-cli",
+      "-conf=/bch.conf",
+      "-datadir=/data",
+      "getblockchaininfo"
+    ]
+  },
+  "resources": {
+    "min_disk_gb": 18,
+    "memory_floor_mb": 2048
+  }
+}

--- a/truffels-agent/catalog_config.go
+++ b/truffels-agent/catalog_config.go
@@ -20,6 +20,8 @@ func RenderConfig(id string, params map[string]any, creds *stackCreds) (map[stri
 	switch id {
 	case "digibyted":
 		return renderDigibyteConf(creds)
+	case "bchn":
+		return renderBchnConf(creds)
 	case "ckpool-dgb":
 		return renderCkpoolDGBConf(params, creds)
 	case "ckstats-db-dgb":
@@ -159,6 +161,57 @@ func renderDigibyteConf(creds *stackCreds) (map[string][]byte, error) {
 	}
 
 	return map[string][]byte{"digibyte.conf": []byte(b.String())}, nil
+}
+
+// renderBchnConf renders the Bitcoin Cash Node config. BCHN is Bitcoin-Core
+// lineage but NOT Bitcoin Core — only options confirmed present in `bitcoind
+// -help` for this build are used here (no rpcwhitelist etc.). The node is
+// pruned, wallet-less, and does not accept inbound P2P (listen=0): a pruned
+// solo-mining node needs neither inbound peers nor a wallet, since the reward
+// is written straight into the coinbase by the pool.
+func renderBchnConf(creds *stackCreds) (map[string][]byte, error) {
+	var b strings.Builder
+	b.WriteString("# Project Truffels — Bitcoin Cash Node\n")
+	b.WriteString("# Generated from the catalog. Do not edit by hand.\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Chain ---\n")
+	b.WriteString("server=1\n")
+	b.WriteString("disablewallet=1\n")
+	// Pruned to ~5 GB of block files. BCH is a Bitcoin-height chain (~860k
+	// blocks), so the in-memory block index stays small; pruning keeps the
+	// disk footprint low without a large RAM cost.
+	b.WriteString("prune=5000\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Network ---\n")
+	// No inbound P2P: a pruned node serves no historical blocks to peers, so
+	// listening only costs bandwidth. Outbound connections still drive the sync.
+	b.WriteString("listen=0\n")
+	b.WriteString("maxconnections=25\n")
+	b.WriteString("maxuploadtarget=5000\n")
+	b.WriteString("\n")
+	b.WriteString("# --- Performance ---\n")
+	b.WriteString("dbcache=512\n")
+	b.WriteString("\n")
+	b.WriteString("# --- ZMQ ---\n")
+	// ZMQ over polling so the pool sees block changes immediately and never
+	// mines shares on a stale template.
+	b.WriteString("zmqpubhashblock=tcp://0.0.0.0:28332\n")
+
+	// When part of a stack, expose RPC so the pool can reach the node with the
+	// shared credential over the stack network. rpcallowip uses the broad
+	// private ranges; actual reachability stays scoped to that network.
+	if creds != nil {
+		b.WriteString("\n")
+		b.WriteString("# --- RPC ---\n")
+		b.WriteString("rpcuser=" + creds.User + "\n")
+		b.WriteString("rpcpassword=" + creds.Pass + "\n")
+		b.WriteString("rpcbind=0.0.0.0\n")
+		b.WriteString("rpcallowip=172.16.0.0/12\n")
+		b.WriteString("rpcallowip=10.0.0.0/8\n")
+		b.WriteString("rpcport=8332\n")
+	}
+
+	return map[string][]byte{"bch.conf": []byte(b.String())}, nil
 }
 
 // safeConfigKey validates that a config file name is a safe bare filename:

--- a/truffels-agent/catalog_config_test.go
+++ b/truffels-agent/catalog_config_test.go
@@ -133,3 +133,50 @@ func TestRenderCkstatsEnvs(t *testing.T) {
 		t.Error("ckstats-db-dgb without creds should error")
 	}
 }
+
+func TestRenderConfigBchn(t *testing.T) {
+	files, err := RenderConfig("bchn", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("RenderConfig: %v", err)
+	}
+	conf, ok := files["bch.conf"]
+	if !ok {
+		t.Fatal("bch.conf is missing")
+	}
+	s := string(conf)
+	for _, want := range []string{"server=1", "disablewallet=1", "prune=5000", "listen=0", "dbcache=512", "zmqpubhashblock="} {
+		if !strings.Contains(s, want) {
+			t.Errorf("bch.conf missing %q:\n%s", want, s)
+		}
+	}
+	// BCHN is not Bitcoin Core: rpcwhitelist does not exist there and sends the
+	// node into a restart loop. It must never appear.
+	if strings.Contains(s, "rpcwhitelist") {
+		t.Error("rpcwhitelist must never be set — it does not exist in BCHN")
+	}
+	// Without stack creds there is no RPC password line.
+	if strings.Contains(s, "rpcpassword=") {
+		t.Error("bch.conf must not contain rpcpassword when rendered without creds")
+	}
+	// Guard against ever committing a payout address into the node config.
+	if strings.Contains(s, "bitcoincash:") || strings.Contains(s, "addr") {
+		t.Errorf("bch.conf must not contain an address:\n%s", s)
+	}
+}
+
+func TestRenderConfigBchnStacked(t *testing.T) {
+	creds := &stackCreds{User: "truffels", Pass: "deadbeefcafe"}
+	files, err := RenderConfig("bchn", map[string]any{}, creds)
+	if err != nil {
+		t.Fatalf("RenderConfig: %v", err)
+	}
+	s := string(files["bch.conf"])
+	for _, want := range []string{
+		"rpcuser=truffels", "rpcpassword=deadbeefcafe",
+		"rpcbind=0.0.0.0", "rpcallowip=172.16.0.0/12", "rpcport=8332",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("stacked bch.conf missing %q:\n%s", want, s)
+		}
+	}
+}

--- a/truffels-agent/handlers_catalog_test.go
+++ b/truffels-agent/handlers_catalog_test.go
@@ -326,3 +326,17 @@ func TestEnsureStackSecretIsStable(t *testing.T) {
 		t.Error("invalid stack name was accepted")
 	}
 }
+
+func TestBchnHasSyncProbe(t *testing.T) {
+	cat, err := LoadCatalog()
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	e := cat["bchn"]
+	if e.ChainInfo == nil || len(e.ChainInfo.SyncProbe) == 0 {
+		t.Fatal("bchn has no chain_info.sync_probe")
+	}
+	if e.ChainInfo.SyncProbe[len(e.ChainInfo.SyncProbe)-1] != "getblockchaininfo" {
+		t.Errorf("sync probe should end in getblockchaininfo, got %v", e.ChainInfo.SyncProbe)
+	}
+}


### PR DESCRIPTION
Phase 1 of the BCH stack: a pruned, wallet-less **Bitcoin Cash Node (BCHN)** as a catalog entry, mirroring the DigiByte node. No pool or dashboard yet — just the node.

## What's in it
- `dockerfiles/bchn/Dockerfile` — official BCHN 29.1.0 aarch64 release binaries, **SHA256-pinned** (`15c5c040…`, cross-checked against the maintainer-signed `SHA256SUMS.29.1.0.asc.Calin_Culianu`; the x86_64 line in that file matches the reference build's GPG-verified value). BCHN only serves `/releases/latest/`, so the SHA pin doubles as the version guard.
- `truffels-agent/catalog/bchn.json` — pruned (`prune=5000`), `listen=0`, no host ports; RPC/ZMQ reachable only over the stack network. `memory_limit 4 GB`, `min_disk 18 GB`.
- `renderBchnConf` — renders `bch.conf` using only options confirmed in this build's `bitcoind -help`. **BCHN is not Bitcoin Core**: `rpcwhitelist` is deliberately absent (it sent the reference node into a restart loop).
- Tests: rendered config, stacked RPC lines, absence of `rpcwhitelist`/addresses, and the `getblockchaininfo` sync probe.

## Money-safety / privacy
- **No payout address anywhere** — the BCH address is an install parameter of the *pool* entry (phase 2), never committed.
- No VPS / WireGuard / IP / hostname / PII. RPC creds come from the runtime stack secret, not literals.

## Verification
- Built the image on-device: SHA verified, `bitcoind -version` → v29.1.0, all 13 config options present in `-help`, `rpcwhitelist` absent.
- Gates green: agent build/gofmt/vet/tests.
- Reviewed locally by **agy + qwen** (money-adjacent). qwen: memory/disk headroom + missing tests (both applied); getinfo-healthcheck concern verified false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA