### PR TITLE
perf: fix Services-page congestion (batch inspects, sync cache, connection pool)

### DIFF
--- a/truffels-agent/exec_test.go
+++ b/truffels-agent/exec_test.go
@@ -31,21 +31,33 @@ func dockerMissing() bool {
 	return err != nil
 }
 
-// --- inspectContainer ---
+// --- handleInspect ---
 
-func TestInspectContainer_ReportsNotFoundWhenTheCommandFails(t *testing.T) {
-	cs := inspectContainer("truffels-bitcoind")
+func TestHandleInspect_ReportsNotFoundWhenTheCommandFails(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/inspect",
+		strings.NewReader(`{"containers":["truffels-bitcoind"]}`))
+	w := httptest.NewRecorder()
+	handleInspect(w, req)
 
-	if cs.Name != "truffels-bitcoind" {
-		t.Errorf("name = %q, want the requested container", cs.Name)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	if cs.Status == "" {
-		t.Error("status must never be empty — every return path sets it")
+	var states []containerState
+	if err := json.Unmarshal(w.Body.Bytes(), &states); err != nil {
+		t.Fatalf("decode: %v", err)
 	}
+	if len(states) != 1 || states[0].Name != "truffels-bitcoind" {
+		t.Fatalf("states = %+v, want one entry for the requested container", states)
+	}
+	if states[0].Status == "" {
+		t.Error("status must never be empty — every path sets it")
+	}
+	// With no docker present the batched inspect returns nothing, and the
+	// handler must map the absent container to not_found (never crash or omit).
 	if dockerMissing() {
-		if cs.Status != "not_found" || cs.Health != "unknown" {
+		if states[0].Status != "not_found" || states[0].Health != "unknown" {
 			t.Errorf("docker unavailable: got status=%q health=%q, want not_found/unknown",
-				cs.Status, cs.Health)
+				states[0].Status, states[0].Health)
 		}
 	}
 }

--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -152,6 +152,7 @@ type containerState struct {
 }
 
 type inspectResult struct {
+	Name  string `json:"Name"`
 	State struct {
 		Status    string `json:"Status"`
 		StartedAt string `json:"StartedAt"`
@@ -335,6 +336,19 @@ func handleInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Inspect all allowed containers in ONE `docker inspect` call. The handler
+	// used to fork one docker CLI process per container, sequentially; under
+	// the Services page's fan-out that meant dozens of concurrent forks and
+	// dockerd contention that pushed inspect latency past the caller's timeout,
+	// so every service read back as "unknown". One batched call collapses that.
+	allowed := make([]string, 0, len(req.Containers))
+	for _, name := range req.Containers {
+		if isAllowedContainer(name) {
+			allowed = append(allowed, name)
+		}
+	}
+	found := batchInspect(allowed)
+
 	states := make([]containerState, 0, len(req.Containers))
 	for _, name := range req.Containers {
 		if !isAllowedContainer(name) {
@@ -342,38 +356,57 @@ func handleInspect(w http.ResponseWriter, r *http.Request) {
 			states = append(states, containerState{Name: name, Status: "denied", Health: "unknown"})
 			continue
 		}
-		states = append(states, inspectContainer(name))
+		if cs, ok := found[name]; ok {
+			states = append(states, cs)
+		} else {
+			states = append(states, containerState{Name: name, Status: "not_found", Health: "unknown"})
+		}
 	}
 
 	writeJSON(w, 200, states)
 }
 
-func inspectContainer(name string) containerState {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+// batchInspect inspects every given container in a single `docker inspect` call
+// and returns the states keyed by container name. Missing containers are simply
+// absent from the map: `docker inspect` still prints the containers it found to
+// stdout when some names don't exist (it just exits non-zero), so the partial
+// output is honored and the error is ignored.
+func batchInspect(names []string) map[string]containerState {
+	result := make(map[string]containerState, len(names))
+	if len(names) == 0 {
+		return result
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()
 
-	out, err := runStdout(ctx, "docker", "inspect", "--format", "{{json .}}", name)
-	if err != nil {
-		return containerState{Name: name, Status: "not_found", Health: "unknown"}
-	}
+	args := append([]string{"inspect", "--format", "{{json .}}"}, names...)
+	out, _ := runStdout(ctx, "docker", args...)
 
-	var ir inspectResult
-	if err := json.Unmarshal([]byte(out), &ir); err != nil {
-		slog.Error("parse inspect", "container", name, "err", err)
-		return containerState{Name: name, Status: "unknown", Health: "unknown"}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var ir inspectResult
+		if err := json.Unmarshal([]byte(line), &ir); err != nil {
+			continue
+		}
+		name := strings.TrimPrefix(ir.Name, "/")
+		if name == "" {
+			continue
+		}
+		cs := containerState{
+			Name:         name,
+			Status:       ir.State.Status,
+			RestartCount: ir.RestartCount,
+			StartedAt:    ir.State.StartedAt,
+			Image:        ir.Config.Image,
+		}
+		if ir.State.Health != nil && ir.State.Status == "running" {
+			cs.Health = ir.State.Health.Status
+		}
+		result[name] = cs
 	}
-
-	cs := containerState{
-		Name:         name,
-		Status:       ir.State.Status,
-		RestartCount: ir.RestartCount,
-		StartedAt:    ir.State.StartedAt,
-		Image:        ir.Config.Image,
-	}
-	if ir.State.Health != nil && ir.State.Status == "running" {
-		cs.Health = ir.State.Health.Status
-	}
-	return cs
+	return result
 }
 
 // --- Image/Build Handlers ---

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 	"time"
 
+	"truffels-api/internal/catalog"
 	"truffels-api/internal/docker"
 	"truffels-api/internal/metrics"
 	"truffels-api/internal/model"
 	"truffels-api/internal/service"
 	"truffels-api/internal/store"
+	"truffels-api/internal/syncstatus"
 )
 
 type Engine struct {
@@ -72,6 +74,19 @@ type Engine struct {
 	// goroutine finishes. Test-only synchronization hook so tests can wait
 	// for the goroutine instead of sleeping; production code never sets it.
 	reclaimDone chan struct{}
+
+	// Sync-status cache: the engine refreshes the chain-node sync progress on
+	// its tick and publishes it here, so the Services handler reads a cached
+	// value instead of running a live probe (a docker exec into an IBD-busy
+	// node) on the request path. Both are nil until SetSyncCache wires them,
+	// which keeps the refresh off in tests that construct a bare engine.
+	catalogClient *catalog.Client
+	syncCache     *syncstatus.Cache
+
+	// syncSlot is a one-token guard: at most one refreshSyncCache runs at a
+	// time and it never blocks evaluate(). A refresh that outlives the 30s
+	// tick simply causes the next tick to skip launching another.
+	syncSlot chan struct{}
 }
 
 func NewEngine(s *store.Store, r *service.Registry, c *metrics.Collector, compose *docker.ComposeClient) *Engine {
@@ -215,6 +230,11 @@ func (e *Engine) evaluate() {
 
 	// Out-of-memory kills (from the agent's Docker event stream)
 	e.checkOOM()
+
+	// Refresh the Services page's cached chain-sync progress off the request
+	// path. Launched on its own goroutine and guarded by syncSlot so a slow
+	// probe never delays the alert checks above or the metric snapshot.
+	e.launchSyncRefresh()
 
 	// ---- Trend alerts: every 10th tick (~5 minutes) ----
 	if e.snapshotTick%10 == 0 {
@@ -734,6 +754,60 @@ func (e *Engine) checkOOM() {
 		} else {
 			e.resolve("oom_killed", tmpl.ID)
 		}
+	}
+}
+
+// SetSyncCache wires the catalog client and sync-status cache the engine
+// publishes chain-node progress into. Call it once after NewEngine, before
+// Start. Without it the engine simply does not refresh the cache (tests that
+// build a bare engine keep the probe off).
+func (e *Engine) SetSyncCache(cc *catalog.Client, cache *syncstatus.Cache) {
+	e.catalogClient = cc
+	e.syncCache = cache
+	e.syncSlot = make(chan struct{}, 1)
+}
+
+// launchSyncRefresh starts a background refresh unless one is already running
+// or the cache is not wired. It never blocks the caller (evaluate()).
+func (e *Engine) launchSyncRefresh() {
+	if e.catalogClient == nil || e.syncCache == nil || e.syncSlot == nil {
+		return
+	}
+	select {
+	case e.syncSlot <- struct{}{}:
+		go func() {
+			defer func() { <-e.syncSlot }()
+			e.refreshSyncCache()
+		}()
+	default:
+		// A previous refresh is still running; skip this tick.
+	}
+}
+
+// refreshSyncCache probes every running catalog chain node's sync progress and
+// publishes it to the cache. A probe error leaves the previous value in place
+// (stale, not wrong) rather than blanking the progress bar while the agent or
+// node is briefly unreachable. Stopped nodes are skipped, so the handler — which
+// only reads the cache for running services — never shows stale progress.
+func (e *Engine) refreshSyncCache() {
+	for _, tmpl := range e.registry.All() {
+		entry, ok := e.catalogClient.Get(tmpl.ID)
+		if !ok || entry.ChainInfo == nil || len(entry.ChainInfo.SyncProbe) == 0 {
+			continue
+		}
+		if len(tmpl.ContainerNames) == 0 {
+			continue
+		}
+		cs, err := docker.InspectContainer(tmpl.ContainerNames[0])
+		if err != nil || cs.Status != "running" {
+			continue
+		}
+		status, err := e.catalogClient.ChainProbe(tmpl.ID)
+		if err != nil {
+			continue // keep last-good value
+		}
+		e.syncCache.Set(tmpl.ID, syncstatus.FromChainStatus(
+			status.Blocks, status.Headers, status.VerificationProgress, status.InitialBlockDownload))
 	}
 }
 

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -791,6 +791,14 @@ func (e *Engine) launchSyncRefresh() {
 // only reads the cache for running services — never shows stale progress.
 func (e *Engine) refreshSyncCache() {
 	for _, tmpl := range e.registry.All() {
+		// Bail promptly on shutdown: a full refresh is several ChainProbes, each
+		// up to the client read timeout, so without this it would keep hitting
+		// the agent for minutes while the API is being torn down.
+		select {
+		case <-e.stopCh:
+			return
+		default:
+		}
 		entry, ok := e.catalogClient.Get(tmpl.ID)
 		if !ok || entry.ChainInfo == nil || len(entry.ChainInfo.SyncProbe) == 0 {
 			continue
@@ -799,7 +807,13 @@ func (e *Engine) refreshSyncCache() {
 			continue
 		}
 		cs, err := docker.InspectContainer(tmpl.ContainerNames[0])
-		if err != nil || cs.Status != "running" {
+		if err != nil {
+			continue // unknown state — keep the last-good value
+		}
+		if cs.Status != "running" {
+			// Stopped: clear the entry so a later restart doesn't flash the
+			// previous run's stale sync percentage before the next probe.
+			e.syncCache.Set(tmpl.ID, nil)
 			continue
 		}
 		status, err := e.catalogClient.ChainProbe(tmpl.ID)

--- a/truffels-api/internal/api/dashboard.go
+++ b/truffels-api/internal/api/dashboard.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"truffels-api/internal/docker"
 	"truffels-api/internal/model"
 )
 
@@ -39,10 +38,12 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// Host metrics
 	host := s.collector.Collect()
 
-	// Service states
+	// Service states — one batched inspect across all services, not one per.
+	tmpls := s.registry.All()
+	byName := inspectAllContainers(tmpls)
 	var services []dashboardService
-	for _, tmpl := range s.registry.All() {
-		containers := docker.InspectContainers(tmpl.ContainerNames)
+	for _, tmpl := range tmpls {
+		containers := containersFor(tmpl, byName)
 		state := deriveState(containers)
 		services = append(services, dashboardService{
 			ID:          tmpl.ID,

--- a/truffels-api/internal/api/electrs_stats.go
+++ b/truffels-api/internal/api/electrs_stats.go
@@ -17,7 +17,10 @@ func (s *Server) handleElectrsStats(w http.ResponseWriter, r *http.Request) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get("http://truffels-electrs:4224/")
 	if err != nil {
-		writeError(w, http.StatusServiceUnavailable, "electrs unreachable: "+err.Error())
+		// A stopped electrs has no container, so Docker's DNS returns
+		// "no such host"; surface that as a plain not-running state instead
+		// of a raw resolver error.
+		writeError(w, http.StatusServiceUnavailable, "electrs is not running")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/truffels-api/internal/api/handlers_test.go
+++ b/truffels-api/internal/api/handlers_test.go
@@ -28,7 +28,7 @@ func newTestServer(t *testing.T) (*Server, *store.Store) {
 	reg := service.NewRegistry("/srv/truffels/compose", "", "", nil, nil)
 	a := auth.New(st)
 
-	srv := NewServer(reg, st, nil, nil, a, nil, nil, nil, "test")
+	srv := NewServer(reg, st, nil, nil, a, nil, nil, nil, nil, "test")
 	return srv, st
 }
 

--- a/truffels-api/internal/api/monitoring.go
+++ b/truffels-api/internal/api/monitoring.go
@@ -28,11 +28,12 @@ func (s *Server) handleMonitoring(w http.ResponseWriter, r *http.Request) {
 
 	since := time.Now().Add(-time.Duration(hours) * time.Hour)
 
-	// Container states from all services
+	// Container states from all services — one batched inspect, not one per.
+	tmpls := s.registry.All()
+	byName := inspectAllContainers(tmpls)
 	var containers []model.MonitoringContainer
-	for _, tmpl := range s.registry.All() {
-		states := docker.InspectContainers(tmpl.ContainerNames)
-		for _, cs := range states {
+	for _, tmpl := range tmpls {
+		for _, cs := range containersFor(tmpl, byName) {
 			containers = append(containers, model.MonitoringContainer{
 				Name:         cs.Name,
 				ServiceID:    tmpl.ID,

--- a/truffels-api/internal/api/router.go
+++ b/truffels-api/internal/api/router.go
@@ -15,6 +15,7 @@ import (
 	"truffels-api/internal/metrics"
 	"truffels-api/internal/service"
 	"truffels-api/internal/store"
+	"truffels-api/internal/syncstatus"
 	"truffels-api/internal/updates"
 )
 
@@ -27,10 +28,11 @@ type Server struct {
 	btcRPC        *bitcoin.Client
 	updateEngine  *updates.Engine
 	catalogClient *catalog.Client
+	syncCache     *syncstatus.Cache
 	Version       string
 }
 
-func NewServer(reg *service.Registry, st *store.Store, comp *docker.ComposeClient, coll *metrics.Collector, a *auth.Auth, btc *bitcoin.Client, ue *updates.Engine, cat *catalog.Client, version string) *Server {
+func NewServer(reg *service.Registry, st *store.Store, comp *docker.ComposeClient, coll *metrics.Collector, a *auth.Auth, btc *bitcoin.Client, ue *updates.Engine, cat *catalog.Client, sc *syncstatus.Cache, version string) *Server {
 	return &Server{
 		registry:      reg,
 		store:         st,
@@ -40,6 +42,7 @@ func NewServer(reg *service.Registry, st *store.Store, comp *docker.ComposeClien
 		btcRPC:        btc,
 		updateEngine:  ue,
 		catalogClient: cat,
+		syncCache:     sc,
 		Version:       version,
 	}
 }

--- a/truffels-api/internal/api/services.go
+++ b/truffels-api/internal/api/services.go
@@ -8,49 +8,69 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"truffels-api/internal/bitcoin"
 	"truffels-api/internal/docker"
 	"truffels-api/internal/model"
 )
 
 func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
-	// Each service's status is an independent set of docker inspects plus RPC/
-	// probe calls. Done sequentially the page grew to ~2s as the catalog stack
-	// added services; fan the per-service work out (bounded) so the wall-clock
-	// is the slowest single service, not their sum. Each goroutine writes its
-	// own slice index, so no shared state is mutated concurrently.
 	tmpls := s.registry.All()
-	services := make([]model.ServiceInstance, len(tmpls))
-	sem := make(chan struct{}, 8)
-	var wg sync.WaitGroup
-	for i, tmpl := range tmpls {
-		wg.Add(1)
-		go func(i int, tmpl model.ServiceTemplate) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
 
-			containers := docker.InspectContainers(tmpl.ContainerNames)
-			enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
-			svc := model.ServiceInstance{
-				Template:   tmpl,
-				State:      deriveState(containers),
-				Enabled:    enabled,
-				Containers: containers,
-			}
-			if !enabled && (svc.State == model.StateStopped || svc.State == model.StateUnknown) {
-				svc.State = model.StateDisabled
-			}
-			svc.DependencyIssues = s.checkDependencyIssues(tmpl)
-			s.enrichSyncInfo(&svc)
-			services[i] = svc
-		}(i, tmpl)
+	// Inspect every container across all services in ONE agent call, instead of
+	// one call per service plus one per dependency. Under the UI's 10s polling
+	// the old per-service fan-out fired ~20 concurrent inspects per response;
+	// each forks a docker CLI process on the agent, and the resulting dockerd
+	// contention pushed inspect latency past the client timeout, so every
+	// service read back "unknown". One batched inspect removes that entirely,
+	// and the sync progress now comes from a cache the alerts engine refreshes
+	// (no live chain probe on this path either), so the remaining per-service
+	// work is map lookups plus a SQLite read — fast enough to run inline.
+	var allNames []string
+	for _, tmpl := range tmpls {
+		allNames = append(allNames, tmpl.ContainerNames...)
 	}
-	wg.Wait()
+	byName := make(map[string]model.ContainerState, len(allNames))
+	for _, cs := range docker.InspectContainers(allNames) {
+		byName[cs.Name] = cs
+	}
+
+	// Bitcoin Core blockchain info feeds only the dependency checks; fetch it
+	// once for the whole response rather than once (or twice) per service.
+	var bcInfo *bitcoin.BlockchainInfo
+	if s.btcRPC != nil {
+		if info, err := s.btcRPC.GetBlockchainInfo(); err == nil {
+			bcInfo = info
+		}
+	}
+
+	services := make([]model.ServiceInstance, len(tmpls))
+	for i, tmpl := range tmpls {
+		containers := make([]model.ContainerState, 0, len(tmpl.ContainerNames))
+		for _, name := range tmpl.ContainerNames {
+			if cs, ok := byName[name]; ok {
+				containers = append(containers, cs)
+			} else {
+				containers = append(containers, model.ContainerState{Name: name, Status: "unknown", Health: "unknown"})
+			}
+		}
+		enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
+		svc := model.ServiceInstance{
+			Template:   tmpl,
+			State:      deriveState(containers),
+			Enabled:    enabled,
+			Containers: containers,
+		}
+		if !enabled && (svc.State == model.StateStopped || svc.State == model.StateUnknown) {
+			svc.State = model.StateDisabled
+		}
+		svc.DependencyIssues = s.checkDependencyIssues(tmpl, byName, bcInfo)
+		s.enrichSyncInfo(&svc)
+		services[i] = svc
+	}
 	writeJSON(w, http.StatusOK, services)
 }
 
@@ -62,7 +82,27 @@ func (s *Server) handleGetService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	containers := docker.InspectContainers(tmpl.ContainerNames)
+	// One batched inspect for this service's containers plus its dependencies',
+	// so checkDependencyIssues reads a map instead of probing each dependency.
+	var allNames []string
+	allNames = append(allNames, tmpl.ContainerNames...)
+	for _, depID := range tmpl.Dependencies {
+		if dep, ok := s.registry.Get(depID); ok {
+			allNames = append(allNames, dep.ContainerNames...)
+		}
+	}
+	byName := make(map[string]model.ContainerState, len(allNames))
+	for _, cs := range docker.InspectContainers(allNames) {
+		byName[cs.Name] = cs
+	}
+	containers := make([]model.ContainerState, 0, len(tmpl.ContainerNames))
+	for _, name := range tmpl.ContainerNames {
+		if cs, ok := byName[name]; ok {
+			containers = append(containers, cs)
+		} else {
+			containers = append(containers, model.ContainerState{Name: name, Status: "unknown", Health: "unknown"})
+		}
+	}
 	enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
 
 	svc := model.ServiceInstance{
@@ -74,7 +114,13 @@ func (s *Server) handleGetService(w http.ResponseWriter, r *http.Request) {
 	if !enabled && (svc.State == model.StateStopped || svc.State == model.StateUnknown) {
 		svc.State = model.StateDisabled
 	}
-	svc.DependencyIssues = s.checkDependencyIssues(tmpl)
+	var bcInfo *bitcoin.BlockchainInfo
+	if s.btcRPC != nil {
+		if info, err := s.btcRPC.GetBlockchainInfo(); err == nil {
+			bcInfo = info
+		}
+	}
+	svc.DependencyIssues = s.checkDependencyIssues(tmpl, byName, bcInfo)
 	s.enrichSyncInfo(&svc)
 	writeJSON(w, http.StatusOK, svc)
 }
@@ -91,34 +137,13 @@ func (s *Server) enrichSyncInfo(svc *model.ServiceInstance) {
 	case "mempool":
 		s.enrichMempoolSync(svc)
 	default:
-		s.enrichCatalogChainSync(svc)
-	}
-}
-
-// enrichCatalogChainSync fills SyncInfo for a running catalog chain node (e.g.
-// DigiByte Core) by asking the agent to run the entry's sync probe. Only entries
-// that declare a probe in chain_info are queried; anything else is a no-op.
-func (s *Server) enrichCatalogChainSync(svc *model.ServiceInstance) {
-	if s.catalogClient == nil {
-		return
-	}
-	e, ok := s.catalogClient.Get(svc.Template.ID)
-	if !ok || e.ChainInfo == nil || len(e.ChainInfo.SyncProbe) == 0 {
-		return
-	}
-	status, err := s.catalogClient.ChainProbe(svc.Template.ID)
-	if err != nil {
-		return
-	}
-	// Fully synced: bitcoin-core reports verificationprogress ~1 and IBD false.
-	if !status.InitialBlockDownload && status.VerificationProgress >= 0.9999 {
-		return
-	}
-	svc.SyncInfo = &model.SyncInfo{
-		Syncing:  true,
-		Progress: status.VerificationProgress,
-		Detail: fmt.Sprintf("%.2f%% (%s / %s blocks)",
-			status.VerificationProgress*100, formatInt(int(status.Blocks)), formatInt(int(status.Headers))),
+		// Catalog chain nodes (e.g. DigiByte, BCHN) read from the sync cache
+		// the alerts engine refreshes on its tick. The live probe — a docker
+		// exec into an IBD-busy node that can take many seconds — is kept off
+		// this request path so the Services page never blocks on it.
+		if s.syncCache != nil {
+			svc.SyncInfo = s.syncCache.Get(svc.Template.ID)
+		}
 	}
 }
 
@@ -555,18 +580,17 @@ func (s *Server) configRoot() string {
 }
 
 // checkDependencyIssues returns a list of unhealthy upstream dependencies.
-func (s *Server) checkDependencyIssues(tmpl model.ServiceTemplate) []string {
+// checkDependencyIssues reports why a service's dependencies would block it.
+// Container states come from the batch inspect the caller already ran (byName)
+// and blockchain info is fetched once per response (bcInfo) — neither issues a
+// per-dependency agent or RPC call.
+func (s *Server) checkDependencyIssues(tmpl model.ServiceTemplate, byName map[string]model.ContainerState, bcInfo *bitcoin.BlockchainInfo) []string {
 	var issues []string
-	if tmpl.RequiresUnpruned && s.btcRPC != nil {
-		if bcInfo, err := s.btcRPC.GetBlockchainInfo(); err == nil && bcInfo.Pruned {
-			issues = append(issues, "requires unpruned Bitcoin Core")
-		}
+	if tmpl.RequiresUnpruned && bcInfo != nil && bcInfo.Pruned {
+		issues = append(issues, "requires unpruned Bitcoin Core")
 	}
-	if tmpl.RequiresSynced && s.btcRPC != nil {
-		if bcInfo, err := s.btcRPC.GetBlockchainInfo(); err == nil && bcInfo.VerificationProgress < 0.9999 {
-			pct := bcInfo.VerificationProgress * 100
-			issues = append(issues, fmt.Sprintf("requires Bitcoin Core fully synced (%.2f%%)", pct))
-		}
+	if tmpl.RequiresSynced && bcInfo != nil && bcInfo.VerificationProgress < 0.9999 {
+		issues = append(issues, fmt.Sprintf("requires Bitcoin Core fully synced (%.2f%%)", bcInfo.VerificationProgress*100))
 	}
 	for _, depID := range tmpl.Dependencies {
 		depTmpl, ok := s.registry.Get(depID)
@@ -574,8 +598,8 @@ func (s *Server) checkDependencyIssues(tmpl model.ServiceTemplate) []string {
 			continue
 		}
 		for _, name := range depTmpl.ContainerNames {
-			cs, err := docker.InspectContainer(name)
-			if err != nil {
+			cs, ok := byName[name]
+			if !ok {
 				continue
 			}
 			if cs.Health == "unhealthy" || cs.Status == "exited" || cs.Status == "restarting" || cs.Status == "not_found" {

--- a/truffels-api/internal/api/services.go
+++ b/truffels-api/internal/api/services.go
@@ -17,6 +17,36 @@ import (
 	"truffels-api/internal/model"
 )
 
+// inspectAllContainers inspects every container of the given templates in ONE
+// batched agent call and returns the states keyed by container name. Every
+// polled endpoint that shows service state uses this so the agent sees a single
+// inspect per response instead of one call per service.
+func inspectAllContainers(tmpls []model.ServiceTemplate) map[string]model.ContainerState {
+	var allNames []string
+	for _, tmpl := range tmpls {
+		allNames = append(allNames, tmpl.ContainerNames...)
+	}
+	byName := make(map[string]model.ContainerState, len(allNames))
+	for _, cs := range docker.InspectContainers(allNames) {
+		byName[cs.Name] = cs
+	}
+	return byName
+}
+
+// containersFor returns the states for one template's containers, filling an
+// "unknown" placeholder for any the batch inspect did not return.
+func containersFor(tmpl model.ServiceTemplate, byName map[string]model.ContainerState) []model.ContainerState {
+	out := make([]model.ContainerState, 0, len(tmpl.ContainerNames))
+	for _, name := range tmpl.ContainerNames {
+		if cs, ok := byName[name]; ok {
+			out = append(out, cs)
+		} else {
+			out = append(out, model.ContainerState{Name: name, Status: "unknown", Health: "unknown"})
+		}
+	}
+	return out
+}
+
 func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
 	tmpls := s.registry.All()
 
@@ -29,14 +59,7 @@ func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
 	// and the sync progress now comes from a cache the alerts engine refreshes
 	// (no live chain probe on this path either), so the remaining per-service
 	// work is map lookups plus a SQLite read — fast enough to run inline.
-	var allNames []string
-	for _, tmpl := range tmpls {
-		allNames = append(allNames, tmpl.ContainerNames...)
-	}
-	byName := make(map[string]model.ContainerState, len(allNames))
-	for _, cs := range docker.InspectContainers(allNames) {
-		byName[cs.Name] = cs
-	}
+	byName := inspectAllContainers(tmpls)
 
 	// Bitcoin Core blockchain info feeds only the dependency checks; fetch it
 	// once for the whole response rather than once (or twice) per service.
@@ -49,14 +72,7 @@ func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
 
 	services := make([]model.ServiceInstance, len(tmpls))
 	for i, tmpl := range tmpls {
-		containers := make([]model.ContainerState, 0, len(tmpl.ContainerNames))
-		for _, name := range tmpl.ContainerNames {
-			if cs, ok := byName[name]; ok {
-				containers = append(containers, cs)
-			} else {
-				containers = append(containers, model.ContainerState{Name: name, Status: "unknown", Health: "unknown"})
-			}
-		}
+		containers := containersFor(tmpl, byName)
 		enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
 		svc := model.ServiceInstance{
 			Template:   tmpl,
@@ -84,25 +100,14 @@ func (s *Server) handleGetService(w http.ResponseWriter, r *http.Request) {
 
 	// One batched inspect for this service's containers plus its dependencies',
 	// so checkDependencyIssues reads a map instead of probing each dependency.
-	var allNames []string
-	allNames = append(allNames, tmpl.ContainerNames...)
+	inspectTmpls := []model.ServiceTemplate{tmpl}
 	for _, depID := range tmpl.Dependencies {
 		if dep, ok := s.registry.Get(depID); ok {
-			allNames = append(allNames, dep.ContainerNames...)
+			inspectTmpls = append(inspectTmpls, dep)
 		}
 	}
-	byName := make(map[string]model.ContainerState, len(allNames))
-	for _, cs := range docker.InspectContainers(allNames) {
-		byName[cs.Name] = cs
-	}
-	containers := make([]model.ContainerState, 0, len(tmpl.ContainerNames))
-	for _, name := range tmpl.ContainerNames {
-		if cs, ok := byName[name]; ok {
-			containers = append(containers, cs)
-		} else {
-			containers = append(containers, model.ContainerState{Name: name, Status: "unknown", Health: "unknown"})
-		}
-	}
+	byName := inspectAllContainers(inspectTmpls)
+	containers := containersFor(tmpl, byName)
 	enabled, _ := s.store.IsServiceEnabled(tmpl.ID)
 
 	svc := model.ServiceInstance{

--- a/truffels-api/internal/api/services_test.go
+++ b/truffels-api/internal/api/services_test.go
@@ -152,7 +152,7 @@ func newTestServerWithAgent(t *testing.T, agentState *mockAgentState) (*Server, 
 	// Set the global agent inspector to use our mock
 	docker.NewAgentInspector(mockSrv.URL)
 
-	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, "test")
+	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 
@@ -1454,7 +1454,7 @@ func newTestServerWithCollector(t *testing.T, agentState *mockAgentState, tempMi
 	_ = os.WriteFile(filepath.Join(procDir, "diskstats"), []byte(""), 0644)
 
 	coll := metrics.NewCollector(procDir, sysDir, diskDir)
-	srv := NewServer(reg, st, compose, coll, a, nil, nil, nil, "test")
+	srv := NewServer(reg, st, compose, coll, a, nil, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 
@@ -1620,7 +1620,7 @@ func newTestServerWithPullAgent(t *testing.T, agentState *mockAgentState, pullOu
 	compose := docker.NewComposeClient(mockSrv.URL)
 	docker.NewAgentInspector(mockSrv.URL)
 
-	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, "test")
+	srv := NewServer(reg, st, compose, nil, a, nil, nil, nil, nil, "test")
 	return srv, st, mockSrv
 }
 

--- a/truffels-api/internal/api/updates.go
+++ b/truffels-api/internal/api/updates.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"truffels-api/internal/docker"
 	"truffels-api/internal/model"
 )
 
@@ -285,6 +284,10 @@ func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
 		StartedAt      string `json:"started_at"`
 	}
 	var floating []floatingService
+	// One batched inspect for all services (this endpoint is polled every 5s);
+	// the floating-tag branch below reads the running image from this map
+	// instead of calling the agent once per floating-tag service.
+	byName := inspectAllContainers(s.registry.All())
 	for _, tmpl := range s.registry.All() {
 		if s.updateEngine.IsUpdating(tmpl.ID) {
 			updating[tmpl.ID] = true
@@ -297,20 +300,21 @@ func (s *Server) handleUpdateStatus(w http.ResponseWriter, r *http.Request) {
 		}
 		if tmpl.FloatingTag {
 			fs := floatingService{ID: tmpl.ID, DisplayName: tmpl.DisplayName}
-			// Get image and tag from running container
-			containers := docker.InspectContainers(tmpl.ContainerNames)
-			if len(containers) > 0 && containers[0].Image != "" {
-				img := containers[0].Image
-				// Strip digest
-				if at := strings.Index(img, "@"); at >= 0 {
-					img = img[:at]
+			// Read image and tag from the running container (from the batch).
+			if len(tmpl.ContainerNames) > 0 {
+				if cs, ok := byName[tmpl.ContainerNames[0]]; ok && cs.Image != "" {
+					img := cs.Image
+					// Strip digest
+					if at := strings.Index(img, "@"); at >= 0 {
+						img = img[:at]
+					}
+					fs.Image = img
+					// Extract tag as version
+					if colon := strings.LastIndex(img, ":"); colon >= 0 {
+						fs.CurrentVersion = img[colon+1:]
+					}
+					fs.StartedAt = cs.StartedAt
 				}
-				fs.Image = img
-				// Extract tag as version
-				if colon := strings.LastIndex(img, ":"); colon >= 0 {
-					fs.CurrentVersion = img[colon+1:]
-				}
-				fs.StartedAt = containers[0].StartedAt
 			}
 			floating = append(floating, fs)
 		}

--- a/truffels-api/internal/api/updates_test.go
+++ b/truffels-api/internal/api/updates_test.go
@@ -29,7 +29,7 @@ func newTestServerWithEngine(t *testing.T) (*Server, *store.Store, *updates.Engi
 	a := auth.New(st)
 	eng := updates.NewEngine(st, reg, nil)
 
-	srv := NewServer(reg, st, nil, nil, a, nil, eng, nil, "test")
+	srv := NewServer(reg, st, nil, nil, a, nil, eng, nil, nil, "test")
 	return srv, st, eng
 }
 

--- a/truffels-api/internal/docker/status.go
+++ b/truffels-api/internal/docker/status.go
@@ -22,6 +22,15 @@ func NewAgentInspector(agentURL string) *AgentInspector {
 		agentURL: agentURL,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
+			// The default transport keeps only 2 idle connections per host, so
+			// bursts of agent calls churn TCP connections. This client talks to
+			// exactly one host (the agent); give it a pool that matches the
+			// fan-out instead of reopening sockets under load.
+			Transport: &http.Transport{
+				MaxIdleConns:        32,
+				MaxIdleConnsPerHost: 16,
+				IdleConnTimeout:     90 * time.Second,
+			},
 		},
 	}
 	agentClient = ai

--- a/truffels-api/internal/syncstatus/cache.go
+++ b/truffels-api/internal/syncstatus/cache.go
@@ -1,0 +1,91 @@
+// Package syncstatus holds the chain-node sync progress that the Services page
+// shows. The alerts engine refreshes it on its background tick; the API handler
+// reads it. This keeps the live chain probe (a docker exec into an IBD-busy
+// node, which can take many seconds) off the request path — the page reads a
+// cached value instead of blocking on the slowest node.
+package syncstatus
+
+import (
+	"strconv"
+	"sync"
+
+	"truffels-api/internal/model"
+)
+
+// Cache maps a service ID to its last known sync progress. A nil value (or a
+// missing key) means "synced or unknown" — the same absence-of-SyncInfo the
+// handler produced when it probed live and the node was fully synced.
+//
+// One writer (the engine tick) and many readers (HTTP handlers), so a RWMutex
+// is the right primitive. Values are treated as immutable once stored; readers
+// get a copy so a later Set can never mutate a pointer a caller still holds.
+type Cache struct {
+	mu sync.RWMutex
+	m  map[string]*model.SyncInfo
+}
+
+// NewCache returns an empty cache.
+func NewCache() *Cache {
+	return &Cache{m: make(map[string]*model.SyncInfo)}
+}
+
+// Set stores (or replaces) the sync info for a service. Pass nil to record that
+// the node is synced / has no progress to show.
+func (c *Cache) Set(id string, info *model.SyncInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[id] = info
+}
+
+// Get returns a copy of the cached sync info, or nil if the service has no
+// entry or is recorded as synced.
+func (c *Cache) Get(id string) *model.SyncInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	info, ok := c.m[id]
+	if !ok || info == nil {
+		return nil
+	}
+	cp := *info
+	return &cp
+}
+
+// FromChainStatus builds the SyncInfo a bitcoin-core-style node reports, or nil
+// when the node is fully synced (verificationprogress ~1 and IBD false) — the
+// same rule the handler used when it probed live.
+func FromChainStatus(blocks, headers int64, verificationProgress float64, initialBlockDownload bool) *model.SyncInfo {
+	if !initialBlockDownload && verificationProgress >= 0.9999 {
+		return nil
+	}
+	return &model.SyncInfo{
+		Syncing:  true,
+		Progress: verificationProgress,
+		Detail:   formatProgress(verificationProgress, blocks, headers),
+	}
+}
+
+func formatProgress(vp float64, blocks, headers int64) string {
+	return strconv.FormatFloat(vp*100, 'f', 2, 64) + "% (" +
+		formatInt(blocks) + " / " + formatInt(headers) + " blocks)"
+}
+
+// formatInt renders an integer with thousands separators, matching the
+// formatting the API handler used for the same field.
+func formatInt(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	neg := ""
+	if n < 0 {
+		neg, s = "-", s[1:]
+	}
+	if len(s) <= 3 {
+		return neg + s
+	}
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b = append(b, ',')
+		}
+		b = append(b, s[i])
+	}
+	return neg + string(b)
+}

--- a/truffels-api/internal/syncstatus/cache_test.go
+++ b/truffels-api/internal/syncstatus/cache_test.go
@@ -1,0 +1,59 @@
+package syncstatus
+
+import (
+	"testing"
+
+	"truffels-api/internal/model"
+)
+
+func TestCacheSetGet(t *testing.T) {
+	c := NewCache()
+
+	if got := c.Get("missing"); got != nil {
+		t.Errorf("missing key should return nil, got %+v", got)
+	}
+
+	info := &model.SyncInfo{Syncing: true, Progress: 0.5, Detail: "50%"}
+	c.Set("bchn", info)
+
+	got := c.Get("bchn")
+	if got == nil || !got.Syncing || got.Progress != 0.5 {
+		t.Fatalf("expected cached info, got %+v", got)
+	}
+	// Get must return a copy, not the stored pointer.
+	if got == info {
+		t.Error("Get returned the stored pointer; must return a copy")
+	}
+	got.Progress = 0.9
+	if again := c.Get("bchn"); again.Progress != 0.5 {
+		t.Errorf("mutating a returned copy changed the cache: %v", again.Progress)
+	}
+
+	// Storing nil records "synced / no info".
+	c.Set("bchn", nil)
+	if got := c.Get("bchn"); got != nil {
+		t.Errorf("nil entry should read back as nil, got %+v", got)
+	}
+}
+
+func TestFromChainStatus(t *testing.T) {
+	// Fully synced → nil (no progress bar).
+	if got := FromChainStatus(800000, 800000, 1.0, false); got != nil {
+		t.Errorf("synced node should produce nil SyncInfo, got %+v", got)
+	}
+	if got := FromChainStatus(800000, 800000, 0.99995, false); got != nil {
+		t.Errorf("vp>=0.9999 and not-IBD should be nil, got %+v", got)
+	}
+
+	// Still in IBD → SyncInfo with formatted detail.
+	got := FromChainStatus(226256, 965199, 0.0348, true)
+	if got == nil || !got.Syncing {
+		t.Fatal("IBD node should produce a syncing SyncInfo")
+	}
+	if got.Progress != 0.0348 {
+		t.Errorf("progress = %v, want 0.0348", got.Progress)
+	}
+	if got.Detail != "3.48% (226,256 / 965,199 blocks)" {
+		t.Errorf("detail = %q", got.Detail)
+	}
+}

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -21,6 +21,7 @@ import (
 	"truffels-api/internal/metrics"
 	"truffels-api/internal/service"
 	"truffels-api/internal/store"
+	"truffels-api/internal/syncstatus"
 	"truffels-api/internal/updates"
 )
 
@@ -70,6 +71,10 @@ func main() {
 	// the alert evaluator doesn't fire spurious warnings against services
 	// that are still being reconciled. See v0.3.1-dev.14 startup-ordering fix.
 	alertEngine := alerts.NewEngine(st, registry, collector, compose)
+	// The engine refreshes chain-sync progress into this cache on its tick;
+	// the Services handler reads it instead of probing nodes live.
+	syncCache := syncstatus.NewCache()
+	alertEngine.SetSyncCache(catalogClient, syncCache)
 	defer alertEngine.Stop()
 
 	// Update engine
@@ -131,7 +136,7 @@ func main() {
 	btcRPC := initBitcoinRPC(cfg.SecretsRoot)
 
 	// HTTP server
-	srv := api.NewServer(registry, st, compose, collector, authenticator, btcRPC, updateEngine, catalogClient, version)
+	srv := api.NewServer(registry, st, compose, collector, authenticator, btcRPC, updateEngine, catalogClient, syncCache, version)
 	httpServer := &http.Server{
 		Addr:    cfg.Listen,
 		Handler: srv.Router(),


### PR DESCRIPTION
Fixes the outage where the admin UI showed **every service as "stopped / unknown"** (bitcoind included) and pages loaded slowly. Root cause (confirmed independently by agy + qwen investigating the live system): the UI's 10s polling fanned out ~20 concurrent agent inspects per response — plus a live chain probe (`docker exec` into an IBD-busy node) — and the agent forked one docker CLI process per container. The resulting dockerd contention pushed inspect latency past the 10s client timeout, so inspects failed and every service read back "unknown".

## What it does
- **agent**: `/v1/inspect` runs ONE `docker inspect <all names>` instead of N sequential forks.
- **api**: `/services`, `/services/{id}`, `/dashboard`, `/monitoring`, `/updates/status` (all polled) now do one batched inspect + one blockchain-info call per response, via shared `inspectAllContainers`/`containersFor` helpers — no per-service or per-dependency agent/RPC calls.
- **api**: agent HTTP client gets a connection pool (`MaxIdleConnsPerHost` 16, was the default 2).
- **api**: chain-sync % is served from a cache the alerts engine refreshes on its 30s tick — the live probe is off the request path. The cache is cleared when a node stops (no stale % after restart) and the refresh bails on shutdown.
- **api**: a stopped electrs's stats read "electrs is not running" instead of a raw DNS error.

## Review
Investigated and reviewed by **agy + qwen** (they ran the live system + read the code). Their findings drove the batching of dashboard/monitoring/update-status and the stale-cache-on-stop fix; two findings were adjudicated as false positives (state gate present; not_found returned in-band). Background engines still inspect per-service off the request path — noted as follow-up.

Gates green: agent + api build/gofmt/vet/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA