### PR TITLE
perf: batch background-engine inspects + post-outage sweep follow-ups

### DIFF
--- a/truffels-agent/main.go
+++ b/truffels-agent/main.go
@@ -605,47 +605,56 @@ func handleImageInspect(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Get image name from container
-	imageOut, err := runStdout(ctx, "docker", "inspect", "--format",
-		"{{.Config.Image}}", req.Container)
+	containerOut, err := runStdout(ctx, "docker", "inspect", "--format",
+		"{{json .}}", req.Container)
 	if err != nil {
 		writeJSON(w, 500, map[string]string{"error": "cannot inspect container: " + err.Error()})
 		return
 	}
-	imageName := strings.TrimSpace(imageOut)
+	var container struct {
+		Config struct {
+			Image string `json:"Image"`
+		} `json:"Config"`
+	}
+	if err := json.Unmarshal([]byte(containerOut), &container); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "cannot inspect container: " + err.Error()})
+		return
+	}
 
-	writeJSON(w, 200, inspectImageByName(ctx, imageName))
+	writeJSON(w, 200, inspectImageByName(ctx, container.Config.Image))
 }
 
-// inspectImageByName reads digest, tags and labels straight off an image. Every
-// docker call here is best-effort: a missing field is reported as empty rather
-// than as a failure, which is what the digest/tag lookups have always done.
-func inspectImageByName(ctx context.Context, imageName string) imageInspectResponse {
-	// Get image digest
-	digestOut, err := runCapture(ctx, "docker", "inspect", "--format",
-		"{{index .RepoDigests 0}}", imageName)
+// dockerObject is the subset of a `docker inspect --format {{json .}}` result
+// both inspect handlers need. RepoDigests[0] is empty when the image has no
+// registry pull recorded — the same case that used to yield an empty digest.
+type dockerObject struct {
+	RepoDigests []string `json:"RepoDigests"`
+	RepoTags    []string `json:"RepoTags"`
+	Config      struct {
+		Image  string            `json:"Image"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+}
+
+// inspectObject reads digest, tags and labels from a single parsed docker
+// inspect result. imageName is the reference the caller looked up — reported as
+// the Image field, since an image's own .Config.Image is the build parent, not
+// its name. Every field is best-effort: a missing one is reported as empty
+// rather than as a failure, which is what the digest/tag lookups have always done.
+func inspectObject(imageName string, obj *dockerObject) imageInspectResponse {
 	digest := ""
-	if err == nil {
-		digest = strings.TrimSpace(digestOut)
+	if len(obj.RepoDigests) > 0 {
+		digest = obj.RepoDigests[0]
 		// Extract just the digest part after @
 		if idx := strings.Index(digest, "@"); idx >= 0 {
 			digest = digest[idx+1:]
 		}
 	}
 
-	// Get tags
-	tagsOut, err := runStdout(ctx, "docker", "inspect", "--format",
-		"{{json .RepoTags}}", imageName)
-	var tags []string
-	if err == nil {
-		_ = json.Unmarshal([]byte(strings.TrimSpace(tagsOut)), &tags)
-	}
-
-	// Get labels — carries org.truffels.source-ref, the ref the image was built from.
-	labelsOut, err := runStdout(ctx, "docker", "inspect", "--format",
-		"{{json .Config.Labels}}", imageName)
-	labels := map[string]string{}
-	if err == nil {
-		_ = json.Unmarshal([]byte(strings.TrimSpace(labelsOut)), &labels)
+	tags := obj.RepoTags
+	labels := obj.Config.Labels
+	if labels == nil {
+		labels = map[string]string{}
 	}
 
 	return imageInspectResponse{
@@ -654,6 +663,22 @@ func inspectImageByName(ctx context.Context, imageName string) imageInspectRespo
 		Tags:   tags,
 		Labels: labels,
 	}
+}
+
+// inspectImageByName reads digest, tags and labels straight off an image with a
+// single docker inspect. A missing or unparseable image is reported as empty
+// fields rather than as a failure, matching the old per-field lookups.
+func inspectImageByName(ctx context.Context, imageName string) imageInspectResponse {
+	out, err := runStdout(ctx, "docker", "inspect", "--format",
+		"{{json .}}", imageName)
+	if err != nil {
+		return imageInspectResponse{Image: imageName}
+	}
+	var obj dockerObject
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		return imageInspectResponse{Image: imageName}
+	}
+	return inspectObject(imageName, &obj)
 }
 
 type imageByNameRequest struct {

--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -220,13 +220,26 @@ func (e *Engine) evaluate() {
 		e.evalWatchedDirs()
 	}
 
+	// One batched inspect for every managed container this tick, shared by the
+	// service and dependency checks below. Previously each did its own
+	// per-container inspect (~20 agent calls per 30s tick); this collapses them
+	// to a single call, the same fix the request-path handlers use.
+	var allNames []string
+	for _, tmpl := range e.registry.All() {
+		allNames = append(allNames, tmpl.ContainerNames...)
+	}
+	byName := make(map[string]model.ContainerState, len(allNames))
+	for _, cs := range docker.InspectContainers(allNames) {
+		byName[cs.Name] = cs
+	}
+
 	// Service health alerts + monitoring state change detection
 	for _, tmpl := range e.registry.All() {
-		e.checkService(tmpl)
+		e.checkService(tmpl, byName)
 	}
 
 	// Dependency health checks
-	e.checkDependencyHealth()
+	e.checkDependencyHealth(byName)
 
 	// Out-of-memory kills (from the agent's Docker event stream)
 	e.checkOOM()
@@ -634,7 +647,7 @@ func (e *Engine) checkTemp(tempC float64) {
 	}
 }
 
-func (e *Engine) checkService(tmpl model.ServiceTemplate) {
+func (e *Engine) checkService(tmpl model.ServiceTemplate, byName map[string]model.ContainerState) {
 	enabled, _ := e.store.IsServiceEnabled(tmpl.ID)
 	// For read-only services (DBs, proxy), suppress exited alerts if all
 	// dependent services are disabled — the user can't control these directly.
@@ -658,8 +671,8 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate) {
 	maxRetries := e.getSettingInt("restart_loop_max_retries", 10)
 
 	for _, name := range tmpl.ContainerNames {
-		cs, err := docker.InspectContainer(name)
-		if err != nil {
+		cs, ok := byName[name]
+		if !ok {
 			continue
 		}
 
@@ -825,7 +838,7 @@ func (e *Engine) refreshSyncCache() {
 	}
 }
 
-func (e *Engine) checkDependencyHealth() {
+func (e *Engine) checkDependencyHealth(byName map[string]model.ContainerState) {
 	mode := e.getSettingStr("dep_handling_mode", "flag_only")
 
 	for _, tmpl := range e.registry.All() {
@@ -846,8 +859,8 @@ func (e *Engine) checkDependencyHealth() {
 
 			upstreamDown := false
 			for _, name := range depTmpl.ContainerNames {
-				cs, err := docker.InspectContainer(name)
-				if err != nil {
+				cs, ok := byName[name]
+				if !ok {
 					continue
 				}
 				if cs.Health == "unhealthy" || cs.Status == "exited" || cs.Status == "restarting" || cs.Status == "not_found" {

--- a/truffels-api/internal/alerts/engine_test.go
+++ b/truffels-api/internal/alerts/engine_test.go
@@ -451,6 +451,20 @@ func setupMockAgent(t *testing.T, states map[string]model.ContainerState) {
 	docker.NewAgentInspector(srv.URL)
 }
 
+// inspectAll builds the batched container-state map the engine now expects,
+// using whatever the test's mock agent returns for every registered container.
+func inspectAll(e *Engine) map[string]model.ContainerState {
+	var names []string
+	for _, t := range e.registry.All() {
+		names = append(names, t.ContainerNames...)
+	}
+	m := make(map[string]model.ContainerState, len(names))
+	for _, cs := range docker.InspectContainers(names) {
+		m[cs.Name] = cs
+	}
+	return m
+}
+
 func newTestEngineWithRegistry(t *testing.T, tmpls []model.ServiceTemplate) (*Engine, *store.Store) {
 	t.Helper()
 	s := newTestStore(t)
@@ -484,7 +498,7 @@ func TestCheckService_DisabledExited_NoAlert(t *testing.T) {
 	_ = s.EnsureService("electrs")
 	_ = s.SetServiceEnabled("electrs", false)
 
-	e.checkService(tmpl)
+	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -505,7 +519,7 @@ func TestCheckService_EnabledExited_Alerts(t *testing.T) {
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{tmpl})
 
 	// Service is enabled by default
-	e.checkService(tmpl)
+	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 1 {
@@ -531,7 +545,7 @@ func TestCheckService_DisabledUnhealthy_StillAlerts(t *testing.T) {
 	_ = s.EnsureService("electrs")
 	_ = s.SetServiceEnabled("electrs", false)
 
-	e.checkService(tmpl)
+	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 1 {
@@ -564,7 +578,7 @@ func TestCheckService_DisabledExited_ResolvesExistingAlert(t *testing.T) {
 	// Now disable and re-check — should resolve
 	_ = s.EnsureService("electrs")
 	_ = s.SetServiceEnabled("electrs", false)
-	e.checkService(tmpl)
+	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ = s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -587,7 +601,7 @@ func TestCheckService_DisabledNotFound_NoAlert(t *testing.T) {
 	_ = s.EnsureService("ckpool")
 	_ = s.SetServiceEnabled("ckpool", false)
 
-	e.checkService(tmpl)
+	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -619,7 +633,7 @@ func TestCheckDependencyHealth_DisabledService_NoAlert(t *testing.T) {
 	_ = s.EnsureService("electrs")
 	_ = s.SetServiceEnabled("electrs", false)
 
-	e.checkDependencyHealth()
+	e.checkDependencyHealth(inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -646,7 +660,7 @@ func TestCheckDependencyHealth_EnabledService_Alerts(t *testing.T) {
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{bitcoind, electrs})
 
 	// electrs is enabled by default
-	e.checkDependencyHealth()
+	e.checkDependencyHealth(inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 1 {
@@ -685,7 +699,7 @@ func TestCheckDependencyHealth_DisabledService_ResolvesExisting(t *testing.T) {
 	// Disable electrs and re-check — should resolve
 	_ = s.EnsureService("electrs")
 	_ = s.SetServiceEnabled("electrs", false)
-	e.checkDependencyHealth()
+	e.checkDependencyHealth(inspectAll(e))
 
 	alerts, _ = s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -718,7 +732,7 @@ func TestCheckService_ReadOnlyExited_AllDependentsDisabled_NoAlert(t *testing.T)
 	_ = s.EnsureService("ckstats")
 	_ = s.SetServiceEnabled("ckstats", false)
 
-	e.checkService(ckstatsDB)
+	e.checkService(ckstatsDB, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 0 {
@@ -746,7 +760,7 @@ func TestCheckService_ReadOnlyExited_SomeDependentsEnabled_Alerts(t *testing.T) 
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{ckstatsDB, ckstats})
 
 	// ckstats is enabled by default — DB being exited is a real problem
-	e.checkService(ckstatsDB)
+	e.checkService(ckstatsDB, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 1 {
@@ -767,7 +781,7 @@ func TestCheckService_ReadOnlyRunning_NoAlertRegardless(t *testing.T) {
 	}
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{ckstatsDB})
 
-	e.checkService(ckstatsDB)
+	e.checkService(ckstatsDB, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 0 {

--- a/truffels-api/internal/api/services.go
+++ b/truffels-api/internal/api/services.go
@@ -84,7 +84,7 @@ func (s *Server) handleListServices(w http.ResponseWriter, r *http.Request) {
 			svc.State = model.StateDisabled
 		}
 		svc.DependencyIssues = s.checkDependencyIssues(tmpl, byName, bcInfo)
-		s.enrichSyncInfo(&svc)
+		s.enrichSyncInfo(&svc, bcInfo)
 		services[i] = svc
 	}
 	writeJSON(w, http.StatusOK, services)
@@ -126,21 +126,21 @@ func (s *Server) handleGetService(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	svc.DependencyIssues = s.checkDependencyIssues(tmpl, byName, bcInfo)
-	s.enrichSyncInfo(&svc)
+	s.enrichSyncInfo(&svc, bcInfo)
 	writeJSON(w, http.StatusOK, svc)
 }
 
-func (s *Server) enrichSyncInfo(svc *model.ServiceInstance) {
+func (s *Server) enrichSyncInfo(svc *model.ServiceInstance, bcInfo *bitcoin.BlockchainInfo) {
 	if svc.State != model.StateRunning {
 		return
 	}
 	switch svc.Template.ID {
 	case "bitcoind":
-		s.enrichBitcoindSync(svc)
+		s.enrichBitcoindSync(svc, bcInfo)
 	case "electrs":
-		s.enrichElectrsSync(svc)
+		s.enrichElectrsSync(svc, bcInfo)
 	case "mempool":
-		s.enrichMempoolSync(svc)
+		s.enrichMempoolSync(svc, bcInfo)
 	default:
 		// Catalog chain nodes (e.g. DigiByte, BCHN) read from the sync cache
 		// the alerts engine refreshes on its tick. The live probe — a docker
@@ -152,12 +152,8 @@ func (s *Server) enrichSyncInfo(svc *model.ServiceInstance) {
 	}
 }
 
-func (s *Server) enrichBitcoindSync(svc *model.ServiceInstance) {
-	if s.btcRPC == nil {
-		return
-	}
-	info, err := s.btcRPC.GetBlockchainInfo()
-	if err != nil {
+func (s *Server) enrichBitcoindSync(svc *model.ServiceInstance, info *bitcoin.BlockchainInfo) {
+	if info == nil {
 		return
 	}
 	// Bitcoin Core reports verificationprogress < 0.9999 during IBD
@@ -172,7 +168,10 @@ func (s *Server) enrichBitcoindSync(svc *model.ServiceInstance) {
 	}
 }
 
-func (s *Server) enrichElectrsSync(svc *model.ServiceInstance) {
+func (s *Server) enrichElectrsSync(svc *model.ServiceInstance, bcInfo *bitcoin.BlockchainInfo) {
+	if bcInfo == nil || bcInfo.Blocks == 0 {
+		return
+	}
 	// Fetch electrs index height from Prometheus metrics
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get("http://truffels-electrs:4224/")
@@ -186,15 +185,6 @@ func (s *Server) enrichElectrsSync(svc *model.ServiceInstance) {
 	}
 	indexHeight := parsePrometheusGauge(string(body), `electrs_index_height{type="tip"}`)
 	if indexHeight == 0 {
-		return
-	}
-
-	// Get bitcoind height for comparison
-	if s.btcRPC == nil {
-		return
-	}
-	bcInfo, err := s.btcRPC.GetBlockchainInfo()
-	if err != nil || bcInfo.Blocks == 0 {
 		return
 	}
 
@@ -212,7 +202,10 @@ func (s *Server) enrichElectrsSync(svc *model.ServiceInstance) {
 	}
 }
 
-func (s *Server) enrichMempoolSync(svc *model.ServiceInstance) {
+func (s *Server) enrichMempoolSync(svc *model.ServiceInstance, bcInfo *bitcoin.BlockchainInfo) {
+	if bcInfo == nil || bcInfo.Blocks == 0 {
+		return
+	}
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(mempoolBaseURL + "/api/v1/blocks/tip/height")
 	if err != nil {
@@ -225,14 +218,6 @@ func (s *Server) enrichMempoolSync(svc *model.ServiceInstance) {
 	}
 	mempoolHeight, err := strconv.Atoi(strings.TrimSpace(string(body)))
 	if err != nil || mempoolHeight == 0 {
-		return
-	}
-
-	if s.btcRPC == nil {
-		return
-	}
-	bcInfo, err := s.btcRPC.GetBlockchainInfo()
-	if err != nil || bcInfo.Blocks == 0 {
 		return
 	}
 

--- a/truffels-api/internal/catalog/client.go
+++ b/truffels-api/internal/catalog/client.go
@@ -42,8 +42,18 @@ func NewClient(agentURL string) *Client {
 	// No client-wide timeout: each call sets its own via a request context, so a
 	// slow teardown is not capped by the same deadline as a quick catalog read.
 	return &Client{
-		agentURL:      agentURL,
-		http:          &http.Client{},
+		agentURL: agentURL,
+		http: &http.Client{
+			// The default transport keeps only 2 idle connections per host, so
+			// bursts of agent calls churn TCP connections. This client talks to
+			// exactly one host (the agent); give it a pool that matches the
+			// fan-out instead of reopening sockets under load.
+			Transport: &http.Transport{
+				MaxIdleConns:        32,
+				MaxIdleConnsPerHost: 16,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
 		readTimeout:   defaultReadTimeout,
 		applyTimeout:  defaultApplyTimeout,
 		removeTimeout: defaultRemoveTimeout,

--- a/truffels-api/main.go
+++ b/truffels-api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"log/slog"
 	"net/http"
 	"os"
@@ -82,6 +83,14 @@ func main() {
 	updateEngine.Start()
 	defer updateEngine.Stop()
 
+	// Shutdown context, shared by the catalog-retry loop below and the graceful
+	// shutdown handler further down. A cancelled context's Done channel is
+	// closed (not consumed), so both consumers observe the signal — unlike a
+	// shared signal channel, where whichever goroutine received it first would
+	// starve the other.
+	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stopSignals()
+
 	// Arm the catalog guards and reconcile installed catalog services. The
 	// agent may still be starting when the API boots (both restart together
 	// on self-update), so retry until the catalog is served.
@@ -90,7 +99,12 @@ func main() {
 			ids, err := catalogClient.IDs()
 			if err != nil {
 				slog.Warn("catalog not yet available, retrying", "err", err)
-				time.Sleep(10 * time.Second)
+				select {
+				case <-time.After(10 * time.Second):
+				case <-shutdownCtx.Done():
+					slog.Info("shutting down during catalog retry")
+					return
+				}
 				continue
 			}
 			updates.SetCatalogIDs(ids)
@@ -142,12 +156,12 @@ func main() {
 		Handler: srv.Router(),
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown — shutdownCtx was armed before the catalog-retry loop so
+	// the same signal wakes that loop too (a closed Done channel fans out to
+	// every waiter).
 	go func() {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-		sig := <-sigCh
-		slog.Info("shutting down", "signal", sig)
+		<-shutdownCtx.Done()
+		slog.Info("shutting down")
 		_ = httpServer.Close()
 	}()
 


### PR DESCRIPTION
Follow-ups from the Services-page congestion fix (dev.48), found by an agy + qwen discovery sweep of the codebase and reviewed by both (NO ISSUES).

- **alerts engine**: `evaluate()` does ONE batched `InspectContainers` per 30s tick shared by `checkService` + `checkDependencyHealth`, instead of ~20 single-container inspects (each a docker CLI fork on the agent). Same batching the request-path handlers use.
- **api**: `enrichSyncInfo` reuses the blockchain info the handlers already fetch — up to 3 fewer `getblockchaininfo` RPCs per Services poll.
- **agent**: `/v1/image/inspect` runs one `docker inspect {{json .}}` per object (was 4 forks).
- **api**: catalog HTTP client gets the pooled transport the agent inspector already has.
- **api**: startup catalog-retry loop + graceful shutdown share a `signal.NotifyContext` (fixes a signal-channel starve risk qwen's first attempt introduced).

qwen implemented the catalog-pool / agent-inspect / shutdown pieces; review caught and fixed two regressions in them (image-inspect `Image` field, and the signal-stealing shutdown) before commit. The update engine was audited and needs no batching (24h cadence). Gates green: agent + api build/gofmt/vet/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA