### PR TITLE
web: translate the last German UI strings to English

### DIFF
--- a/truffels-web/src/pages/ServiceDetailPage.tsx
+++ b/truffels-web/src/pages/ServiceDetailPage.tsx
@@ -162,7 +162,7 @@ export default function ServiceDetailPage() {
             disabled={actionLoading}
             className="px-3 py-1.5 rounded text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 transition-colors disabled:opacity-50"
           >
-            Deinstallieren
+            Uninstall
           </button>
         )}
         {actionMsg && <span className="text-sm text-gray-400 ml-2">{actionMsg}</span>}
@@ -170,15 +170,15 @@ export default function ServiceDetailPage() {
 
       <ConfirmDialog
         open={uninstallOpen}
-        title="Dienst deinstallieren"
+        title="Uninstall service"
         onCancel={() => !uninstallLoading && setUninstallOpen(false)}
         onConfirm={doUninstall}
-        confirmLabel={uninstallLoading ? 'Deinstalliere...' : 'Deinstallieren'}
+        confirmLabel={uninstallLoading ? 'Uninstalling…' : 'Uninstall'}
         confirmDisabled={uninstallLoading || (purgeData && confirmId !== id)}
       >
         <div className="space-y-4">
           <p className="text-sm text-gray-300">
-            Soll der Dienst <strong>{svc.template.display_name}</strong> wirklich deinstalliert werden?
+            Really uninstall <strong>{svc.template.display_name}</strong>?
           </p>
           <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-300">
             <input
@@ -187,13 +187,13 @@ export default function ServiceDetailPage() {
               onChange={(e) => setPurgeData(e.target.checked)}
               className="w-4 h-4 rounded border-gray-600 bg-surface text-accent focus:ring-accent/50"
             />
-            Daten löschen (purge_data)
+            Delete data (purge_data)
           </label>
           
           {purgeData && (
             <div className="flex flex-col gap-1 mt-2">
               <label className="text-xs text-gray-400">
-                Bitte tippen Sie die ID <span className="font-mono text-gray-200">{id}</span> ein, um das Löschen zu bestätigen:
+                Type the ID <span className="font-mono text-gray-200">{id}</span> to confirm deletion:
               </label>
               <input
                 type="text"

--- a/truffels-web/src/pages/ServicesPage.tsx
+++ b/truffels-web/src/pages/ServicesPage.tsx
@@ -60,7 +60,7 @@ export default function ServicesPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Services</h1>
         <Link to="/services/add" className="px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded text-sm font-medium transition-colors">
-          Dienst hinzufügen
+          Add Service
         </Link>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
The Add-Service button and the uninstall dialog were still German while the rest of the UI is English. Now: Add Service / Uninstall / Really uninstall <name>? / Delete data (purge_data) / type-the-ID confirm prompt. Text-only, no logic change. (Implemented by qwen, reviewed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA