### PR TITLE
alerts: stop nagging about deliberately-stopped services

### DIFF
--- a/truffels-api/internal/alerts/engine.go
+++ b/truffels-api/internal/alerts/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"truffels-api/internal/catalog"
@@ -268,6 +269,9 @@ func (e *Engine) evaluate() {
 		if err := e.store.PruneDirSizeSnapshots(time.Now().Add(-168 * time.Hour)); err != nil {
 			slog.Error("prune dir size snapshots", "err", err)
 		}
+		if err := e.store.PruneResolvedAlerts(time.Now().Add(-30 * 24 * time.Hour)); err != nil {
+			slog.Error("prune resolved alerts", "err", err)
+		}
 	}
 }
 
@@ -282,6 +286,21 @@ type watchedDir struct {
 	// a release. Defaults live in the getSettingInt calls in evalWatchedDirs.
 	warnKey     string
 	criticalKey string
+}
+
+// serviceIsRunning reports whether any of the service's containers is running.
+// Used by evalWatchedDirs to skip dir-size evaluation for stopped services —
+// a stopped service's data dir can't cause a live OOM, so alerting on it is
+// noise. It inspects fresh rather than reusing evaluate()'s batched map
+// because evalWatchedDirs runs at most once per 60s tick and the watched set
+// is tiny (one entry today), so one extra agent call per poll is acceptable.
+func serviceIsRunning(tmpl model.ServiceTemplate) bool {
+	for _, name := range tmpl.ContainerNames {
+		if cs, err := docker.InspectContainer(name); err == nil && cs.Status == "running" {
+			return true
+		}
+	}
+	return false
 }
 
 var watchedDirs = []watchedDir{
@@ -301,6 +320,16 @@ func (e *Engine) evalWatchedDirs() {
 		return
 	}
 	for _, w := range watchedDirs {
+		tmpl, ok := e.registry.Get(w.serviceID)
+		if !ok || !serviceIsRunning(tmpl) {
+			// Stopped service: its data dir can't cause a live OOM. Clear any
+			// stale size alerts and skip the whole evaluation (including
+			// reclaim).
+			e.resolve("dir_size_warning", w.serviceID)
+			e.resolve("dir_size_critical", w.serviceID)
+			continue
+		}
+
 		size, _, err := e.compose.HostDirSize(w.path)
 		if err != nil {
 			slog.Debug("dir-size fetch failed", "path", w.path, "err", err)
@@ -648,27 +677,18 @@ func (e *Engine) checkTemp(tempC float64) {
 }
 
 func (e *Engine) checkService(tmpl model.ServiceTemplate, byName map[string]model.ContainerState) {
-	enabled, _ := e.store.IsServiceEnabled(tmpl.ID)
-	// For read-only services (DBs, proxy), suppress exited alerts if all
-	// dependent services are disabled — the user can't control these directly.
-	if tmpl.ReadOnly && enabled {
-		if deps := e.registry.Dependents(tmpl.ID); len(deps) > 0 {
-			allDisabled := true
-			for _, depID := range deps {
-				depEnabled, _ := e.store.IsServiceEnabled(depID)
-				if depEnabled {
-					allDisabled = false
-					break
-				}
-			}
-			if allDisabled {
-				enabled = false
-			}
-		}
-	}
+	// service_unhealthy now fires only for a running-but-failing healthcheck, so
+	// the enabled/read-only suppression that used to gate the "exited" alert is
+	// gone — a stopped service simply produces no unhealthy containers here.
 	threshold := e.getSettingInt("restart_loop_count", 5)
 	windowMin := e.getSettingInt("restart_loop_window_min", 10)
 	maxRetries := e.getSettingInt("restart_loop_max_retries", 10)
+
+	// Unhealthy check, aggregated across the service's containers: one alert
+	// listing every unhealthy container, resolved once none are. A stopped or
+	// missing container is not alerted here — a clean stop is operator intent
+	// (noise), and crash-loops / OOM-kills have their own alert types.
+	unhealthyNames := []string{}
 
 	for _, name := range tmpl.ContainerNames {
 		cs, ok := byName[name]
@@ -676,20 +696,8 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate, byName map[string]mode
 			continue
 		}
 
-		// Unhealthy check
-		alertType := "service_unhealthy"
 		if cs.Health == "unhealthy" {
-			e.upsert(alertType, tmpl.ID, model.SeverityCritical,
-				"Container %s is unhealthy", name)
-		} else if cs.Status == "exited" || cs.Status == "not_found" {
-			if enabled {
-				e.upsert(alertType, tmpl.ID, model.SeverityWarning,
-					"Container %s is %s", name, cs.Status)
-			} else {
-				e.resolve(alertType, tmpl.ID)
-			}
-		} else {
-			e.resolve(alertType, tmpl.ID)
+			unhealthyNames = append(unhealthyNames, name)
 		}
 
 		// Record container's StartedAt on first observation per engine
@@ -730,6 +738,13 @@ func (e *Engine) checkService(tmpl model.ServiceTemplate, byName map[string]mode
 			}
 		}
 		e.prevStates[name] = cs
+	}
+
+	if len(unhealthyNames) > 0 {
+		e.upsert("service_unhealthy", tmpl.ID, model.SeverityCritical,
+			"Containers %s are unhealthy", strings.Join(unhealthyNames, ", "))
+	} else {
+		e.resolve("service_unhealthy", tmpl.ID)
 	}
 }
 
@@ -847,6 +862,21 @@ func (e *Engine) checkDependencyHealth(byName map[string]model.ContainerState) {
 		}
 		enabled, _ := e.store.IsServiceEnabled(tmpl.ID)
 		if !enabled {
+			e.resolve("upstream_unhealthy", tmpl.ID)
+			continue
+		}
+
+		// A stopped dependent can't serve stale data, so warning about its
+		// upstream is noise — only alert while it actually has a running
+		// container.
+		dependentRunning := false
+		for _, name := range tmpl.ContainerNames {
+			if cs, ok := byName[name]; ok && cs.Status == "running" {
+				dependentRunning = true
+				break
+			}
+		}
+		if !dependentRunning {
 			e.resolve("upstream_unhealthy", tmpl.ID)
 			continue
 		}

--- a/truffels-api/internal/alerts/engine_test.go
+++ b/truffels-api/internal/alerts/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -506,7 +507,7 @@ func TestCheckService_DisabledExited_NoAlert(t *testing.T) {
 	}
 }
 
-func TestCheckService_EnabledExited_Alerts(t *testing.T) {
+func TestCheckService_ExitedContainer_NoAlert(t *testing.T) {
 	setupMockAgent(t, map[string]model.ContainerState{
 		"truffels-electrs": {Name: "truffels-electrs", Status: "exited", Health: ""},
 	})
@@ -518,15 +519,44 @@ func TestCheckService_EnabledExited_Alerts(t *testing.T) {
 	}
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{tmpl})
 
-	// Service is enabled by default
+	// Service is enabled by default. An exited container is operator intent
+	// (a clean stop), not a failing healthcheck — no alert.
+	e.checkService(tmpl, inspectAll(e))
+
+	alerts, _ := s.GetActiveAlerts()
+	if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts for enabled service with an exited container, got %d: %v", len(alerts), alerts)
+	}
+}
+
+func TestCheckService_Unhealthy_Alerts(t *testing.T) {
+	setupMockAgent(t, map[string]model.ContainerState{
+		"truffels-electrs": {Name: "truffels-electrs", Status: "running", Health: "unhealthy"},
+	})
+
+	tmpl := model.ServiceTemplate{
+		ID:             "electrs",
+		DisplayName:    "electrs",
+		ContainerNames: []string{"truffels-electrs"},
+	}
+	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{tmpl})
+
+	// Service is enabled by default. A running container with a failing
+	// healthcheck is the only state that raises service_unhealthy.
 	e.checkService(tmpl, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
 	if len(alerts) != 1 {
-		t.Fatalf("expected 1 alert for enabled+exited service, got %d", len(alerts))
+		t.Fatalf("expected 1 alert for enabled service with an unhealthy container, got %d", len(alerts))
 	}
-	if alerts[0].Severity != model.SeverityWarning {
-		t.Fatalf("expected warning, got %q", alerts[0].Severity)
+	if alerts[0].Type != "service_unhealthy" {
+		t.Fatalf("expected service_unhealthy, got %q", alerts[0].Type)
+	}
+	if alerts[0].Severity != model.SeverityCritical {
+		t.Fatalf("expected critical, got %q", alerts[0].Severity)
+	}
+	if !strings.Contains(alerts[0].Message, "truffels-electrs") {
+		t.Fatalf("expected the alert message to name the unhealthy container, got %q", alerts[0].Message)
 	}
 }
 
@@ -644,6 +674,9 @@ func TestCheckDependencyHealth_DisabledService_NoAlert(t *testing.T) {
 func TestCheckDependencyHealth_EnabledService_Alerts(t *testing.T) {
 	setupMockAgent(t, map[string]model.ContainerState{
 		"truffels-bitcoind": {Name: "truffels-bitcoind", Status: "exited", Health: ""},
+		// The dependent must be running for the alert to fire — a stopped
+		// electrs can't serve stale data, so its upstream state is noise.
+		"truffels-electrs": {Name: "truffels-electrs", Status: "running", Health: ""},
 	})
 
 	bitcoind := model.ServiceTemplate{
@@ -659,7 +692,7 @@ func TestCheckDependencyHealth_EnabledService_Alerts(t *testing.T) {
 	}
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{bitcoind, electrs})
 
-	// electrs is enabled by default
+	// electrs is enabled by default and running, with its upstream exited
 	e.checkDependencyHealth(inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
@@ -668,6 +701,34 @@ func TestCheckDependencyHealth_EnabledService_Alerts(t *testing.T) {
 	}
 	if alerts[0].Type != "upstream_unhealthy" {
 		t.Fatalf("expected upstream_unhealthy, got %q", alerts[0].Type)
+	}
+}
+
+func TestCheckDependencyHealth_DependentNotRunning_NoAlert(t *testing.T) {
+	setupMockAgent(t, map[string]model.ContainerState{
+		"truffels-bitcoind": {Name: "truffels-bitcoind", Status: "exited", Health: ""},
+	})
+
+	bitcoind := model.ServiceTemplate{
+		ID:             "bitcoind",
+		DisplayName:    "Bitcoin Core",
+		ContainerNames: []string{"truffels-bitcoind"},
+	}
+	electrs := model.ServiceTemplate{
+		ID:             "electrs",
+		DisplayName:    "electrs",
+		ContainerNames: []string{"truffels-electrs"},
+		Dependencies:   []string{"bitcoind"},
+	}
+	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{bitcoind, electrs})
+
+	// electrs is enabled but has no running container (the mock reports it
+	// as not_found) — upstream_unhealthy must stay suppressed.
+	e.checkDependencyHealth(inspectAll(e))
+
+	alerts, _ := s.GetActiveAlerts()
+	if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts for a dependent with no running container, got %d: %v", len(alerts), alerts)
 	}
 }
 
@@ -759,12 +820,14 @@ func TestCheckService_ReadOnlyExited_SomeDependentsEnabled_Alerts(t *testing.T) 
 	}
 	e, s := newTestEngineWithRegistry(t, []model.ServiceTemplate{ckstatsDB, ckstats})
 
-	// ckstats is enabled by default — DB being exited is a real problem
+	// An exited container no longer alerts (a clean stop is operator intent);
+	// only a running-but-unhealthy container does. So a stopped read-only DB is
+	// silent regardless of whether dependents are enabled.
 	e.checkService(ckstatsDB, inspectAll(e))
 
 	alerts, _ := s.GetActiveAlerts()
-	if len(alerts) != 1 {
-		t.Fatalf("expected 1 alert for read-only service with enabled dependents, got %d", len(alerts))
+	if len(alerts) != 0 {
+		t.Fatalf("expected no alert for an exited read-only service, got %d", len(alerts))
 	}
 }
 

--- a/truffels-api/internal/alerts/reclaim_engine_test.go
+++ b/truffels-api/internal/alerts/reclaim_engine_test.go
@@ -268,7 +268,9 @@ func TestTryReclaim_ClearFailsRollsBackUp(t *testing.T) {
 func TestTryReclaim_SkipsWhenServiceStopped(t *testing.T) {
 	e, mock := newReclaimTestEngine(t, 950*1024*1024, "exited", true, true)
 
-	waitReclaim(t, e)
+	// Not running: evalWatchedDirs resolves and skips synchronously before any
+	// reclaim goroutine, so there is nothing to wait on.
+	e.evalWatchedDirs()
 
 	stop, clear, up := mock.counts()
 	if stop != 0 || clear != 0 || up != 0 {
@@ -470,16 +472,27 @@ func TestDirSizeCritical_TailDropsPromiseInsideCooldown(t *testing.T) {
 	}
 }
 
-// TestDirSizeCritical_TailDropsPromiseWhenNotRunning covers the other
-// guardrail the old wording ignored.
-func TestDirSizeCritical_TailDropsPromiseWhenNotRunning(t *testing.T) {
+// TestDirSizeCritical_SkippedWhenServiceNotRunning pins the current guardrail:
+// a not-running service skips dir-size evaluation entirely, so no
+// dir_size_critical alert is raised at all — and any pre-existing one is
+// resolved. (The old behavior evaluated the size and only dropped the
+// "cleared automatically" tail from the message; that scenario is now fully
+// suppressed.)
+func TestDirSizeCritical_SkippedWhenServiceNotRunning(t *testing.T) {
 	e, _ := newReclaimTestEngine(t, 950*1024*1024, "exited", true, true)
 
-	waitReclaim(t, e)
+	// Seed a stale alert from a time when the service was running.
+	e.upsert("dir_size_critical", "mempool", model.SeverityCritical, "stale oversized cache")
 
-	msg := criticalDirSizeMessage(t, e)
-	if strings.Contains(msg, "cleared automatically") {
-		t.Fatalf("alert promises an automatic reclaim while the service is stopped: %s", msg)
+	// The service isn't running, so evalWatchedDirs resolves and skips before
+	// any reclaim — call it directly (no reclaim goroutine to wait on).
+	e.evalWatchedDirs()
+
+	active, _ := e.store.GetActiveAlerts()
+	for _, a := range active {
+		if a.Type == "dir_size_critical" && a.ServiceID == "mempool" {
+			t.Fatalf("expected no dir_size_critical alert while the service is not running, got: %+v", a)
+		}
 	}
 }
 

--- a/truffels-api/internal/store/monitoring.go
+++ b/truffels-api/internal/store/monitoring.go
@@ -365,3 +365,10 @@ func (s *Store) PruneServiceEvents(keepN int) error {
 		 )`, keepN)
 	return err
 }
+
+// PruneResolvedAlerts deletes resolved alerts older than the given time.
+func (s *Store) PruneResolvedAlerts(olderThan time.Time) error {
+	ts := olderThan.UTC().Format("2006-01-02 15:04:05")
+	_, err := s.db.Exec(`DELETE FROM alerts WHERE resolved_at IS NOT NULL AND resolved_at < ?`, ts)
+	return err
+}

--- a/truffels-web/src/pages/AlertsPage.tsx
+++ b/truffels-web/src/pages/AlertsPage.tsx
@@ -14,6 +14,12 @@ const ALERT_TYPE_LABELS: Record<string, string> = {
   memory_trend: 'Memory Trend',
   disk_trend: 'Disk Trend',
   temp_trend: 'Temperature Trend',
+  dir_size_warning: 'Data Directory Size',
+  dir_size_critical: 'Data Directory Critical',
+  auto_reclaim_interrupted: 'Auto-Reclaim Interrupted',
+  auto_reclaim_failed: 'Auto-Reclaim Failed',
+  update_failed: 'Update Failed',
+  compose_reconcile_failed: 'Compose Reconcile Failed',
 }
 
 export default function AlertsPage() {

--- a/truffels-web/src/pages/DashboardPage.tsx
+++ b/truffels-web/src/pages/DashboardPage.tsx
@@ -129,6 +129,11 @@ export default function DashboardPage() {
               </div>
             ))}
           </div>
+          {alerts.active_count > alerts.recent.length && (
+            <Link to="/alerts" className="block text-sm text-blue-400 hover:text-blue-300 mt-3">
+              View all {alerts.active_count} alerts →
+            </Link>
+          )}
         </Card>
       )}
     </div>


### PR DESCRIPTION
Fixes the alert-page noise (15 active alerts, most for services the operator deliberately stopped). From an agy+qwen audit of the live system.

- **service_unhealthy** only for a running container with a failing healthcheck (aggregated, one alert lists all unhealthy containers). Exited/stopped no longer alerts — crash-loops/OOMs have their own types.
- **upstream_unhealthy** only when the dependent is actually running.
- **dir_size** skipped/resolved when the owning service isn't running (a stopped mempool can't OOM from its cache).
- **prune resolved alerts** after 30d (table had ~60k rows / 36 MB).
- **web**: dashboard 'View all N alerts →' link; AlertsPage labels for the unlabeled types.

Implemented by qwen; I removed a now-dead read-only suppression block and updated the tests that encoded the old exited-alert behavior (plus added positive-path coverage). Gates green: build/gofmt/vet/tests + web tsc. PR2 (new alerts: swap_exhaustion, node_stuck, agent_unreachable) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ppf7zicvhPHnWGcSHkDgA